### PR TITLE
Add CLA, CONTRIBUTING guide, and PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- What does this change, and why? -->
+
+## Test plan
+
+<!-- Commands run and cases covered. -->
+
+## Contributor License Agreement
+
+- [ ] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,24 @@
+name: CLA check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  cla:
+    name: Contributor License Agreement
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify CLA checkbox is ticked
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if printf '%s' "$PR_BODY" | grep -qiE '^[[:space:]]*-[[:space:]]*\[x\][[:space:]]*I have read the \[CLA\]'; then
+            echo "CLA checkbox is ticked."
+          else
+            echo "::error title=CLA not accepted::Tick the CLA checkbox in the pull request description. See CLA.md for the agreement; the checkbox is in .github/PULL_REQUEST_TEMPLATE.md."
+            exit 1
+          fi

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,27 @@
+# Contributor License Agreement
+
+## Why this exists
+
+`gwtransport` is released under AGPL-3.0 so the code stays open. Some organizations can't use AGPL — internal policy, license incompatibility, SaaS concerns — so I also offer commercial licenses to them. That revenue funds continued development of the open project.
+
+This CLA is what makes the dual path possible: instead of chasing down every past contributor each time a commercial license is negotiated, contributors agree up front that their code can ship under both AGPL-3.0 and other terms.
+
+You keep the copyright in your contribution. You just grant me the rights needed to distribute it.
+
+## Terms
+
+By submitting a contribution to this project, You agree with Bas des Tombe ("Maintainer"):
+
+1. **Copyright license.** You grant the Maintainer a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license to use, reproduce, modify, distribute, publicly display, and create derivative works of Your contribution, and to sublicense these rights under any terms, including commercial or proprietary terms.
+
+2. **Patent license.** You grant the Maintainer and downstream recipients a perpetual, worldwide, non-exclusive, royalty-free, irrevocable license under any patent claims You own or control that are necessarily infringed by Your contribution or its use within the project.
+
+3. **Right to contribute.** The contribution is Your original work, or You have sufficient rights to submit it under this CLA. If Your employer has rights to Your work, You have their permission to contribute, or they have waived those rights.
+
+4. **As is.** Contributions are provided without warranty of any kind.
+
+5. **You keep Your copyright.** This is a license, not an assignment. You remain free to use Your contribution for any other purpose.
+
+## How to accept
+
+Check the CLA box in the pull request template. One acceptance covers all Your future contributions to this project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to gwtransport
+
+Thanks for your interest. Contributions of code, tests, docs, and examples are welcome.
+
+## Contributor License Agreement
+
+Every contribution needs an accepted [CLA](CLA.md). It exists so `gwtransport` can stay AGPL-3.0 _and_ be commercially licensed to organizations that cannot use AGPL — the commercial side funds the open project. You keep the copyright in your contribution; you just grant the rights needed to distribute it under both licenses.
+
+You accept the CLA by checking the box in the [pull request template](.github/PULL_REQUEST_TEMPLATE.md). One acceptance covers all your future contributions.
+
+## Before you open a PR
+
+- Keep the change focused. A short description of _what_ and _why_ is enough.
+- Run the tests, linting, and type checks listed in [CLAUDE.md](CLAUDE.md#commands) or [copilot-instructions.md](.github/copilot-instructions.md#commands).
+- Follow the code style and domain conventions in [CLAUDE.md](CLAUDE.md#code-style) or [copilot-instructions.md](.github/copilot-instructions.md#code-style).
+
+## Questions
+
+Open an issue on GitHub.


### PR DESCRIPTION
## Summary

- Adds `CLA.md` — a lean contributor license agreement that lets `gwtransport` stay AGPL-3.0 *and* be commercially licensed to organizations that cannot use AGPL. Contributors keep their copyright and grant a sublicensable license covering both paths.
- Adds `.github/PULL_REQUEST_TEMPLATE.md` with Summary / Test plan sections and a CLA acceptance checkbox.
- Adds `CONTRIBUTING.md` explaining the rationale in one paragraph and pointing to the CLA and PR template.

## Test plan

- [x] `npx prettier --check` passes on all three new files.
- [ ] Verify the new PR template renders on the next PR opened against `main`.

## Contributor License Agreement

- [x] I have read the [CLA](/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.