### PR TITLE
Update CI workflows for multi-version Python testing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+      - name: Set up Python
+        run: uv python install
       - name: Install the project
         run: uv sync --extra test
       - name: Run inline examples that are part of the documentation

--- a/.github/workflows/examples_testing.yml
+++ b/.github/workflows/examples_testing.yml
@@ -11,17 +11,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  pytest-examples:
-    name: Pytest examples
+  test-examples-minimum:
+    name: Python 3.11 - minimum dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-      - name: Install the project
-        run: uv sync --extra test
+      - name: Set up Python
+        run: uv python install 3.11
+      - name: Install with minimum dependencies
+        run: uv sync --extra test --resolution lowest-direct --python 3.11
+      - name: Run tests
+        run: uv run pytest tests/examples
+
+  test-examples-latest:
+    name: Python 3.13 - latest dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+      - name: Install with latest dependencies
+        run: uv sync --extra test --python 3.13
       - name: Run tests with coverage
         run: uv run pytest tests/examples --cov=src --cov-report=xml:coverage/coverage_examples.xml --cov-report=html:coverage/htmlcov_examples --cov-append
       - name: Create coverage badge
@@ -53,7 +67,7 @@ jobs:
 
   deploy-examples:
     if: ${{ github.ref == 'refs/heads/main' && always() }}
-    needs: pytest-examples
+    needs: [test-examples-minimum, test-examples-latest]
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/functional_testing.yml
+++ b/.github/workflows/functional_testing.yml
@@ -11,17 +11,31 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  pytest:
-    name: python
+  test-minimum:
+    name: Python 3.11 - minimum dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
-      - name: Install the project
-        run: uv sync --extra test
+      - name: Set up Python
+        run: uv python install 3.11
+      - name: Install with minimum dependencies
+        run: uv sync --extra test --resolution lowest-direct --python 3.11
+      - name: Run tests
+        run: uv run pytest tests/src
+
+  test-latest:
+    name: Python 3.13 - latest dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Set up Python 3.13
+        run: uv python install 3.13
+      - name: Install with latest dependencies
+        run: uv sync --extra test --python 3.13
       - name: Run tests with coverage
         run: uv run pytest tests/src --cov=src --cov-report=xml:coverage/coverage.xml --cov-report=html:coverage/htmlcov --cov-append
       - name: Create coverage badge
@@ -53,7 +67,7 @@ jobs:
 
   deploy:
     if: ${{ github.ref == 'refs/heads/main' && always() }}
-    needs: pytest
+    needs: [test-minimum, test-latest]
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: false
+      - name: Set up Python 3.13
+        run: uv python install 3.13
       - name: Install the project
         run: uv sync --extra test
       - name: Python format


### PR DESCRIPTION
Refactored GitHub Actions workflows to test against both Python 3.11 (minimum dependencies) and Python 3.13 (latest dependencies) for examples and functional tests. Added explicit Python setup steps and improved dependency resolution. Updated linting workflow to use Python 3.13.