### PR TITLE
Add Python 3.14 support to devcontainer and CI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
-	"name": "Python 3",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bullseye",
-	"postCreateCommand": "pip install -e .[test]"
+	"name": "gwtransport - Python 3.14",
+	"image": "mcr.microsoft.com/devcontainers/python:1-3.14",
+	"features": {
+		"ghcr.io/devcontainers-extra/features/uv": {}
+	},
+	"postCreateCommand": "uv sync --extra test --python 3.14"
 }

--- a/.github/workflows/examples_testing.yml
+++ b/.github/workflows/examples_testing.yml
@@ -26,16 +26,16 @@ jobs:
         run: uv run pytest tests/examples
 
   test-examples-latest:
-    name: Python 3.13 - latest dependencies
+    name: Python 3.14 - latest dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Set up Python 3.13
-        run: uv python install 3.13
+      - name: Set up Python 3.14
+        run: uv python install 3.14
       - name: Install with latest dependencies
-        run: uv sync --extra test --python 3.13
+        run: uv sync --extra test --python 3.14
       - name: Run tests with coverage
         run: uv run pytest tests/examples --cov=src --cov-report=xml:coverage/coverage_examples.xml --cov-report=html:coverage/htmlcov_examples --cov-append
       - name: Create coverage badge

--- a/.github/workflows/functional_testing.yml
+++ b/.github/workflows/functional_testing.yml
@@ -26,16 +26,16 @@ jobs:
         run: uv run pytest tests/src
 
   test-latest:
-    name: Python 3.13 - latest dependencies
+    name: Python 3.14 - latest dependencies
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Set up Python 3.13
-        run: uv python install 3.13
+      - name: Set up Python 3.14
+        run: uv python install 3.14
       - name: Install with latest dependencies
-        run: uv sync --extra test --python 3.13
+        run: uv sync --extra test --python 3.14
       - name: Run tests with coverage
         run: uv run pytest tests/src --cov=src --cov-report=xml:coverage/coverage.xml --cov-report=html:coverage/htmlcov --cov-append
       - name: Create coverage badge

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v7
-      - name: Set up Python 3.13
-        run: uv python install 3.13
+      - name: Set up Python 3.14
+        run: uv python install 3.14
       - name: Install the project
         run: uv sync --extra test
       - name: Python format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Hydrology",
   "Topic :: Scientific/Engineering :: Physics",


### PR DESCRIPTION
Updated devcontainer configuration and GitHub Actions workflows to use Python 3.14 instead of 3.13. Added Python 3.14 classifier to pyproject.toml for package metadata.