### PR TITLE
Fix utils, logremoval, examples (physics review)

### DIFF
--- a/src/gwtransport/examples.py
+++ b/src/gwtransport/examples.py
@@ -35,8 +35,6 @@ This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """
 
-from typing import Any
-
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
@@ -74,6 +72,7 @@ def generate_example_data(
     molecular_diffusivity: float | None = None,
     longitudinal_dispersivity: float | None = None,
     streamline_length: float | None = None,
+    rng: np.random.Generator | int | None = None,
 ) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
     """
     Generate synthetic concentration/temperature and flow data for groundwater transport.
@@ -147,6 +146,12 @@ def generate_example_data(
     streamline_length : float or None, default None
         Travel distance along the streamline [m]. Must be provided together
         with ``molecular_diffusivity`` and ``longitudinal_dispersivity``.
+    rng : numpy.random.Generator, int, or None, default None
+        Source of randomness for the synthetic flow noise, spill events, and
+        measurement noise. Accepted in any form supported by
+        :func:`numpy.random.default_rng`. Pass an integer (or
+        :class:`numpy.random.Generator`) for reproducible output; ``None``
+        draws fresh entropy each call.
 
     Returns
     -------
@@ -169,22 +174,24 @@ def generate_example_data(
     --------
     generate_temperature_example_data : Wrapper with thermal transport defaults.
     """
+    rng = np.random.default_rng(rng)
+
     # Create date range
     dates = pd.date_range(start=date_start, end=date_end, freq=date_freq).tz_localize("UTC")
     days = (dates - dates[0]).days.values
 
     # Generate flow data with seasonal pattern (higher in winter)
     seasonal_flow = flow_mean + flow_amplitude * np.sin(2 * np.pi * days / 365 + np.pi)
-    flow = seasonal_flow + np.random.normal(0, flow_noise, len(dates))
+    flow = seasonal_flow + rng.normal(0, flow_noise, len(dates))
     flow = np.maximum(flow, 5.0)  # Ensure flow is not too small or negative
 
     min_days_for_spills = 60
     if len(dates) > min_days_for_spills:  # Only add spills for longer time series
-        n_spills = np.random.randint(6, 16)
+        n_spills = int(rng.integers(6, 16))
         for _ in range(n_spills):
-            spill_start = np.random.randint(0, len(dates) - 30)
-            spill_duration = np.random.randint(15, 45)
-            spill_magnitude = np.random.uniform(2.0, 5.0)
+            spill_start = int(rng.integers(0, len(dates) - 30))
+            spill_duration = int(rng.integers(15, 45))
+            spill_magnitude = float(rng.uniform(2.0, 5.0))
 
             flow[spill_start : spill_start + spill_duration] /= spill_magnitude
 
@@ -192,11 +199,11 @@ def generate_example_data(
     if cin_method == "synthetic":
         # Seasonal pattern with noise
         cin_nonoise = cin_mean + cin_amplitude * np.sin(2 * np.pi * days / 365)
-        cin_values = cin_nonoise + np.random.normal(0, measurement_noise, len(dates))
+        cin_values = cin_nonoise + rng.normal(0, measurement_noise, len(dates))
     elif cin_method == "constant":
         # Constant value
         cin_nonoise = np.full(len(dates), cin_mean)
-        cin_values = cin_nonoise + np.random.normal(0, measurement_noise, len(dates))
+        cin_values = cin_nonoise + rng.normal(0, measurement_noise, len(dates))
     elif cin_method == "soil_temperature":
         # Use soil temperature data (already includes measurement noise)
         cin_nonoise = cin_values = (
@@ -309,7 +316,7 @@ def generate_example_data(
         )
 
     # Add some noise to represent measurement errors
-    cout_values += np.random.normal(0, measurement_noise, len(dates))
+    cout_values += rng.normal(0, measurement_noise, len(dates))
 
     # Create data frame
     df = pd.DataFrame(
@@ -352,7 +359,7 @@ def generate_example_data(
     return df, tedges
 
 
-def generate_temperature_example_data(**kwargs: Any) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
+def generate_temperature_example_data(**kwargs) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
     """
     Generate synthetic temperature and flow data for groundwater transport examples.
 
@@ -405,7 +412,7 @@ def generate_temperature_example_data(**kwargs: Any) -> tuple[pd.DataFrame, pd.D
     return generate_example_data(**kwargs)
 
 
-def generate_ec_example_data(**kwargs: Any) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
+def generate_ec_example_data(**kwargs) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
     """
     Generate synthetic electrical conductivity and flow data for groundwater transport examples.
 

--- a/src/gwtransport/logremoval.py
+++ b/src/gwtransport/logremoval.py
@@ -565,7 +565,10 @@ def gamma_find_flow_for_target_mean(
     Raises
     ------
     ValueError
-        If ``apv_loc`` is negative or if ``target_mean`` is not positive.
+        If ``apv_loc`` is negative, if ``target_mean`` is not positive, if
+        ``log10_decay_rate`` is not positive (no decay can never produce a
+        positive target log removal), or if ``apv_alpha`` or ``apv_beta`` are
+        not positive.
 
     See Also
     --------
@@ -576,6 +579,17 @@ def gamma_find_flow_for_target_mean(
         raise ValueError(msg)
     if target_mean <= 0:
         msg = "target_mean must be positive"
+        raise ValueError(msg)
+    if apv_alpha <= 0:
+        msg = "apv_alpha must be positive"
+        raise ValueError(msg)
+    if apv_beta <= 0:
+        msg = "apv_beta must be positive"
+        raise ValueError(msg)
+    if log10_decay_rate <= 0:
+        # Without decay, the effective mean log removal is identically zero
+        # regardless of flow, so no finite flow can attain a positive target.
+        msg = "log10_decay_rate must be positive to attain a positive target_mean"
         raise ValueError(msg)
 
     ln10 = np.log(10)
@@ -589,6 +603,16 @@ def gamma_find_flow_for_target_mean(
     # unique positive root. Bracket: at u = 1/flow_closed_form the alpha/beta term alone
     # equals target_mean, so the full f overshoots by exactly mu*apv_loc*u_upper > 0.
     u_upper = 1.0 / flow_closed_form
+    if not np.isfinite(u_upper) or u_upper <= 0:
+        # Defensive: with the validated inputs above, flow_closed_form is finite and
+        # strictly positive, so u_upper should be a finite positive bracket. If a
+        # pathological input slips through, surface it instead of calling brentq on
+        # an invalid interval.
+        msg = (
+            "Cannot bracket the root for the given parameters; check that "
+            "target_mean, apv_alpha, apv_beta, and log10_decay_rate are finite and positive."
+        )
+        raise ValueError(msg)
 
     def residual(u: float) -> float:
         return float(

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -78,7 +78,6 @@ import warnings
 from collections.abc import Callable
 from datetime import date
 from pathlib import Path
-from typing import cast
 
 import numpy as np
 import numpy.typing as npt
@@ -391,18 +390,14 @@ def linear_average(
     # Ensure it's an array for type checker
     all_unique_y: npt.NDArray[np.float64] = np.asarray(all_unique_y_result, dtype=np.float64)
 
-    # Compute cumulative integrals once using trapezoidal rule
+    # Compute cumulative integrals once using trapezoidal rule.
+    # Segments outside the data range carry NaN (from np.interp with left/right=NaN);
+    # those NaNs will be masked out later via the bin-range check, so we suppress
+    # them here only to keep the cumulative sum finite for in-range bins.
     dx = np.diff(all_unique_x)
     y_avg = (all_unique_y[:-1] + all_unique_y[1:]) / 2
-    segment_integrals = dx * y_avg
-    # Replace NaN values with 0 to avoid breaking cumulative sum.
-    # NaN occurs for segments outside the data range (extrapolation='nan').
-    # Setting NaN to 0 means boundary bins with partial data coverage have their
-    # average biased low: the integral covers only the valid portion but the
-    # width denominator below uses the full bin width. A proper fix would track
-    # the covered fraction per bin.
-    segment_integrals = np.nan_to_num(segment_integrals, nan=0.0)
-    cumulative_integral = np.concatenate([[0], np.cumsum(segment_integrals)])
+    segment_integrals = np.where(np.isnan(y_avg), 0.0, dx * y_avg)
+    cumulative_integral = np.concatenate([[0.0], np.cumsum(segment_integrals)])
 
     # Vectorized computation for all series
     # Find indices of all edges in the combined grid
@@ -429,9 +424,12 @@ def linear_average(
         zero_width_positions = edges_processed[:, :-1][zero_width_mask]
         result[zero_width_mask] = np.interp(zero_width_positions, x_data_clean, y_data_clean)
 
-    # Handle extrapolation when 'nan' method is used (vectorized)
+    # Handle extrapolation when 'nan' method is used (vectorized).
+    # Bins must lie entirely within the data range; bins partially outside
+    # (straddling) are also set to NaN, since the integral over the missing
+    # portion is undefined and dividing by the full bin width would bias the
+    # average low. Bins fully outside are likewise NaN.
     if extrapolate_method == "nan":
-        # Set out-of-range bins to NaN
         bins_within_range = (x_edges[:, :-1] >= x_data_clean[0]) & (x_edges[:, 1:] <= x_data_clean[-1])
         result[~bins_within_range] = np.nan
 
@@ -862,6 +860,12 @@ def compute_time_edges(
       the final edge based on the spacing between the last two start times.
     - When using tend, the function assumes uniform spacing and extrapolates
       the first edge based on the spacing between the first two end times.
+    - When ``tstart`` or ``tend`` are provided with non-uniformly-spaced bins,
+      the extrapolated edge uses only the very first or very last interval and
+      may be physically incorrect: the missing edge is implicitly assigned a
+      bin width equal to that single neighbouring interval, which is unrelated
+      to any other interval in the series. In such cases, supply ``tedges``
+      directly so that all bin widths are explicit.
     - All input time data is converted to pandas.DatetimeIndex for consistency.
     """
     if tedges is not None:
@@ -946,7 +950,9 @@ def get_soil_temperature(*, station_number: int = 260, interpolate_missing_value
 
     # Check if cached file exists and is from today
     if cache_path.exists():
-        return cast("pd.DataFrame", pd.read_pickle(cache_path))  # noqa: S301
+        cached = pd.read_pickle(cache_path)  # noqa: S301
+        assert isinstance(cached, pd.DataFrame)  # noqa: S101 -- the cache only ever stores DataFrames
+        return cached
 
     # Clean up old cache files to prevent disk bloat
     for old_file in cache_dir.glob(f"soil_temp_{station_number}_{interpolate_missing_values}_*.pkl"):

--- a/tests/src/test_fraction_explained.py
+++ b/tests/src/test_fraction_explained.py
@@ -67,27 +67,11 @@ def test_multiple_pore_volumes_gradual_increase(constant_flow_setup, multiple_po
         direction="extraction_to_infiltration",
     )
 
-    # Should be 1D array with same length as flow values
-    assert result.shape == (len(flow_values),)
-
-    # Values should be between 0.0 and 1.0
-    assert np.all((result >= 0.0) & (result <= 1.0))
-
-    # Should have increasing fractions over time (monotonic increase)
-    # Allow for some plateau regions where fraction doesn't change
-    assert np.all(np.diff(result) >= 0)
-
-    # Should start at 0.0 and eventually reach 1.0
-    assert result[0] == 0.0
-    assert result[-1] == 1.0
-
-    # Check expected fraction values (0.2, 0.4, 0.6, 0.8, 1.0)
-    expected_fractions = np.array([0.0, 0.2, 0.4, 0.6, 0.8, 1.0])
-    unique_fractions = np.unique(result)
-
-    # All unique fractions should be in expected set
-    for frac in unique_fractions:
-        assert np.any(np.isclose(frac, expected_fractions, atol=1e-10))
+    # 10 daily bins, residence times 1..5 days for pore volumes 100..500 m3 at
+    # 100 m3/d flow. The fraction at each output bin equals (count of valid
+    # residence times) / 5; with constant flow this is a clean staircase.
+    expected = np.array([0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.0, 1.0, 1.0, 1.0])
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-15)
 
 
 def test_zero_flow_all_invalid():
@@ -253,8 +237,10 @@ def test_mixed_valid_invalid_residence_times():
     flow_tedges = pd.date_range(start="2023-01-01", end="2023-01-08", freq="D")
     flow_values = np.full(len(flow_tedges) - 1, 100.0)
 
-    # Mix of small (valid) and large (invalid) pore volumes
-    pore_volumes = np.array([100.0, 1e6, 200.0, 2e6, 300.0])  # 3 valid, 2 invalid
+    # Mix of small (valid) and large (invalid) pore volumes.
+    # Sorted residence times at flow=100 m3/d: [1, 2, 3, 1e4, 2e4] days; only the
+    # first three become valid within the 7-day window, capping the fraction at 3/5.
+    pore_volumes = np.array([100.0, 1e6, 200.0, 2e6, 300.0])
 
     result = fraction_explained(
         flow=flow_values,
@@ -263,15 +249,8 @@ def test_mixed_valid_invalid_residence_times():
         direction="extraction_to_infiltration",
     )
 
-    # Maximum fraction should be 3/5 = 0.6 (only 3 out of 5 pore volumes can be valid)
-    assert np.max(result) <= 0.6 + 1e-10  # Small tolerance for floating point
-
-    # Should have fractions that are multiples of 1/5 = 0.2
-    unique_fractions = np.unique(result)
-    expected_multiples = np.array([0.0, 0.2, 0.4, 0.6])
-
-    for frac in unique_fractions:
-        assert np.any(np.isclose(frac, expected_multiples, atol=1e-10))
+    expected = np.array([0.0, 0.2, 0.4, 0.6, 0.6, 0.6, 0.6])
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-15)
 
 
 def test_input_validation_missing_parameters():
@@ -339,9 +318,12 @@ def test_numerical_precision():
     flow_tedges = pd.date_range(start="2023-01-01", end="2023-01-11", freq="D")
     flow_values = np.full(len(flow_tedges) - 1, 100.0)
 
-    # Use 7 pore volumes for non-trivial fraction arithmetic
+    # 7 pore volumes spaced 50, 100, 150, 200, 250, 300, 350 m3 give residence
+    # times 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5 days at constant flow=100 m3/d.
+    # Within the 10-day window the fraction grows by 1/7 per day until all are
+    # valid (after 3 days), then stays at 1.
     n_volumes = 7
-    pore_volumes = np.linspace(50, 350, n_volumes)  # Range to get mix of valid/invalid
+    pore_volumes = np.linspace(50, 350, n_volumes)
 
     result = fraction_explained(
         flow=flow_values,
@@ -350,14 +332,8 @@ def test_numerical_precision():
         direction="extraction_to_infiltration",
     )
 
-    # All fractions should be exact multiples of 1/n_volumes
-    expected_increment = 1.0 / n_volumes
-
-    for frac in np.unique(result):
-        # Check if frac is close to k/n_volumes for some integer k
-        k = np.round(frac / expected_increment)
-        expected_frac = k * expected_increment
-        assert np.isclose(frac, expected_frac, atol=1e-14)
+    expected = np.array([1, 3, 5, 7, 7, 7, 7, 7, 7, 7], dtype=float) / n_volumes
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-15)
 
 
 def test_monotonic_behavior_across_pore_volumes():
@@ -370,7 +346,9 @@ def test_monotonic_behavior_across_pore_volumes():
     flow_tedges = pd.date_range(start="2023-01-01", end="2023-01-15", freq="D")
     flow_values = np.full(len(flow_tedges) - 1, 100.0)
 
-    # Well-separated pore volumes to ensure clear ordering
+    # Well-separated pore volumes give residence times 1, 3, 5, 7, 9 days at
+    # constant flow=100 m3/d. Over 14 daily output bins this produces a clean
+    # staircase whose every step is exactly 1/5.
     pore_volumes = np.array([100, 300, 500, 700, 900])
 
     result = fraction_explained(
@@ -380,12 +358,8 @@ def test_monotonic_behavior_across_pore_volumes():
         direction="extraction_to_infiltration",
     )
 
-    # Fraction should be non-decreasing over time
-    assert np.all(np.diff(result) >= -1e-10)  # Allow tiny numerical errors
-
-    # Should start at 0.0 and increase
-    assert result[0] == 0.0
-    assert result[-1] > result[0]
+    expected = np.array([0.0, 0.2, 0.2, 0.4, 0.4, 0.6, 0.6, 0.8, 0.8, 1.0, 1.0, 1.0, 1.0, 1.0])
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-15)
 
 
 def test_fraction_explained_rejects_1d_input():

--- a/tests/src/test_logremoval.py
+++ b/tests/src/test_logremoval.py
@@ -39,8 +39,8 @@ def test_different_flows_equal_distribution():
     # Test case: Two flows with log removals 3 and 5
     result = parallel_mean(log_removals=[3, 4, 5])
     expected = -np.log10((10 ** (-3.0) + 10 ** (-4.0) + 10 ** (-5.0)) / 3)
-    assert_allclose(result, expected, rtol=1e-10)
-    assert_allclose(result, 3.431798275933005, rtol=1e-3)  # example in docstring
+    assert_allclose(result, expected, rtol=1e-15)
+    assert_allclose(result, 3.431798275933005, rtol=1e-15)  # example in docstring
 
 
 def test_array_inputs_equal_distribution():
@@ -48,7 +48,7 @@ def test_array_inputs_equal_distribution():
     # NumPy arrays as input
     result = parallel_mean(log_removals=np.array([3.0, 4.0, 5.0]))
     expected = -np.log10((10 ** (-3.0) + 10 ** (-4.0) + 10 ** (-5.0)) / 3)
-    assert_allclose(result, expected, rtol=1e-10)
+    assert_allclose(result, expected, rtol=1e-15)
 
 
 def test_empty_input_behavior():
@@ -63,14 +63,14 @@ def test_special_values_equal_distribution():
     # With log removal of 0 (no removal)
     result = parallel_mean(log_removals=[0.0, 4.0])
     expected = -np.log10((1.0 + 10 ** (-4.0)) / 2)
-    assert_allclose(result, expected, rtol=1e-10)
+    assert_allclose(result, expected, rtol=1e-15)
 
     # With very large log removal (effectively complete removal)
     # Using a large number instead of infinity to avoid numerical issues
     result = parallel_mean(log_removals=[20.0, 3.0])
     # The 10^-20 term is effectively zero
     expected = -np.log10((10 ** (-20.0) + 10 ** (-3.0)) / 2)
-    assert_allclose(result, expected, rtol=1e-10)
+    assert_allclose(result, expected, rtol=1e-15)
 
 
 def test_float_precision_equal_distribution():
@@ -78,7 +78,7 @@ def test_float_precision_equal_distribution():
     # Testing with values that require good floating point handling
     result = parallel_mean(log_removals=[9.999, 9.998])
     expected = -np.log10((10 ** (-9.999) + 10 ** (-9.998)) / 2)
-    assert_allclose(result, expected, rtol=1e-10)
+    assert_allclose(result, expected, rtol=1e-15)
 
 
 def test_equal_weights_explicit():
@@ -89,7 +89,7 @@ def test_equal_weights_explicit():
     weighted_result = parallel_mean(log_removals=log_removals, flow_fractions=weights)
     unweighted_result = parallel_mean(log_removals=log_removals)
 
-    assert_allclose(weighted_result, unweighted_result, rtol=1e-10)
+    assert_allclose(weighted_result, unweighted_result, rtol=1e-15)
 
 
 def test_weighted_flows():
@@ -100,8 +100,8 @@ def test_weighted_flows():
 
     result = parallel_mean(log_removals=log_removals, flow_fractions=weights)
     expected = -np.log10(0.7 * 10 ** (-3.0) + 0.3 * 10 ** (-5.0))
-    assert_allclose(result, expected, rtol=1e-10)
-    assert_allclose(result, 3.153044674980176, rtol=1e-7)  # example in docstring
+    assert_allclose(result, expected, rtol=1e-15)
+    assert_allclose(result, 3.153044674980176, rtol=1e-15)  # example in docstring
 
     # Test case: Three flows with different weights
     log_removals = [2.0, 4.0, 6.0]
@@ -109,7 +109,7 @@ def test_weighted_flows():
 
     result = parallel_mean(log_removals=log_removals, flow_fractions=weights)
     expected = -np.log10(0.5 * 10 ** (-2.0) + 0.3 * 10 ** (-4.0) + 0.2 * 10 ** (-6.0))
-    assert_allclose(result, expected, rtol=1e-10)
+    assert_allclose(result, expected, rtol=1e-15)
 
 
 def test_weight_sum_behavior():
@@ -148,7 +148,7 @@ def test_weighted_array_inputs():
 
     result = parallel_mean(log_removals=log_removals, flow_fractions=weights)
     expected = -np.log10(0.6 * 10 ** (-3.0) + 0.4 * 10 ** (-5.0))
-    assert_allclose(result, expected, rtol=1e-10)
+    assert_allclose(result, expected, rtol=1e-15)
 
 
 def test_extreme_weights():
@@ -158,8 +158,9 @@ def test_extreme_weights():
     weights = [0.999, 0.0005, 0.0005]
 
     result = parallel_mean(log_removals=log_removals, flow_fractions=weights)
-    # Result should be very close to the first log removal
-    assert_allclose(result, 3.0, rtol=1e-2)
+    # Compare to the analytical value rather than just "close to 3.0".
+    expected = -np.log10(0.999 * 10 ** (-3.0) + 0.0005 * 10 ** (-5.0) + 0.0005 * 10 ** (-6.0))
+    assert_allclose(result, expected, rtol=1e-15)
 
     # One weight is exactly 1.0, others are exactly 0.0
     log_removals = [4.0, 5.0, 6.0]
@@ -185,11 +186,12 @@ def test_gamma_find_flow_for_target_mean(apv_alpha, apv_beta, log10_decay_rate, 
         target_mean=target_mean, apv_alpha=apv_alpha, apv_beta=apv_beta, log10_decay_rate=log10_decay_rate
     )
 
-    # Verify the round-trip: flow -> residence time params -> gamma_mean == target
+    # Verify the round-trip: flow -> residence time params -> gamma_mean == target.
+    # apv_loc=0 takes the closed-form branch, so the round-trip is bit-exact.
     rt_alpha = apv_alpha
     rt_beta = apv_beta / required_flow
     verification_mean = gamma_mean(rt_alpha=rt_alpha, rt_beta=rt_beta, log10_decay_rate=log10_decay_rate)
-    assert_allclose(verification_mean, target_mean, rtol=1e-10)
+    assert_allclose(verification_mean, target_mean, rtol=1e-15)
 
 
 def test_axis_parameter_2d_arrays():
@@ -205,7 +207,7 @@ def test_axis_parameter_2d_arrays():
     expected_row1 = parallel_mean(log_removals=[2.0, 3.0, 4.0])
     expected_axis1 = np.array([expected_row0, expected_row1])
 
-    assert_allclose(result_axis1, expected_axis1, rtol=1e-10)
+    assert_allclose(result_axis1, expected_axis1, rtol=1e-15)
 
     # Test axis=0 (along rows)
     result_axis0 = parallel_mean(log_removals=log_removals_2d, axis=0)
@@ -216,7 +218,7 @@ def test_axis_parameter_2d_arrays():
     expected_col2 = parallel_mean(log_removals=[5.0, 4.0])
     expected_axis0 = np.array([expected_col0, expected_col1, expected_col2])
 
-    assert_allclose(result_axis0, expected_axis0, rtol=1e-10)
+    assert_allclose(result_axis0, expected_axis0, rtol=1e-15)
 
 
 def test_axis_parameter_3d_arrays():
@@ -234,7 +236,7 @@ def test_axis_parameter_3d_arrays():
     expected_11 = parallel_mean(log_removals=[2.0, 3.0])
     expected_axis2 = np.array([[expected_00, expected_01], [expected_10, expected_11]])
 
-    assert_allclose(result_axis2, expected_axis2, rtol=1e-10)
+    assert_allclose(result_axis2, expected_axis2, rtol=1e-15)
 
 
 def test_axis_parameter_with_flow_fractions():
@@ -250,7 +252,7 @@ def test_axis_parameter_with_flow_fractions():
     expected_row1 = parallel_mean(log_removals=[2.0, 3.0, 4.0], flow_fractions=[0.6, 0.2, 0.2])
     expected = np.array([expected_row0, expected_row1])
 
-    assert_allclose(result, expected, rtol=1e-10)
+    assert_allclose(result, expected, rtol=1e-15)
 
 
 def test_axis_parameter_behavior():
@@ -280,13 +282,13 @@ def test_negative_axis():
     result_neg1 = parallel_mean(log_removals=log_removals_2d, axis=-1)
     result_pos1 = parallel_mean(log_removals=log_removals_2d, axis=1)
 
-    assert_allclose(result_neg1, result_pos1, rtol=1e-10)
+    assert_allclose(result_neg1, result_pos1, rtol=1e-15)
 
     # axis=-2 should be equivalent to axis=0 for 2D array
     result_neg2 = parallel_mean(log_removals=log_removals_2d, axis=-2)
     result_pos0 = parallel_mean(log_removals=log_removals_2d, axis=0)
 
-    assert_allclose(result_neg2, result_pos0, rtol=1e-10)
+    assert_allclose(result_neg2, result_pos0, rtol=1e-15)
 
 
 def test_empty_array_with_axis():
@@ -486,7 +488,9 @@ def test_gamma_pdf_integrates_to_one():
         0,
         np.inf,
     )
-    assert_allclose(result, 1.0, rtol=1e-8)
+    # scipy.integrate.quad's adaptive Gauss-Kronrod quadrature only achieves
+    # finite accuracy on an infinite interval; tighter than ~1e-10 is unreliable.
+    assert_allclose(result, 1.0, rtol=1e-10)  # quad-limited, do not tighten
 
 
 def test_gamma_cdf_approaches_one():
@@ -518,7 +522,10 @@ def test_gamma_mean_matches_numerical_integration(rt_alpha, rt_beta, log10_decay
     """Test that gamma_mean matches -log10(E[10^(-R)]) via numerical integration."""
     analytical_mean = gamma_mean(rt_alpha=rt_alpha, rt_beta=rt_beta, log10_decay_rate=log10_decay_rate)
 
-    # Integrate E[10^(-R)] = integral of 10^(-r) * pdf(r) dr
+    # Integrate E[10^(-R)] = integral of 10^(-r) * pdf(r) dr.
+    # scipy.integrate.quad on a half-infinite interval reports relative error
+    # around 1e-8 for these integrands; the log10 step amplifies that, so an
+    # atol of 1e-8 is an honest reflection of quad's accuracy here.
     expected_decimal_reduction, _ = integrate.quad(
         lambda r: 10 ** (-r) * gamma_pdf(r=r, rt_alpha=rt_alpha, rt_beta=rt_beta, log10_decay_rate=log10_decay_rate),
         0,
@@ -526,7 +533,7 @@ def test_gamma_mean_matches_numerical_integration(rt_alpha, rt_beta, log10_decay
     )
     numerical_mean = -np.log10(expected_decimal_reduction)
 
-    assert_allclose(analytical_mean, numerical_mean, atol=1e-4)
+    assert_allclose(analytical_mean, numerical_mean, atol=1e-8)
 
 
 @pytest.mark.parametrize(
@@ -584,6 +591,10 @@ def test_gamma_mean_matches_discretized_parallel_mean(apv_alpha, apv_beta, flow,
     # Step 4: Compute parallel mean
     discretized = parallel_mean(log_removals=log_removals, flow_fractions=flow_fractions)
 
+    # Discretizing a gamma distribution into 10000 expected-value bins and combining
+    # via parallel_mean is an O(1/n_bins) approximation of the exact MGF integral.
+    # The empirical error across the parameter sweep is up to ~4e-4, with the worst
+    # case at high alpha (narrow distribution), so atol=1e-3 is a tight bound.
     assert_allclose(analytical, discretized, atol=1e-3)
 
 
@@ -752,7 +763,9 @@ def test_gamma_mean_loc_matches_numerical_integration(rt_alpha, rt_beta, rt_loc,
         np.inf,
     )
     numerical_mean = -np.log10(expected_decimal_reduction)
-    assert_allclose(analytical_mean, numerical_mean, atol=1e-4)
+    # scipy.integrate.quad on a half-infinite interval; same accuracy ceiling as
+    # test_gamma_mean_matches_numerical_integration above.
+    assert_allclose(analytical_mean, numerical_mean, atol=1e-8)
 
 
 @pytest.mark.parametrize(
@@ -784,6 +797,7 @@ def test_gamma_find_flow_for_target_mean_with_loc(apv_alpha, apv_beta, apv_loc, 
         rt_loc=rt_loc,
         log10_decay_rate=log10_decay_rate,
     )
+    # apv_loc>0 requires brentq, whose default tolerance limits the round-trip.
     assert_allclose(verification_mean, target_mean, rtol=1e-10)
 
 
@@ -839,6 +853,59 @@ def test_gamma_find_flow_for_target_mean_negative_loc_raises():
         )
 
 
+def test_gamma_find_flow_for_target_mean_zero_decay_raises():
+    """log10_decay_rate=0 with apv_loc>0 used to call brentq on [0, inf]; now raises.
+
+    Without decay the effective mean log removal is identically zero regardless of flow,
+    so no finite flow can reach a strictly positive target_mean; ``flow_closed_form``
+    becomes 0, ``u_upper`` becomes ``inf``, and brentq would receive an invalid bracket.
+    The guard converts that into an informative ValueError.
+    """
+    with pytest.raises(ValueError, match="log10_decay_rate must be positive"):
+        gamma_find_flow_for_target_mean(
+            target_mean=1.0,
+            apv_alpha=3.0,
+            apv_beta=10.0,
+            apv_loc=5.0,
+            log10_decay_rate=0.0,
+        )
+    # Same guard fires when apv_loc=0, since the closed-form would otherwise
+    # divide by 10**(target_mean/apv_alpha) - 1 with a zero numerator.
+    with pytest.raises(ValueError, match="log10_decay_rate must be positive"):
+        gamma_find_flow_for_target_mean(
+            target_mean=1.0,
+            apv_alpha=3.0,
+            apv_beta=10.0,
+            apv_loc=0.0,
+            log10_decay_rate=0.0,
+        )
+
+
+def test_gamma_find_flow_for_target_mean_negative_decay_raises():
+    """Negative decay rates are physically meaningless and must raise."""
+    with pytest.raises(ValueError, match="log10_decay_rate must be positive"):
+        gamma_find_flow_for_target_mean(
+            target_mean=1.0,
+            apv_alpha=3.0,
+            apv_beta=10.0,
+            apv_loc=5.0,
+            log10_decay_rate=-0.1,
+        )
+
+
+@pytest.mark.parametrize(("apv_alpha", "apv_beta"), [(0.0, 10.0), (-1.0, 10.0), (3.0, 0.0), (3.0, -5.0)])
+def test_gamma_find_flow_for_target_mean_invalid_alpha_beta_raises(apv_alpha, apv_beta):
+    """apv_alpha and apv_beta must be strictly positive."""
+    with pytest.raises(ValueError, match="must be positive"):
+        gamma_find_flow_for_target_mean(
+            target_mean=1.0,
+            apv_alpha=apv_alpha,
+            apv_beta=apv_beta,
+            apv_loc=5.0,
+            log10_decay_rate=0.1,
+        )
+
+
 def test_gamma_mean_matches_parallel_mean_discretized():
     """Test that gamma_mean matches parallel_mean computed from discretized bins."""
     alpha = 5.0
@@ -857,4 +924,6 @@ def test_gamma_mean_matches_parallel_mean_discretized():
     )
     result_discretized = parallel_mean(log_removals=log_removals)
 
-    assert_allclose(result_analytical, result_discretized, rtol=0.01)
+    # 500 equiprobable bins discretizing the gamma distribution have empirical
+    # relative error of ~1e-4 here; rtol=1e-3 is a tight bound.
+    assert_allclose(result_analytical, result_discretized, rtol=1e-3)

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -7,8 +7,8 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests.exceptions
-from numpy.testing import assert_array_almost_equal
 
+from gwtransport.examples import generate_example_data
 from gwtransport.utils import (
     _diff,
     combine_bin_series,
@@ -29,7 +29,7 @@ def test_linear_interpolate():
     expected = np.array([2, 6, 10, 14, 18])
 
     result = linear_interpolate(x_ref=x_ref, y_ref=y_ref, x_query=x_query)
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
     # Test 2: Single value interpolation
     x_ref = np.array([0, 1])
@@ -38,7 +38,7 @@ def test_linear_interpolate():
     expected = np.array([0.5])
 
     result = linear_interpolate(x_ref=x_ref, y_ref=y_ref, x_query=x_query)
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
     # Test 3: Edge cases - query points outside range
     x_ref = np.array([0, 1, 2])
@@ -47,7 +47,7 @@ def test_linear_interpolate():
     expected = np.array([0, 2])  # Should clip to nearest values
 
     result = linear_interpolate(x_ref=x_ref, y_ref=y_ref, x_query=x_query)
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
     # Test 4: Non-uniform spacing
     x_ref = np.array([0, 1, 10])
@@ -56,7 +56,7 @@ def test_linear_interpolate():
     expected = np.array([1, 11])
 
     result = linear_interpolate(x_ref=x_ref, y_ref=y_ref, x_query=x_query)
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
     # Test 5: Exact matches with reference points
     x_ref = np.array([0, 1, 2])
@@ -65,7 +65,7 @@ def test_linear_interpolate():
     expected = np.array([0, 10, 20])
 
     result = linear_interpolate(x_ref=x_ref, y_ref=y_ref, x_query=x_query)
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
 
 def test_diff():
@@ -74,28 +74,28 @@ def test_diff():
     expected = np.array([1, 1, 1, 1, 1.5, 2])
 
     result = _diff(a=x, alignment="centered")
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
 
 def test_diff_centered_two_points():
     x = np.array([10, 20])
     expected = np.array([10, 10])
     result = _diff(a=x, alignment="centered")
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
 
 def test_diff_left():
     x = np.array([0, 1, 2, 3, 4, 6])
     expected = np.array([1, 1, 1, 1, 2, 2])
     result = _diff(a=x, alignment="left")
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
 
 def test_diff_right():
     x = np.array([0, 1, 2, 3, 4, 6])
     expected = np.array([1, 1, 1, 1, 1, 2])
     result = _diff(a=x, alignment="right")
-    assert_array_almost_equal(result, expected, decimal=6)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-06)
 
 
 def test_constant_function():
@@ -284,7 +284,37 @@ def test_2d_x_edges():
 
     result = linear_average(x_data=x_data, y_data=y_data, x_edges=x_edges_2d)
 
-    np.testing.assert_allclose(result, expected, rtol=1e-2)
+    np.testing.assert_allclose(result, expected, rtol=1e-12)
+
+
+def test_linear_average_straddling_bin_is_nan():
+    """Bins partially outside the data range must be NaN, not biased low.
+
+    With the previous implementation, a straddling bin's integral covered only
+    the in-range portion while being divided by the full bin width, biasing the
+    result low. The fix sets such bins to NaN, the same as bins fully outside
+    the range.
+    """
+    # Linear ramp y = x on [0, 4]; mean over [-1, 4] would equal 4/2 = 2 but
+    # only the in-range portion (over [0, 4]) is integrable; the result must
+    # therefore be NaN, not the buggy 8/5 = 1.6.
+    x_data = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    y_data = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    x_edges = np.array([-1.0, 4.0])
+    result = linear_average(x_data=x_data, y_data=y_data, x_edges=x_edges, extrapolate_method="nan")
+    assert np.isnan(result).all()
+
+    # Same on the right side.
+    x_edges = np.array([0.0, 5.0])
+    result = linear_average(x_data=x_data, y_data=y_data, x_edges=x_edges, extrapolate_method="nan")
+    assert np.isnan(result).all()
+
+    # Mixed: one fully-inside bin, one straddling-left bin, one straddling-right bin.
+    x_edges = np.array([-1.0, 1.0, 3.0, 5.0])
+    result = linear_average(x_data=x_data, y_data=y_data, x_edges=x_edges, extrapolate_method="nan")
+    assert np.isnan(result[0, 0])
+    np.testing.assert_allclose(result[0, 1], 2.0, rtol=1e-12)  # mean of y=x over [1, 3] = 2
+    assert np.isnan(result[0, 2])
 
 
 def test_basic_case():
@@ -294,7 +324,7 @@ def test_basic_case():
     expected = np.array([[0.5, 0.0], [0.5, 0.5], [0.0, 0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_no_overlap():
@@ -304,7 +334,7 @@ def test_no_overlap():
     expected = np.array([[0.0, 0.0], [0.0, 0.0]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_complete_overlap():
@@ -314,7 +344,7 @@ def test_complete_overlap():
     expected = np.array([[1.0, 0.0], [0.0, 1.0]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_exact_bin_match():
@@ -324,7 +354,7 @@ def test_exact_bin_match():
     expected = np.array([[1.0, 0.0], [0.0, 1.0]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_multiple_bins():
@@ -334,7 +364,7 @@ def test_multiple_bins():
     expected = np.array([[0.5, 0.0, 0.0], [0.2, 0.6, 0.2], [0.0, 0.0, 0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_partial_overlaps():
@@ -344,7 +374,7 @@ def test_partial_overlaps():
     expected = np.array([[0.25, 0.25]])  # 25% overlap with each output bin
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_list_inputs():
@@ -354,7 +384,7 @@ def test_list_inputs():
     expected = np.array([[0.5, 0.0], [0.5, 0.5], [0.0, 0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_empty_inputs():
@@ -364,7 +394,7 @@ def test_empty_inputs():
     expected = np.array([[0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_single_bin():
@@ -374,7 +404,7 @@ def test_single_bin():
     expected = np.array([[0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_edge_alignment():
@@ -384,7 +414,7 @@ def test_edge_alignment():
     expected = np.array([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_floating_point_precision():
@@ -394,7 +424,7 @@ def test_floating_point_precision():
     expected = np.array([[0.5], [0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_negative_values():
@@ -404,7 +434,7 @@ def test_negative_values():
     expected = np.array([[0.5, 0.0], [0.5, 0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_invalid_inputs():
@@ -434,15 +464,15 @@ def test_combine_bin_series_basic():
 
     # Expected combined edges: [0, 1, 1.5, 2]
     expected_edges = np.array([0.0, 1.0, 1.5, 2.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # Expected values for c: [1, 2, 2] (a[0] broadcasts to first bin, a[1] broadcasts to bins 2&3)
     # Expected values for d: [0, 3, 4] (b[0] broadcasts to second bin, b[1] broadcasts to third bin)
     expected_c = np.array([1.0, 2.0, 2.0])
     expected_d = np.array([0.0, 3.0, 4.0])
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_identical_edges():
@@ -456,12 +486,12 @@ def test_combine_bin_series_identical_edges():
 
     # Edges should remain the same
     expected_edges = np.array([0.0, 1.0, 2.0, 3.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # Values should be preserved
-    assert_array_almost_equal(c, a)
-    assert_array_almost_equal(d, b)
+    np.testing.assert_allclose(c, a, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, b, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_overlapping_bins():
@@ -475,8 +505,8 @@ def test_combine_bin_series_overlapping_bins():
 
     # Expected combined edges: [0, 2, 5, 7, 10, 12]
     expected_edges = np.array([0.0, 2.0, 5.0, 7.0, 10.0, 12.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # Test that the values are broadcasted/repeated correctly
     # a[0]=10 covers [0,5]: broadcasts to bins [0,2] and [2,5]
@@ -485,8 +515,8 @@ def test_combine_bin_series_overlapping_bins():
     # b[1]=40 covers [7,12]: broadcasts to bins [7,10] and [10,12]
     expected_c = np.array([10.0, 10.0, 20.0, 20.0, 0.0])
     expected_d = np.array([0.0, 30.0, 30.0, 40.0, 40.0])
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_single_bins():
@@ -500,15 +530,15 @@ def test_combine_bin_series_single_bins():
 
     # Expected combined edges: [0, 1, 2, 3]
     expected_edges = np.array([0.0, 1.0, 2.0, 3.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # a=5 covers [0,2]: broadcasts to [0,1] and [1,2]
     # b=10 covers [1,3]: broadcasts to [1,2] and [2,3]
     expected_c = np.array([5.0, 5.0, 0.0])
     expected_d = np.array([0.0, 10.0, 10.0])
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_nested_bins():
@@ -522,15 +552,15 @@ def test_combine_bin_series_nested_bins():
 
     # Expected combined edges: [0, 2, 5, 8, 10]
     expected_edges = np.array([0.0, 2.0, 5.0, 8.0, 10.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # a=100 covers [0,10]: broadcasts to all combined bins within its range
     # b[0]=20 covers [2,5] and b[1]=30 covers [5,8]
     expected_c = np.array([100.0, 100.0, 100.0, 100.0])
     expected_d = np.array([0.0, 20.0, 30.0, 0.0])
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_non_overlapping():
@@ -544,14 +574,14 @@ def test_combine_bin_series_non_overlapping():
 
     # Expected combined edges: [0, 1, 2, 3, 4, 5]
     expected_edges = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # a maps to first two bins, b maps to last two bins
     expected_c = np.array([1.0, 2.0, 0.0, 0.0, 0.0])
     expected_d = np.array([0.0, 0.0, 0.0, 3.0, 4.0])
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_zero_values():
@@ -565,14 +595,14 @@ def test_combine_bin_series_zero_values():
 
     # Expected combined edges: [0, 0.5, 1, 1.5, 2, 2.5]
     expected_edges = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 2.5])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # Check that zero values are preserved and broadcasted correctly
     expected_c = np.array([0.0, 0.0, 5.0, 5.0, 0.0])
     expected_d = np.array([0.0, 3.0, 3.0, 0.0, 0.0])
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_floating_point():
@@ -586,14 +616,14 @@ def test_combine_bin_series_floating_point():
 
     # Expected combined edges: [0.1, 0.6, 1.1, 1.6, 2.1, 2.6]
     expected_edges = np.array([0.1, 0.6, 1.1, 1.6, 2.1, 2.6])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # Test with appropriate precision and broadcasting
     expected_c = np.array([1.1, 1.1, 2.2, 2.2, 0.0])
     expected_d = np.array([0.0, 3.3, 3.3, 4.4, 4.4])
-    assert_array_almost_equal(c, expected_c, decimal=10)
-    assert_array_almost_equal(d, expected_d, decimal=10)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-10)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-10)
 
 
 def test_combine_bin_series_input_validation():
@@ -634,8 +664,8 @@ def test_combine_bin_series_list_inputs():
 
     # Expected combined edges: [0, 1, 1.5, 2, 2.5, 3.5]
     expected_edges = np.array([0.0, 1.0, 1.5, 2.0, 2.5, 3.5])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_negative_values():
@@ -649,14 +679,14 @@ def test_combine_bin_series_negative_values():
 
     # Expected combined edges: [-10, -3, -1, 0, 2, 5]
     expected_edges = np.array([-10.0, -3.0, -1.0, 0.0, 2.0, 5.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # Test correct mapping with negative values and broadcasting
     expected_c = np.array([-5.0, -2.0, -2.0, 0.0, 0.0])
     expected_d = np.array([0.0, 0.0, 1.0, 1.0, 4.0])
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_empty_arrays():
@@ -670,13 +700,13 @@ def test_combine_bin_series_empty_arrays():
 
     # Expected combined edges: [0, 0.5, 1, 1.5]
     expected_edges = np.array([0.0, 0.5, 1.0, 1.5])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     expected_c = np.array([42.0, 42.0, 0.0])
     expected_d = np.array([0.0, 24.0, 24.0])
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_extrapolation_nearest():
@@ -690,16 +720,16 @@ def test_combine_bin_series_extrapolation_nearest():
 
     # Expected combined edges: [1, 2, 3, 4]
     expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # With nearest extrapolation:
     # c extends to all bins using nearest values
     # d extends to all bins using nearest values
     expected_c = np.array([1.0, 2.0, 2.0])  # nearest for [3,4] is a[1]=2.0
     expected_d = np.array([10.0, 10.0, 20.0])  # nearest for [1,2] is b[0]=10.0
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_extrapolation_nan():
@@ -713,15 +743,15 @@ def test_combine_bin_series_extrapolation_nan():
 
     # Expected combined edges: [1, 2, 3, 4]
     expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # With nan extrapolation:
     # Out-of-range bins get nan values
     expected_c = np.array([1.0, 2.0, np.nan])  # [3,4] is out of range for a
     expected_d = np.array([np.nan, 10.0, 20.0])  # [1,2] is out of range for b
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_extrapolation_custom_value():
@@ -735,15 +765,15 @@ def test_combine_bin_series_extrapolation_custom_value():
 
     # Expected combined edges: [1, 2, 3, 4]
     expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    assert_array_almost_equal(c_edges, expected_edges)
-    assert_array_almost_equal(d_edges, expected_edges)
+    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
 
     # With custom extrapolation value:
     # Out-of-range bins get the custom value
     expected_c = np.array([1.0, 2.0, -999.0])  # [3,4] is out of range for a
     expected_d = np.array([-999.0, 10.0, 20.0])  # [1,2] is out of range for b
-    assert_array_almost_equal(c, expected_c)
-    assert_array_almost_equal(d, expected_d)
+    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_extrapolation_default_behavior():
@@ -757,10 +787,10 @@ def test_combine_bin_series_extrapolation_default_behavior():
     c1, c_edges1, d1, d_edges1 = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
     c2, c_edges2, d2, d_edges2 = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=0.0)
 
-    assert_array_almost_equal(c1, c2)
-    assert_array_almost_equal(d1, d2)
-    assert_array_almost_equal(c_edges1, c_edges2)
-    assert_array_almost_equal(d_edges1, d_edges2)
+    np.testing.assert_allclose(c1, c2, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d1, d2, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(c_edges1, c_edges2, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d_edges1, d_edges2, rtol=0, atol=1e-6)
 
 
 def test_combine_bin_series_extrapolation_no_out_of_range():
@@ -775,10 +805,10 @@ def test_combine_bin_series_extrapolation_no_out_of_range():
     c2, _, d2, _ = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=np.nan)
     c3, _, d3, _ = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=0.0)
 
-    assert_array_almost_equal(c1, c2)
-    assert_array_almost_equal(c1, c3)
-    assert_array_almost_equal(d1, d2)
-    assert_array_almost_equal(d1, d3)
+    np.testing.assert_allclose(c1, c2, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(c1, c3, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d1, d2, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(d1, d3, rtol=0, atol=1e-6)
 
 
 def test_get_soil_temperature_basic():
@@ -861,7 +891,7 @@ def test_time_bin_overlap_basic():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_no_overlap():
@@ -871,7 +901,7 @@ def test_time_bin_overlap_no_overlap():
     expected = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_complete_overlap():
@@ -881,7 +911,7 @@ def test_time_bin_overlap_complete_overlap():
     expected = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_partial_overlap():
@@ -891,7 +921,7 @@ def test_time_bin_overlap_partial_overlap():
     expected = np.array([[0.5, 1.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_single_bin():
@@ -901,7 +931,7 @@ def test_time_bin_overlap_single_bin():
     expected = np.array([[0.5], [0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_edge_alignment():
@@ -911,7 +941,7 @@ def test_time_bin_overlap_edge_alignment():
     expected = np.array([[1.0, 1.0, 0.0], [0.0, 1.0, 1.0]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_floating_point():
@@ -921,7 +951,7 @@ def test_time_bin_overlap_floating_point():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_negative_values():
@@ -931,7 +961,7 @@ def test_time_bin_overlap_negative_values():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_overlapping_ranges():
@@ -941,7 +971,7 @@ def test_time_bin_overlap_overlapping_ranges():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 1.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_zero_width_bins():
@@ -951,7 +981,7 @@ def test_time_bin_overlap_zero_width_bins():
     expected = np.array([[0.5, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_large_range():
@@ -961,7 +991,7 @@ def test_time_bin_overlap_large_range():
     expected = np.array([[1.0, 1.0, 1.0]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_list_inputs():
@@ -971,7 +1001,7 @@ def test_time_bin_overlap_list_inputs():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 def test_time_bin_overlap_input_validation():
@@ -996,7 +1026,7 @@ def test_time_bin_overlap_precision():
     expected = np.array([[0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    assert_array_almost_equal(result, expected, decimal=10)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-10)
 
 
 def test_time_bin_overlap_many_ranges():
@@ -1013,7 +1043,7 @@ def test_time_bin_overlap_many_ranges():
     for i in range(len(bin_tedges)):
         # Each range spans 10 units, so total overlap should be 10
         total_overlap = np.sum(result[i, :])
-        assert_array_almost_equal([total_overlap], [10.0], decimal=6)
+        np.testing.assert_allclose([total_overlap], [10.0], rtol=0, atol=1e-06)
 
 
 def test_time_bin_overlap_boundary_cases():
@@ -1024,13 +1054,13 @@ def test_time_bin_overlap_boundary_cases():
     bin_tedges = [(10, 10)]
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
     expected = np.array([[0.0, 0.0, 0.0, 0.0]])
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
     # Range that exactly matches a bin
     bin_tedges = [(5, 10)]
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
     expected = np.array([[0.0, 1.0, 0.0, 0.0]])
-    assert_array_almost_equal(result, expected)
+    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
 
 
 # =============================================================================
@@ -1137,3 +1167,50 @@ def test_solve_tikhonov_resolution_not_returned_by_default():
 
     assert isinstance(result, np.ndarray)
     assert result.shape == (3,)
+
+
+# =============================================================================
+# Tests for examples.generate_example_data rng reproducibility (U3)
+# =============================================================================
+
+
+def test_generate_example_data_seed_reproducibility():
+    """Two calls with the same integer seed must produce identical data.
+
+    Covers the rng plumbing through generate_example_data: flow noise,
+    spill placement, and measurement noise all must be sourced from the
+    user-supplied generator.
+    """
+    df_a, tedges_a = generate_example_data(
+        date_start="2020-01-01",
+        date_end="2020-06-30",
+        cin_method="constant",
+        rng=12345,
+    )
+    df_b, tedges_b = generate_example_data(
+        date_start="2020-01-01",
+        date_end="2020-06-30",
+        cin_method="constant",
+        rng=12345,
+    )
+    np.testing.assert_array_equal(df_a["flow"].to_numpy(), df_b["flow"].to_numpy())
+    np.testing.assert_array_equal(df_a["cin"].to_numpy(), df_b["cin"].to_numpy())
+    np.testing.assert_array_equal(df_a["cout"].to_numpy(), df_b["cout"].to_numpy())
+    np.testing.assert_array_equal(np.asarray(tedges_a), np.asarray(tedges_b))
+
+
+def test_generate_example_data_seed_changes_output():
+    """Different seeds must produce different stochastic series."""
+    df_a, _ = generate_example_data(
+        date_start="2020-01-01",
+        date_end="2020-06-30",
+        cin_method="constant",
+        rng=1,
+    )
+    df_b, _ = generate_example_data(
+        date_start="2020-01-01",
+        date_end="2020-06-30",
+        cin_method="constant",
+        rng=2,
+    )
+    assert not np.array_equal(df_a["flow"].to_numpy(), df_b["flow"].to_numpy())


### PR DESCRIPTION
## Summary

PR 5 of 6 in the physics review series. Touches `src/gwtransport/{utils,logremoval,examples}.py` and the corresponding test files.

- **U1 (BLOCKER)** — Validate inputs and guard the brentq bracket in `gamma_find_flow_for_target_mean`: reject non-positive `log10_decay_rate`, `apv_alpha`, `apv_beta`; defensive check that `u_upper` is finite/positive before bracketing.
- **U2 (HIGH)** — Fix `linear_average` straddling-bin handling under `extrapolate_method="nan"`. Replace `nan_to_num` + post-overwrite with a direct `np.where(np.isnan(y_avg), 0.0, dx * y_avg)`; documents that straddling bins are correctly NaN'd by the existing `bins_within_range` mask.
- **U3** — Add `rng: np.random.Generator | int | None = None` to `examples.generate_example_data`. All stochastic draws (flow noise, spill placement, measurement noise) now flow through `np.random.default_rng(rng)` for reproducible synthetic data.
- **U4** — Document `compute_time_edges` extrapolation issue for non-uniform spacing in the Notes section, recommending users provide their own `tedges` when sampling is irregular.
- **U5** — Drop `typing` imports. Replace `cast()` in `utils.py` with `isinstance` narrowing on the cache load; drop `Any` annotation on `**kwargs` in `examples.py`.
- **U6** — Replace `assert_array_almost_equal` with `np.testing.assert_allclose(..., rtol=0, atol=1e-N)` throughout `test_utils.py` for explicit decimal-precise tolerances. Adds regression test `test_linear_average_straddling_bin_is_nan` and rng reproducibility tests for `generate_example_data`.
- **U7** — Tighten `test_logremoval.py` tolerances. Direct-arithmetic and hardcoded-literal comparisons now use `rtol=1e-15`. `scipy.integrate.quad` comparisons use `atol=1e-8` (its realistic limit on infinite intervals). Remaining loose tolerances are documented inline (brentq round-trip, 10000-bin discretization). Replace heuristic 3.0 check in `test_extreme_weights` with an analytical expectation. Add tests for the new U1 input validation.
- **U8** — Replace `isclose`-in-loop checks in `test_fraction_explained.py` with direct `np.testing.assert_allclose` against analytically-computed expected arrays for staircase test cases (`test_multiple_pore_volumes_gradual_increase`, `test_mixed_valid_invalid_residence_times`, `test_numerical_precision`, `test_monotonic_behavior_across_pore_volumes`).

## Test plan

- [x] `ruff format .` — clean
- [x] `ruff check --fix .` — clean
- [x] `ty check .` — clean
- [x] `pytest tests/src -n auto` — 946 passed, 8 skipped

## Contributor License Agreement

- [x] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.