### PR TITLE
Clarify relationship between APVD and pore-scale dispersion

### DIFF
--- a/docs/source/user_guide/assumptions.rst
+++ b/docs/source/user_guide/assumptions.rst
@@ -66,6 +66,19 @@ Physical/Hydrogeological Assumptions
 
    \frac{\sigma^2_{\text{diffusion}}}{\sigma^2_{\text{advection}}} < 0.1 \implies \text{Diffusion negligible}
 
+**Understanding the scale-dependence:**
+
+What appears as "dispersion" at one scale becomes "advection through heterogeneity" at a finer observation scale. The APVD captures velocity variations at the aquifer scale; :math:`\alpha_L` captures variations at the pore scale. These are the same physical phenomenon at different resolutions. See :ref:`concept-dispersion-scales` for details.
+
+**Relationship to the diffusion module:**
+
+When using the ``advection`` module, only macro-scale spreading from the pore volume distribution is modeled. To add pore-scale diffusive/dispersive spreading, use:
+
+- :mod:`gwtransport.diffusion_fast` for approximate but fast Gaussian smoothing
+- :mod:`gwtransport.diffusion` for analytical advection-dispersion solutions
+
+Alternatively, use the "equivalent APVD std" approach described in :doc:`/examples/05_Diffusion_Dispersion` to convert pore-scale dispersion to equivalent APVD spreading, allowing continued use of the fast advection module.
+
 .. _assumption-steady-streamlines:
 
 2. Steady Streamlines

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -132,6 +132,32 @@ A key advantage of ``gwtransport`` is how it handles dispersion:
 
 This is fundamentally different from traditional numerical transport models where dispersion must be parameterized separately and grid resolution affects results.
 
+.. _concept-dispersion-scales:
+
+Dispersion as Scale-Dependent Heterogeneity
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+All spreading in porous media transport arises from **velocity heterogeneity** at different scales:
+
+1. **Molecular scale**: Brownian motion causes spreading even in uniform flow (:math:`D_m`)
+2. **Pore scale** (~mm to cm): Velocity varies within and between pores (:math:`\alpha_L`, longitudinal dispersivity)
+3. **Local scale** (~m to 10m): Conductivity varies between soil layers and lenses
+4. **Aquifer scale** (~10m to km): Different streamlines have different path lengths (captured by APVD)
+
+The boundaries between these scales are **not sharp**. This is why measured dispersivity (:math:`\alpha_L`) famously increases with experiment scale—larger measurements "see" more heterogeneity.
+
+**gwtransport's approach:**
+
+- The **pore volume distribution (APVD)** captures macro-scale heterogeneity explicitly
+- The **diffusion module** adds molecular diffusion (:math:`D_m`) and mechanical dispersion (:math:`\alpha_L`)
+- For most bank filtration applications, APVD dominates and pore-scale dispersion is negligible
+
+**When calibrating APVD from breakthrough curves**, the fitted :math:`\sigma_{apv}` already includes all spreading sources at scales smaller than the APVD resolution. Adding :math:`\alpha_L` would double-count.
+
+**When computing APVD from streamline analysis**, only macro-scale path lengths are captured. Pore-scale dispersion (:math:`\alpha_L`) can be meaningfully added.
+
+See :doc:`/examples/05_Diffusion_Dispersion` for quantitative guidance on comparing these contributions and formulas to convert dispersion effects to equivalent APVD standard deviation.
+
 Calibration Approaches
 ----------------------
 

--- a/examples/05_Diffusion_Dispersion.ipynb
+++ b/examples/05_Diffusion_Dispersion.ipynb
@@ -3,21 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Diffusion and Dispersion in Solute Transport\n",
-    "\n",
-    "Breakthrough curve spreading arises from three independent processes:\n",
-    "\n",
-    "| Component                 | Symbol          | Physical cause                 | Pore velocity scaling                     |\n",
-    "| ------------------------- | --------------- | ------------------------------ | ----------------------------------------- |\n",
-    "| **Aquifer heterogeneity** | $\\sigma_{apv}$  | Different streamline lengths   | $\\propto \\tau$                            |\n",
-    "| **Molecular diffusion**   | $\\sigma_{diff}$ | Brownian motion                | $\\propto \\sqrt{\\tau}$, independent of $v$ |\n",
-    "| **Mechanical dispersion** | $\\sigma_{disp}$ | Pore-scale velocity variations | $\\propto \\sqrt{\\tau}$, scales with $v$    |\n",
-    "\n",
-    "where $v$ is the pore velocity (= specific discharge $q$ / porosity $n$).\n",
-    "\n",
-    "**Key insight**: Molecular diffusion and mechanical dispersion produce spreading characterized by $\\sigma_x = \\sqrt{2 D_L \\tau}$. This spatial spreading can be converted to equivalent APVD units for comparison with aquifer heterogeneity."
-   ]
+   "source": "# Diffusion and Dispersion in Solute Transport\n\n## Physical Background: Dispersion as Scale-Dependent Heterogeneity\n\nAll spreading in groundwater transport arises from **velocity heterogeneity**. What we call \"dispersion\" vs \"heterogeneity\" is simply a matter of observation scale:\n\n| Scale | Mechanism | gwtransport representation |\n|-------|-----------|---------------------------|\n| Molecular | Brownian motion | $D_m$ (molecular diffusivity) |\n| Pore (~mm-cm) | Velocity variations in pores | $\\alpha_L$ (dispersivity) |\n| Aquifer (~m-km) | Different streamline paths | APVD ($\\sigma_{apv}$) |\n\n**Key insight**: These are the same phenomenon at different resolutions. The boundaries are not sharp—this is why measured $\\alpha_L$ increases with experiment scale.\n\n### When to use each approach\n\n| APVD source | Recommendation |\n|-------------|----------------|\n| **Breakthrough curve fitting** | Use APVD only (dispersion already absorbed in $\\sigma_{apv}$) |\n| **Streamline analysis** | Can add $\\alpha_L$ for unresolved pore-scale effects |\n| **Either** | Use \"equivalent APVD std\" to combine and use fast advection module |\n\n## Spreading Components\n\nBreakthrough curve spreading arises from three independent processes:\n\n| Component                 | Symbol          | Physical cause                 | Pore velocity scaling                     |\n| ------------------------- | --------------- | ------------------------------ | ----------------------------------------- |\n| **Aquifer heterogeneity** | $\\sigma_{apv}$  | Different streamline lengths   | $\\propto \\tau$                            |\n| **Molecular diffusion**   | $\\sigma_{diff}$ | Brownian motion                | $\\propto \\sqrt{\\tau}$, independent of $v$ |\n| **Mechanical dispersion** | $\\sigma_{disp}$ | Pore-scale velocity variations | $\\propto \\sqrt{\\tau}$, scales with $v$    |\n\nwhere $v$ is the pore velocity (= specific discharge $q$ / porosity $n$).\n\n**Key insight**: Molecular diffusion and mechanical dispersion produce spreading characterized by $\\sigma_x = \\sqrt{2 D_L \\tau}$. This spatial spreading can be converted to equivalent APVD units for comparison with aquifer heterogeneity."
   },
   {
    "cell_type": "markdown",
@@ -232,6 +218,11 @@
     "    print(\"RECOMMENDATION: Use diffusion for accuracy\")\n",
     "print(\"=\" * 50)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "source": "## Using Combined Std with Advection Module (Fast Approach)\n\nWhen diffusion/dispersion effects are significant but you want the speed of the advection module, use the combined standard deviation. This is valid because both APVD heterogeneity and pore-scale dispersion represent the same physical phenomenon (velocity heterogeneity) at different observation scales—their variances can be added.\n\n```python\n# Instead of calling diffusion.infiltration_to_extraction (slow),\n# use advection with combined std (fast):\ncout_fast = advection.gamma_infiltration_to_extraction(\n    cin=cin,\n    flow=flow,\n    tedges=tedges,\n    cout_tedges=cout_tedges,\n    mean=mean_apv,\n    std=sigma_apv_diff_disp,  # Combined: sqrt(σ²_apv + σ²_diff_disp)\n    n_bins=nbins,\n    retardation_factor=retardation,\n)\n```\n\n**When is this approach valid?**\n- Flow is relatively constant (so diffusion effects are well-approximated)\n- You want fast computation with reasonable accuracy\n- Either APVD was calibrated from streamlines OR you want to add diffusion to existing APVD\n\n**When to use full diffusion module instead:**\n- Flow varies significantly over time\n- High precision is required\n- You need to model different dispersivities for different pore volumes",
+   "metadata": {}
   },
   {
    "cell_type": "markdown",

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -25,6 +25,13 @@ Available functions:
   (alpha, beta) or (mean, std). Discretizes gamma distribution into equal-probability bins.
   Use case: Heterogeneous aquifer with calibrated gamma parameters.
 
+Note on dispersion: The spreading from the pore volume distribution (APVD) represents
+macro-scale aquifer heterogeneity—this is the same physical phenomenon as "dispersion"
+but at a larger observation scale. If APVD was calibrated from breakthrough curves, this
+spreading already includes all dispersion effects at smaller scales. To add pore-scale
+dispersion separately (when APVD comes from streamline analysis), use
+:mod:`gwtransport.diffusion`. See :ref:`concept-dispersion-scales` for details.
+
 - :func:`extraction_to_infiltration_series` - Single pore volume, time-shift only
   (deconvolution). Shifts extraction time edges backward by residence time. Concentration
   values remain unchanged (cin = cout). Symmetric inverse of infiltration_to_extraction_series.
@@ -367,6 +374,14 @@ def gamma_infiltration_to_extraction(
     gamma_extraction_to_infiltration : Reverse operation (deconvolution)
     gwtransport.gamma.bins : Create gamma distribution bins
     gwtransport.residence_time.residence_time : Compute residence times
+    gwtransport.diffusion.infiltration_to_extraction : Add pore-scale dispersion
+
+    Notes
+    -----
+    The spreading from the gamma-distributed pore volumes represents macro-scale aquifer
+    heterogeneity. If parameters (mean, std) were calibrated from breakthrough curves,
+    pore-scale dispersion is already implicitly included. See :ref:`concept-dispersion-scales`
+    for guidance on when to add pore-scale dispersion using the diffusion module.
 
     Examples
     --------
@@ -498,6 +513,20 @@ def gamma_extraction_to_infiltration(
     -------
     numpy.ndarray
         Concentration of the compound in the infiltrating water [ng/m3] or temperature.
+
+    See Also
+    --------
+    extraction_to_infiltration : Deconvolution with explicit pore volume distribution
+    gamma_infiltration_to_extraction : Forward operation (convolution)
+    gwtransport.gamma.bins : Create gamma distribution bins
+    gwtransport.diffusion.extraction_to_infiltration : Deconvolution with pore-scale dispersion
+
+    Notes
+    -----
+    The spreading from the gamma-distributed pore volumes represents macro-scale aquifer
+    heterogeneity. If parameters (mean, std) were calibrated from breakthrough curves,
+    pore-scale dispersion is already implicitly included. See :ref:`concept-dispersion-scales`
+    for guidance on when to add pore-scale dispersion using the diffusion module.
 
     Examples
     --------

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -210,20 +210,20 @@ def compute_sigma_array(
     neighboring time steps are blended together when applying diffusive smoothing.
 
     The computation follows these steps:
-    1. Calculate residence time (rt) for water parcels traveling through the aquifer
-    2. Compute the diffusive spreading length: L_diff = sqrt(2 * D * rt) [m]
-       This is the physical distance over which concentrations spread due to diffusion
-    3. Compute the advective step size: dx = (Q * dt / V_pore) * L_aquifer [m]
-       This is the physical distance the water moves during one time step
-    4. Sigma = L_diff / dx converts the physical spreading into array index units
 
-    Why divide by dx?
-    The Gaussian filter operates on array indices, not physical distances. If the
-    diffusive spreading is 10 meters and each time step moves water 2 meters, then
-    sigma = 10/2 = 5 means the filter should blend across ~5 time steps. This
-    normalization accounts for variable flow rates: faster flow means larger dx,
-    so fewer time steps are blended (smaller sigma), even though the physical
-    spreading remains the same.
+    1. Calculate residence time (rt) for water parcels traveling through the aquifer
+    2. Compute the diffusive spreading length: L_diff = sqrt(2 * D * rt) [m].
+       This is the physical distance over which concentrations spread due to diffusion.
+    3. Compute the advective step size: dx = (Q * dt / V_pore) * L_aquifer [m].
+       This is the physical distance the water moves during one time step.
+    4. Sigma = L_diff / dx converts the physical spreading into array index units.
+
+    Why divide by dx? The Gaussian filter operates on array indices, not physical
+    distances. If the diffusive spreading is 10 meters and each time step moves
+    water 2 meters, then sigma = 10/2 = 5 means the filter should blend across
+    ~5 time steps. This normalization accounts for variable flow rates: faster
+    flow means larger dx, so fewer time steps are blended (smaller sigma), even
+    though the physical spreading remains the same.
 
     Parameters
     ----------
@@ -277,20 +277,20 @@ def compute_scaled_sigma_array(
     neighboring time steps are blended together when applying diffusive smoothing.
 
     The computation follows these steps:
-    1. Calculate residence time (rt) for water parcels traveling through the aquifer
-    2. Compute the diffusive spreading length: L_diff = sqrt(2 * D * rt) [m]
-       This is the physical distance over which concentrations spread due to diffusion
-    3. Compute the advective step size: dx = (Q * dt / V_pore) * L_aquifer [m]
-       This is the physical distance the water moves during one time step
-    4. Sigma = L_diff / dx converts the physical spreading into array index units
 
-    Why divide by dx?
-    The Gaussian filter operates on array indices, not physical distances. If the
-    diffusive spreading is 10 meters and each time step moves water 2 meters, then
-    sigma = 10/2 = 5 means the filter should blend across ~5 time steps. This
-    normalization accounts for variable flow rates: faster flow means larger dx,
-    so fewer time steps are blended (smaller sigma), even though the physical
-    spreading remains the same.
+    1. Calculate residence time (rt) for water parcels traveling through the aquifer
+    2. Compute the diffusive spreading length: L_diff = sqrt(2 * D * rt) [m].
+       This is the physical distance over which concentrations spread due to diffusion.
+    3. Compute the advective step size: dx = (Q * dt / V_pore) * L_aquifer [m].
+       This is the physical distance the water moves during one time step.
+    4. Sigma = L_diff / dx converts the physical spreading into array index units.
+
+    Why divide by dx? The Gaussian filter operates on array indices, not physical
+    distances. If the diffusive spreading is 10 meters and each time step moves
+    water 2 meters, then sigma = 10/2 = 5 means the filter should blend across
+    ~5 time steps. This normalization accounts for variable flow rates: faster
+    flow means larger dx, so fewer time steps are blended (smaller sigma), even
+    though the physical spreading remains the same.
 
     Parameters
     ----------


### PR DESCRIPTION
## Summary

- Document that macro-scale heterogeneity (APVD) and pore-scale dispersion (α_L) are the same physical phenomenon—velocity heterogeneity—observed at different observation scales
- Provide practical guidance on when to use each approach based on how APVD was calibrated
- Add formulas to convert dispersion effects to equivalent APVD standard deviation for use with fast advection module

## Changes

### Documentation
- **concepts.rst**: Add new section `concept-dispersion-scales` explaining the continuum of scales from molecular to aquifer
- **assumptions.rst**: Expand "Advection-Dominated Transport" assumption with scale-dependence explanation and relationship to diffusion module

### Code
- **advection.py**: Add dispersion notes to module docstring and gamma function docstrings with See Also references
- **diffusion.py**: Refine warning messages to be more nuanced about when combining APVD with dispersivity is appropriate vs when it may double-count
- **diffusion_fast.py**: Fix docstring formatting that caused Sphinx warnings

### Examples
- **05_Diffusion_Dispersion.ipynb**: Expand with physics background explaining scale-dependent heterogeneity, decision table for when to use each approach, and practical "equivalent APVD std" code example

## Physics Background

All spreading in groundwater transport arises from velocity heterogeneity at different scales:

| Scale | Mechanism | gwtransport representation |
|-------|-----------|---------------------------|
| Molecular | Brownian motion | D_m (molecular diffusivity) |
| Pore (~mm-cm) | Velocity variations in pores | α_L (dispersivity) |
| Aquifer (~m-km) | Different streamline paths | APVD (σ_apv) |

The scale boundaries are not sharp—this is why measured α_L increases with experiment scale.

## Practical Guidance

| APVD source | Recommendation |
|-------------|----------------|
| Breakthrough curve fitting | Use APVD only (dispersion already absorbed in σ_apv) |
| Streamline analysis | Can add α_L for unresolved pore-scale effects |
| Either | Use "equivalent APVD std" to combine and use fast advection module |

## Test plan

- [x] All 716 unit tests pass
- [x] Notebook test for 05_Diffusion_Dispersion.ipynb passes
- [x] Sphinx documentation builds without docstring errors
- [x] Linting passes (ruff format, ruff check)