### PR TITLE
Fix gamma + residence_time (physics review)

### DIFF
--- a/src/gwtransport/gamma.py
+++ b/src/gwtransport/gamma.py
@@ -424,7 +424,7 @@ def bin_masses(*, alpha: float, beta: float, bin_edges: npt.ArrayLike) -> npt.ND
         msg = "Bin edges must be increasing"
         raise ValueError(msg)
     if np.any(bin_edges < 0):
-        msg = "Bin edges must be positive"
+        msg = "Bin edges must be non-negative"
         raise ValueError(msg)
     val = gammainc(alpha, bin_edges / beta)
     return val[1:] - val[:-1]

--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -257,27 +257,19 @@ def residence_time_mean(
         a = flow_cum[None, :] - retardation_factor * aquifer_pore_volumes[:, None]
         days = linear_interpolate(x_ref=flow_cum, y_ref=flow_tedges_days, x_query=a, left=np.nan, right=np.nan)
         data_edges = flow_tedges_days - days
-        # Process each pore volume (row) separately. Although linear_average supports 2D x_edges,
-        # our use case is different: multiple time series (different y_data) with same edges,
-        # rather than same time series with multiple edge sets.
-        data_avg = np.array([
-            linear_average(x_data=flow_tedges_days, y_data=y, x_edges=tedges_out_days)[0] for y in data_edges
-        ])
     elif direction == "infiltration_to_extraction":
         # In how many days the water that is infiltrated now be extracted
         a = flow_cum[None, :] + retardation_factor * aquifer_pore_volumes[:, None]
         days = linear_interpolate(x_ref=flow_cum, y_ref=flow_tedges_days, x_query=a, left=np.nan, right=np.nan)
         data_edges = days - flow_tedges_days
-        # Process each pore volume (row) separately. Although linear_average supports 2D x_edges,
-        # our use case is different: multiple time series (different y_data) with same edges,
-        # rather than same time series with multiple edge sets.
-        data_avg = np.array([
-            linear_average(x_data=flow_tedges_days, y_data=y, x_edges=tedges_out_days)[0] for y in data_edges
-        ])
     else:
         msg = "direction should be 'extraction_to_infiltration' or 'infiltration_to_extraction'"
         raise ValueError(msg)
-    return data_avg
+
+    # Vectorized linear average across all pore volumes in one call. ``data_edges`` is 2D
+    # with shape (n_pore_volumes, n_flow_edges); each row shares the same x_data and the
+    # same x_edges. linear_average's 2D-y_data path handles per-row NaN segments cleanly.
+    return linear_average(x_data=flow_tedges_days, y_data=data_edges, x_edges=tedges_out_days)
 
 
 def fraction_explained(
@@ -397,8 +389,9 @@ def freundlich_retardation(
     Raises
     ------
     ValueError
-        If ``porosity`` is not in ``(0, 1)``, if ``bulk_density`` is not positive, or if
-        ``freundlich_k`` is negative.
+        If ``porosity`` is not in ``(0, 1)``, if ``bulk_density`` is not positive, if
+        ``freundlich_k`` is negative, or if any ``concentration`` is non-positive while
+        ``freundlich_n < 1`` (the retardation factor diverges as ``C -> 0``).
 
     See Also
     --------
@@ -431,7 +424,12 @@ def freundlich_retardation(
         msg = f"Freundlich K must be non-negative, got {freundlich_k}"
         raise ValueError(msg)
 
-    concentration_safe = np.maximum(concentration, 1e-12)  # Avoid zero concentration issues
-    return 1.0 + (bulk_density / porosity) * freundlich_k * freundlich_n * np.power(
-        concentration_safe, freundlich_n - 1
-    )
+    # For n < 1 the Freundlich retardation factor 1 + (rho_b/theta) * k_f * n * C^(n-1)
+    # diverges as C -> 0. Silently clamping concentration would produce a very large but
+    # finite value that depends on an arbitrary regularization constant; instead, refuse
+    # the call so the user can decide how to handle non-positive concentrations.
+    if freundlich_n < 1.0 and np.any(concentration <= 0):
+        msg = "concentration must be strictly positive when freundlich_n < 1 (retardation diverges as C -> 0)"
+        raise ValueError(msg)
+
+    return 1.0 + (bulk_density / porosity) * freundlich_k * freundlich_n * np.power(concentration, freundlich_n - 1)

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -285,17 +285,24 @@ def linear_average(
     Parameters
     ----------
     x_data : array-like
-        x-coordinates of the time series data points, must be in ascending order
+        x-coordinates of the time series data points, must be in ascending order.
     y_data : array-like
-        y-coordinates of the time series data points
+        y-coordinates of the time series data points. Can be 1D or 2D.
+
+        - If 1D: shape ``(n_data,)`` -- a single series.
+        - If 2D: shape ``(n_series_y, n_data)`` -- multiple series sharing the same
+          ``x_data``. The leading axis is averaged independently per row. Cannot be
+          combined with 2D ``x_edges`` (each row of ``x_edges`` and each row of
+          ``y_data`` would otherwise have to broadcast against each other, which is
+          not supported).
     x_edges : array-like
-        x-coordinates of the integration edges. Can be 1D or 2D.
-        - If 1D: shape (n_edges,). Can be 1D or 2D.
-        - If 1D: shape (n_edges,), must be in ascending order
-        - If 2D: shape (n_series, n_edges), each row must be in ascending order
-        - If 2D: shape (n_series, n_edges), each row must be in ascending order
+        x-coordinates of the integration edges.
+
+        - If 1D: shape ``(n_edges,)``, must be in ascending order.
+        - If 2D: shape ``(n_series_x, n_edges)``, each row must be in ascending order.
     extrapolate_method : str, optional
         Method for handling extrapolation. Default is 'nan'.
+
         - 'outer': Extrapolate using the outermost data points.
         - 'nan': Extrapolate using np.nan.
         - 'raise': Raise an error for out-of-bounds values.
@@ -304,17 +311,19 @@ def linear_average(
     -------
     numpy.ndarray
         2D array of average values between consecutive pairs of x_edges.
-        Shape is (n_series, n_bins) where n_bins = n_edges - 1.
-        If x_edges is 1D, n_series = 1.
+        Shape is ``(n_series, n_bins)`` where ``n_bins = n_edges - 1`` and
+        ``n_series = max(n_series_x, n_series_y)``. Both ``x_edges`` and ``y_data``
+        being 1D yields ``n_series = 1``.
 
     Raises
     ------
     ValueError
-        If ``x_edges`` is not 1D or 2D. If ``x_data`` and ``y_data`` have different
-        lengths or are empty. If ``x_edges`` has fewer than 2 values per row. If
-        ``x_data`` is not in ascending order. If ``x_edges`` rows are not in ascending
-        order. If ``extrapolate_method`` is ``'raise'`` and any edge falls outside the
-        data range.
+        If ``x_edges`` is not 1D or 2D. If ``y_data`` is not 1D or 2D. If both
+        ``x_edges`` and ``y_data`` are 2D. If ``x_data`` and ``y_data`` have
+        incompatible shapes or are empty. If ``x_edges`` has fewer than 2 values per
+        row. If ``x_data`` is not in ascending order. If ``x_edges`` rows are not in
+        ascending order. If ``extrapolate_method`` is ``'raise'`` and any edge falls
+        outside the data range.
 
     Examples
     --------
@@ -332,6 +341,13 @@ def linear_average(
     >>> linear_average(x_data=x_data, y_data=y_data, x_edges=x_edges_2d)
     array([[0.66666667, 0.66666667],
            [0.91666667, 0.5       ]])
+
+    Multiple y-series with shared x_data and x_edges:
+
+    >>> y_data_2d = [[0, 1, 1, 0], [0, 2, 2, 0]]
+    >>> linear_average(x_data=x_data, y_data=y_data_2d, x_edges=x_edges)
+    array([[0.66666667, 0.66666667],
+           [1.33333333, 1.33333333]])
     """
     # Convert inputs to numpy arrays
     x_data = np.asarray(x_data, dtype=float)
@@ -345,8 +361,25 @@ def linear_average(
         msg = "x_edges must be 1D or 2D array"
         raise ValueError(msg)
 
+    # Ensure y_data is always 2D internally with shape (n_series_y, n_data)
+    if y_data.ndim == 1:
+        y_data = y_data[np.newaxis, :]
+    elif y_data.ndim != 2:  # noqa: PLR2004
+        msg = "y_data must be 1D or 2D array"
+        raise ValueError(msg)
+
+    # 2D y_data requires 1D x_edges (no per-row x_edges allowed). The combination would
+    # require an outer product over (n_series_x, n_series_y), which is intentionally
+    # not supported -- callers can loop or stack instead.
+    n_series_x = x_edges.shape[0]
+    n_series_y = y_data.shape[0]
+    if n_series_x > 1 and n_series_y > 1:
+        msg = "Cannot combine 2D x_edges with 2D y_data"
+        raise ValueError(msg)
+    n_series = max(n_series_x, n_series_y)
+
     # Input validation
-    if len(x_data) != len(y_data) or len(x_data) == 0:
+    if y_data.shape[1] != x_data.shape[0] or x_data.shape[0] == 0:
         msg = "x_data and y_data must have the same length and be non-empty"
         raise ValueError(msg)
     if x_edges.shape[1] < 2:  # noqa: PLR2004
@@ -359,17 +392,24 @@ def linear_average(
         msg = "x_edges must be in ascending order along each row"
         raise ValueError(msg)
 
-    # Filter out NaN values
-    show = ~np.isnan(x_data) & ~np.isnan(y_data)
+    # Filter out NaN values. With 2D y_data, a column is dropped only when all rows
+    # have NaN there; per-row NaNs are handled via segment masking below so that one
+    # series' NaNs do not contaminate the others.
+    x_nan = np.isnan(x_data)
+    y_any_finite = np.any(~np.isnan(y_data), axis=0)
+    show = ~x_nan & y_any_finite
     if show.sum() < 2:  # noqa: PLR2004
         if show.sum() == 1 and extrapolate_method == "outer":
-            # For single data point with outer extrapolation, use constant value
-            constant_value = y_data[show][0]
-            return np.full(shape=(x_edges.shape[0], x_edges.shape[1] - 1), fill_value=constant_value)
-        return np.full(shape=(x_edges.shape[0], x_edges.shape[1] - 1), fill_value=np.nan)
+            # For a single retained data point with outer extrapolation, use the
+            # row-wise value broadcast across all output bins.
+            constant_value = y_data[:, show][:, 0]  # shape (n_series_y,)
+            return np.broadcast_to(constant_value[:, None], (n_series, x_edges.shape[1] - 1)).astype(
+                np.float64, copy=True
+            )
+        return np.full(shape=(n_series, x_edges.shape[1] - 1), fill_value=np.nan)
 
     x_data_clean = x_data[show]
-    y_data_clean = y_data[show]
+    y_data_clean = y_data[:, show]  # shape (n_series_y, n_clean)
 
     # Handle extrapolation for all series at once (vectorized)
     if extrapolate_method == "outer":
@@ -385,19 +425,44 @@ def linear_average(
     # Create a combined grid of all unique x points (data + all edges)
     all_unique_x = np.unique(np.concatenate([x_data_clean, edges_processed.ravel()]))
 
-    # Interpolate y values at all unique x points once
-    all_unique_y_result = np.interp(all_unique_x, x_data_clean, y_data_clean, left=np.nan, right=np.nan)
-    # Ensure it's an array for type checker
-    all_unique_y: npt.NDArray[np.float64] = np.asarray(all_unique_y_result, dtype=np.float64)
+    # Interpolate y values at all unique x points once. For 2D y_data we vectorize
+    # the linear interpolation manually since np.interp does not accept 2D y.
+    if n_series_y == 1:
+        all_unique_y_result = np.interp(all_unique_x, x_data_clean, y_data_clean[0], left=np.nan, right=np.nan)
+        all_unique_y: npt.NDArray[np.float64] = np.asarray(all_unique_y_result, dtype=np.float64)[np.newaxis, :]
+    else:
+        # Locate each query x in x_data_clean. For x within the data range, idx is in
+        # [1, len(x_data_clean) - 1] so left_idx = idx - 1 is the bracketing left index.
+        idx = np.searchsorted(x_data_clean, all_unique_x).clip(1, len(x_data_clean) - 1)
+        left_idx = idx - 1
+        right_idx = idx
+        x_left = x_data_clean[left_idx]
+        x_right = x_data_clean[right_idx]
+        denom = x_right - x_left
+        # Detect query points coincident with an x_data point. Handling them via a
+        # direct lookup avoids the IEEE 754 trap where NaN * 0 = NaN, which would
+        # otherwise contaminate exact-endpoint queries adjacent to a NaN sample.
+        on_left_node = denom == 0  # only happens if x_left == x_right (duplicate)
+        weights = np.where(on_left_node, 0.0, (all_unique_x - x_left) / np.where(on_left_node, 1.0, denom))
+        all_unique_y = y_data_clean[:, left_idx] * (1.0 - weights) + y_data_clean[:, right_idx] * weights
+        # Override at exact x_data positions to avoid NaN * 0 contamination.
+        is_left_match = all_unique_x == x_left
+        is_right_match = all_unique_x == x_right
+        all_unique_y[:, is_left_match] = y_data_clean[:, left_idx[is_left_match]]
+        all_unique_y[:, is_right_match] = y_data_clean[:, right_idx[is_right_match]]
+        # Mark out-of-range query points as NaN (matches np.interp(left=nan, right=nan)).
+        out_of_range = (all_unique_x < x_data_clean[0]) | (all_unique_x > x_data_clean[-1])
+        all_unique_y[:, out_of_range] = np.nan
 
     # Compute cumulative integrals once using trapezoidal rule.
-    # Segments outside the data range carry NaN (from np.interp with left/right=NaN);
+    # Segments outside the data range carry NaN (from the interp step with left/right=NaN);
     # those NaNs will be masked out later via the bin-range check, so we suppress
     # them here only to keep the cumulative sum finite for in-range bins.
     dx = np.diff(all_unique_x)
-    y_avg = (all_unique_y[:-1] + all_unique_y[1:]) / 2
-    segment_integrals = np.where(np.isnan(y_avg), 0.0, dx * y_avg)
-    cumulative_integral = np.concatenate([[0.0], np.cumsum(segment_integrals)])
+    y_avg = (all_unique_y[:, :-1] + all_unique_y[:, 1:]) / 2
+    segment_integrals = np.where(np.isnan(y_avg), 0.0, dx[np.newaxis, :] * y_avg)
+    # Cumulative integral with leading 0 along the x axis.
+    cumulative_integral = np.concatenate([np.zeros((y_avg.shape[0], 1)), np.cumsum(segment_integrals, axis=1)], axis=1)
 
     # Vectorized computation for all series
     # Find indices of all edges in the combined grid
@@ -405,24 +470,50 @@ def linear_average(
     # Ensure it's a 2D array for type checker
     edge_indices: npt.NDArray[np.intp] = np.asarray(edge_indices_result, dtype=np.intp).reshape(edges_processed.shape)
 
-    # Compute integral between consecutive edges for all series (vectorized)
-    integral_values = cumulative_integral[edge_indices[:, 1:]] - cumulative_integral[edge_indices[:, :-1]]
+    # Compute integral between consecutive edges. Broadcast over n_series via the leading axis
+    # of cumulative_integral. edge_indices is (n_series_x, n_bins+1); cumulative_integral is
+    # (n_series_y, n_unique_x). We rely on n_series_x == 1 or n_series_y == 1 (enforced above).
+    integral_values = cumulative_integral[:, edge_indices[:, 1:]] - cumulative_integral[:, edge_indices[:, :-1]]
+    # integral_values has shape (n_series_y, n_series_x, n_bins). Squeeze the singleton.
+    integral_values_2d = integral_values[0] if n_series_y == 1 else integral_values[:, 0, :]
 
     # Compute widths between consecutive edges for all series (vectorized)
-    edge_widths = np.diff(edges_processed, axis=1)
+    edge_widths = np.diff(edges_processed, axis=1)  # shape (n_series_x, n_bins)
+    # Broadcast widths to match (n_series, n_bins)
+    edge_widths_b = np.broadcast_to(edge_widths, (n_series, edge_widths.shape[1])) if n_series_y > 1 else edge_widths
 
     # Handle zero-width intervals (vectorized)
-    zero_width_mask = edge_widths == 0
-    result = np.zeros_like(edge_widths)
+    zero_width_mask = edge_widths_b == 0
+    result = np.zeros_like(edge_widths_b, dtype=np.float64)
 
     # For non-zero width intervals, compute average = integral / width (vectorized)
     non_zero_mask = ~zero_width_mask
-    result[non_zero_mask] = integral_values[non_zero_mask] / edge_widths[non_zero_mask]
+    result[non_zero_mask] = integral_values_2d[non_zero_mask] / edge_widths_b[non_zero_mask]
 
     # For zero-width intervals, interpolate y-value directly (vectorized)
     if np.any(zero_width_mask):
-        zero_width_positions = edges_processed[:, :-1][zero_width_mask]
-        result[zero_width_mask] = np.interp(zero_width_positions, x_data_clean, y_data_clean)
+        # Positions where zero width occurs; use the left edge's x position.
+        if n_series_y == 1:
+            zero_positions = edges_processed[:, :-1][zero_width_mask]  # 1D
+            result[zero_width_mask] = np.interp(zero_positions, x_data_clean, y_data_clean[0])
+        else:
+            # zero_width_mask has shape (n_series_y, n_bins); positions vary per row.
+            # edges_processed is (1, n_bins+1) here since n_series_x == 1.
+            edges_left = np.broadcast_to(edges_processed[:, :-1], (n_series, edge_widths.shape[1]))
+            zero_positions = edges_left[zero_width_mask]
+            # Interpolate per series using the same x_data_clean. Find bracketing indices
+            # for each zero-width position, then index into the appropriate y row.
+            # Get the row index for each zero-width entry.
+            row_idx_grid = np.broadcast_to(np.arange(n_series)[:, None], (n_series, edge_widths.shape[1]))
+            zero_rows = row_idx_grid[zero_width_mask]
+            idx_z = np.searchsorted(x_data_clean, zero_positions).clip(1, len(x_data_clean) - 1)
+            xl = x_data_clean[idx_z - 1]
+            xr = x_data_clean[idx_z]
+            denom_z = np.where(xr == xl, 1.0, xr - xl)
+            w_z = (zero_positions - xl) / denom_z
+            yl = y_data_clean[zero_rows, idx_z - 1]
+            yr = y_data_clean[zero_rows, idx_z]
+            result[zero_width_mask] = yl * (1.0 - w_z) + yr * w_z
 
     # Handle extrapolation when 'nan' method is used (vectorized).
     # Bins must lie entirely within the data range; bins partially outside
@@ -431,7 +522,23 @@ def linear_average(
     # average low. Bins fully outside are likewise NaN.
     if extrapolate_method == "nan":
         bins_within_range = (x_edges[:, :-1] >= x_data_clean[0]) & (x_edges[:, 1:] <= x_data_clean[-1])
+        if n_series_y > 1:
+            bins_within_range = np.broadcast_to(bins_within_range, (n_series, bins_within_range.shape[1]))
         result[~bins_within_range] = np.nan
+
+        # With 2D y_data, propagate per-row NaNs from the y series itself: any output bin
+        # that touches an x_data segment with NaN y in this row must be NaN. Per-row NaN
+        # info is preserved in all_unique_y; mark bins whose [edge_left, edge_right]
+        # contains a NaN segment for this row.
+        if n_series_y > 1:
+            # For each unique-x segment, is it NaN in this row?
+            seg_nan = np.isnan(y_avg)  # shape (n_series_y, n_unique_x - 1)
+            # A bin spans segments [edge_indices[0, b], edge_indices[0, b+1])
+            # For each row, count NaN segments per bin via cumulative sums.
+            seg_nan_cum = np.concatenate([np.zeros((n_series_y, 1)), np.cumsum(seg_nan, axis=1)], axis=1)
+            nan_count_per_bin = seg_nan_cum[:, edge_indices[0, 1:]] - seg_nan_cum[:, edge_indices[0, :-1]]
+            row_has_nan_in_bin = nan_count_per_bin > 0
+            result[row_has_nan_in_bin] = np.nan
 
     return result
 

--- a/tests/src/test_gamma.py
+++ b/tests/src/test_gamma.py
@@ -91,7 +91,7 @@ def test_bins_basic(gamma_params):
     # Check if the sum of the expected value of each bin is equal to the expected value of the distribution (alpha * beta)
     expected_value_bins = np.sum(result["expected_values"] * result["probability_mass"])
     expected_value_gamma = gamma_params["alpha"] * gamma_params["beta"]
-    assert expected_value_gamma == expected_value_bins
+    np.testing.assert_allclose(expected_value_gamma, expected_value_bins, rtol=1e-12)
 
 
 def test_bins_expected_values(gamma_params):
@@ -618,6 +618,64 @@ def test_bins_loc_lower_bound_equals_loc():
     r = gamma_bins(alpha=3.0, beta=1.5, loc=loc, n_bins=10)
     assert r["lower_bound"][0] == loc
     assert r["edges"][0] == loc
+
+
+def test_bins_expected_values_against_scipy_quadrature():
+    """Validate ``gamma.bins()['expected_values']`` against scipy.stats.gamma.expect to machine precision.
+
+    ``gamma.bins`` uses the closed-form identity
+        E[X * 1_{a <= X < b}] = alpha * beta * (F_{alpha+1}(b/beta) - F_{alpha+1}(a/beta))
+    so the conditional mean within a bin is
+        E[X | a <= X < b] = alpha * beta * (CDF diff of Gamma(alpha+1, beta)) / P(a <= X < b)
+
+    Compared against scipy adaptive quadrature (``gamma.expect``), which is accurate to roughly
+    1e-8 absolute error by default. A coefficient swap such as ``alpha * beta`` -> ``alpha + beta``
+    would produce errors many orders of magnitude larger than the quadrature tolerance.
+    """
+    test_cases = [
+        # (alpha, beta, loc, n_bins / quantile_edges)
+        (0.5, 2.0, 0.0, 5),  # strong curvature
+        (1.0, 1.5, 0.0, 4),  # exponential
+        (2.5, 1.5, 0.0, 6),  # moderate
+        (5.0, 0.8, 0.0, 8),  # bell-shaped
+        (3.0, 2.0, 4.5, 7),  # shifted
+        (0.7, 3.0, 1.2, 5),  # shifted strong-curvature
+    ]
+    custom_quantile_edges = np.array([0.0, 0.1, 0.35, 0.6, 0.85, 1.0])
+
+    for alpha, beta, loc, n_bins in test_cases:
+        for edges_spec in (n_bins, custom_quantile_edges):
+            kwargs: dict = {"alpha": alpha, "beta": beta, "loc": loc}
+            if isinstance(edges_spec, int):
+                kwargs["n_bins"] = edges_spec
+            else:
+                kwargs["quantile_edges"] = edges_spec
+
+            result = gamma_bins(**kwargs)
+            edges = result["edges"]
+            expected_values = result["expected_values"]
+            probability_mass = result["probability_mass"]
+
+            dist = gamma_dist(alpha, scale=beta, loc=loc)
+            n = len(expected_values)
+            expected_quad = np.empty(n)
+            for i in range(n):
+                lo = edges[i]
+                hi = edges[i + 1] if np.isfinite(edges[i + 1]) else np.inf
+                # scipy.gamma.expect returns int_{lo}^{hi} x * f(x) dx (an unconditional integral).
+                unconditional_mean = dist.expect(lambda x: x, lb=lo, ub=hi, conditional=False)
+                expected_quad[i] = unconditional_mean / probability_mass[i]
+
+            # scipy.integrate.quad default tolerance is ~1.49e-8 absolute, which scales with the
+            # magnitude of the expected values. Use a comparable absolute tolerance.
+            atol = 1e-7 * max(1.0, np.abs(expected_values).max())
+            np.testing.assert_allclose(
+                expected_values,
+                expected_quad,
+                atol=atol,
+                rtol=1e-10,
+                err_msg=f"alpha={alpha}, beta={beta}, loc={loc}, edges_spec={edges_spec}",
+            )
 
 
 def test_bins_alpha_less_than_one_large_nbins():

--- a/tests/src/test_residence_time.py
+++ b/tests/src/test_residence_time.py
@@ -122,11 +122,13 @@ def test_retardation_factor():
         direction="extraction_to_infiltration",
     )
 
-    # Residence time should double with retardation factor of 2
+    # With constant flow, retardation factor R must scale residence time by exactly R.
+    # The linear-interpolation step on a piecewise-linear cumulative-flow curve is exact for
+    # constant flow, so the ratio is 2.0 to machine precision wherever both are valid.
     valid_mask = ~np.isnan(result_no_retardation[0]) & ~np.isnan(result_with_retardation[0])
-    if np.any(valid_mask):
-        ratio = result_with_retardation[0, valid_mask] / result_no_retardation[0, valid_mask]
-        assert np.allclose(ratio, 2.0, rtol=0.1)
+    assert np.any(valid_mask)
+    ratio = result_with_retardation[0, valid_mask] / result_no_retardation[0, valid_mask]
+    np.testing.assert_allclose(ratio, 2.0, rtol=1e-12)
 
 
 def test_custom_index():
@@ -299,10 +301,18 @@ def test_negative_flow():
     assert not np.all(np.isfinite(result))
 
 
-def test_flow_variations(sample_flow_data):
-    """Test that residence times respond appropriately to flow variations."""
-    flow_values, flow_tedges = sample_flow_data
-    pore_volume = 500.0  # Use a larger pore volume to get valid results
+def test_flow_variations(constant_flow_data):
+    """Doubling constant flow exactly halves the residence time.
+
+    With variable flow, doubling flow does *not* halve residence time exactly: the
+    inverse-cum-flow inversion satisfies V_p = integral_{t-tau}^{t} Q(s) ds, and
+    rescaling Q -> 2Q gives V_p = integral_{t-tau'}^{t} 2 * Q(s) ds, i.e. the new tau'
+    is the time over which the *original* Q integrates to V_p / 2 -- generally not
+    tau / 2. Only for constant Q is the relationship exact. This test therefore uses a
+    constant-flow fixture to enforce the exact halving to machine precision.
+    """
+    flow_values, flow_tedges = constant_flow_data
+    pore_volume = 200.0  # m³, gives valid results across the whole window
 
     result1 = residence_time(
         flow=flow_values,
@@ -318,13 +328,10 @@ def test_flow_variations(sample_flow_data):
         direction="extraction_to_infiltration",
     )
 
-    # Find positions where both results have valid values
     valid_mask = ~np.isnan(result1[0]) & ~np.isnan(result2[0])
-
-    if np.any(valid_mask):
-        # Residence times should approximately halve with double flow
-        ratio = result1[0, valid_mask] / result2[0, valid_mask]
-        assert np.allclose(ratio, 2.0, rtol=0.3)
+    assert np.any(valid_mask)
+    ratio = result1[0, valid_mask] / result2[0, valid_mask]
+    np.testing.assert_allclose(ratio, 2.0, rtol=1e-12)
 
 
 def test_consistency_between_timing_methods():
@@ -501,38 +508,130 @@ def test_freundlich_retardation_concentration_dependence():
     assert result[0] > result[1] > result[2]
 
     # Check exact values
-    expected = 1.0 + (rho_b / theta) * k_f * n * np.power(np.maximum(concentrations, 1e-12), n - 1)
+    expected = 1.0 + (rho_b / theta) * k_f * n * np.power(concentrations, n - 1)
     np.testing.assert_allclose(result, expected, rtol=1e-10)
 
 
-def test_variable_flow_residence_time_analytical():
-    """Test residence_time with linearly increasing flow against analytical solution.
+def test_freundlich_retardation_zero_concentration_n_lt_one_raises():
+    """For n < 1 the retardation factor diverges as C -> 0; non-positive C must raise."""
+    # Zero concentration with n < 1: must raise
+    with pytest.raises(ValueError, match="concentration must be strictly positive when freundlich_n < 1"):
+        freundlich_retardation(
+            concentration=np.array([0.0, 1.0]),
+            freundlich_k=0.5,
+            freundlich_n=0.7,
+            bulk_density=1500.0,
+            porosity=0.3,
+        )
 
-    For Q(t) = q0 + a*t, cumulative volume V(t) = q0*t + a*t²/2.
-    Residence time tau satisfies V(t) - V(t-tau) = V_p.
+    # Negative concentration with n < 1: must raise
+    with pytest.raises(ValueError, match="concentration must be strictly positive when freundlich_n < 1"):
+        freundlich_retardation(
+            concentration=np.array([-0.1, 1.0]),
+            freundlich_k=0.5,
+            freundlich_n=0.7,
+            bulk_density=1500.0,
+            porosity=0.3,
+        )
+
+
+def test_freundlich_retardation_zero_concentration_n_geq_one_allowed():
+    """For n >= 1 the retardation factor is finite at C = 0 (or constant for n = 1); must not raise."""
+    # n = 1 -> retardation factor independent of C
+    result = freundlich_retardation(
+        concentration=np.array([0.0, 1.0, 2.0]),
+        freundlich_k=0.5,
+        freundlich_n=1.0,
+        bulk_density=1500.0,
+        porosity=0.3,
+    )
+    expected_constant = 1.0 + (1500.0 / 0.3) * 0.5 * 1.0
+    np.testing.assert_allclose(result, expected_constant, rtol=1e-12)
+
+    # n > 1 -> retardation factor equals 1 at C = 0
+    result = freundlich_retardation(
+        concentration=np.array([0.0, 1.0]),
+        freundlich_k=0.5,
+        freundlich_n=1.5,
+        bulk_density=1500.0,
+        porosity=0.3,
+    )
+    np.testing.assert_allclose(result[0], 1.0, rtol=1e-12)
+
+
+def test_variable_flow_residence_time_analytical():
+    """Test ``residence_time`` against an exact analytical residence time for variable flow.
+
+    For piecewise-constant flow ``flow[i]`` over time bins of width ``dt``, sample the rate
+    ``Q(t) = q0 + a * t`` at bin midpoints (``flow[i] = q0 + a * (i + 0.5) * dt``). Then the
+    function's cumulative-flow curve, evaluated at ``index = flow_tedges`` (i.e. integer
+    edge times), is exact for the piecewise-constant flow profile -- there is no bin-center
+    interpolation error. The analytical residence time ``tau`` at extraction time
+    ``t_index = N * dt`` is recovered exactly by accumulating bin volumes backward in time
+    until ``V_p`` is exhausted, then taking the partial bin contribution. This matches the
+    function's internal inversion to machine precision.
+
+    Note: comparing against the *continuous* analytical solution
+    ``V(t) - V(t - tau) = V_p`` with ``V(t) = q0 * t + a / 2 * t^2`` would only be accurate
+    to ``O(a * dt^2 / Q)`` because the function's piecewise-linear V differs from the
+    continuous quadratic V on the open intervals. Since the goal of this test is to validate
+    the function rather than the discretization, we compare to the function's exact
+    residence time given its piecewise-constant flow, computed via direct backward bin
+    accumulation.
     """
     q0 = 100.0  # m³/day
-    a = 2.0  # m³/day²  (flow increase rate)
+    a = 2.0  # m³/day²
     n_days = 200
     pore_volume = 500.0  # m³
+    dt = 1.0  # day
 
     flow_tedges = pd.date_range(start="2023-01-01", periods=n_days + 1, freq="D")
     t_days = np.arange(n_days, dtype=float)
-    flow_values = q0 + a * (t_days + 0.5)  # midpoint flow
+    flow_values = q0 + a * (t_days + 0.5) * dt  # midpoint sampling of the linear ramp
 
+    # Evaluate at flow_tedges (integer edge times) -- avoids the bin-center interpolation
+    # path and keeps the test exact w.r.t. the function's piecewise-constant flow.
     result = residence_time(
         flow=flow_values,
         flow_tedges=flow_tedges,
         aquifer_pore_volumes=pore_volume,
+        index=flow_tedges,
         direction="extraction_to_infiltration",
     )
 
-    # For constant flow q0=100, tau = V_p/Q = 500/100 = 5 days
-    # With increasing flow, tau should be slightly less than 5 days
-    # (more recent water had higher flow)
-    valid = ~np.isnan(result[0])
+    # Closed-form continuous-Q residence time, used only as a sanity check for monotonicity
+    # and ordering, not for the precision comparison.
+    t_ext = np.arange(n_days + 1, dtype=float)
+    disc = (q0 + a * t_ext) ** 2 - 2.0 * a * pore_volume
+    tau_continuous = np.full_like(t_ext, np.nan)
+    valid_disc = disc >= 0
+    tau_continuous[valid_disc] = ((q0 + a * t_ext[valid_disc]) - np.sqrt(disc[valid_disc])) / a
+
+    # Exact analytical residence time for the piecewise-constant flow profile and
+    # integer-endpoint extraction times. Walk backward bin-by-bin until V_p is exhausted.
+    cum_flow = np.concatenate(([0.0], np.cumsum(flow_values * dt)))  # V at edges 0, 1, ..., N
+
+    tau_exact = np.full(n_days + 1, np.nan)
+    for i in range(n_days + 1):
+        target = cum_flow[i] - pore_volume
+        if target < 0:
+            continue  # not enough cumulative flow yet -> NaN
+        # Find the bin index k such that cum_flow[k] <= target < cum_flow[k+1].
+        k = int(np.searchsorted(cum_flow, target, side="right") - 1)
+        # Partial position within bin k (in days from start of bin k).
+        partial = (target - cum_flow[k]) / flow_values[k]
+        s_back = k + partial  # days since simulation start
+        tau_exact[i] = i - s_back  # both in days
+
+    valid = ~np.isnan(result[0]) & ~np.isnan(tau_exact)
     assert np.any(valid)
 
-    # Residence time should be close to V_p / mean_flow but not exact
-    mean_rt = np.mean(result[0, valid])
-    assert mean_rt < pore_volume / q0  # Less than V_p/q0 since flow increases
+    # Function output must equal the bin-by-bin exact solution to machine precision.
+    np.testing.assert_allclose(result[0, valid], tau_exact[valid], rtol=1e-12)
+
+    # Sanity check: the discrete solution agrees with the continuous one to within the
+    # expected discretization error a * dt^2 / (8 * Q_min).
+    q_min = float(np.min(flow_values))
+    bias_bound = a * dt**2 / (8.0 * q_min)
+    valid_cont = valid & ~np.isnan(tau_continuous)
+    np.testing.assert_allclose(tau_exact[valid_cont], tau_continuous[valid_cont], atol=bias_bound, rtol=1e-3)

--- a/tests/src/test_residence_time_mean.py
+++ b/tests/src/test_residence_time_mean.py
@@ -126,9 +126,11 @@ def test_retardation_factor(constant_flow_data):
     assert np.isnan(result_with_retardation[0, 0])
     assert np.isnan(result_with_retardation[0, 1])
 
-    # Later values should be valid
-    assert np.isclose(result_with_retardation[0, 2], 2 * result_no_retardation[0, 1])
-    assert np.isclose(result_with_retardation[0, 3], 2 * result_no_retardation[0, 2])
+    # Later values should be valid. With constant flow, retardation R = 2 must scale
+    # the mean residence time by exactly 2, since the underlying linear interpolation
+    # (and the linear average over output bins) is exact for piecewise-constant flow.
+    np.testing.assert_allclose(result_with_retardation[0, 2], 2 * result_no_retardation[0, 1], rtol=1e-12)
+    np.testing.assert_allclose(result_with_retardation[0, 3], 2 * result_no_retardation[0, 2], rtol=1e-12)
 
 
 def test_multiple_pore_volumes(constant_flow_data):
@@ -221,9 +223,15 @@ def test_negative_flow(constant_flow_data):
     assert np.all(np.isnan(result))
 
 
-def test_flow_variations(sample_flow_data):
-    """Test that residence times respond appropriately to flow variations."""
-    flow_values, flow_tedges = sample_flow_data
+def test_flow_variations(constant_flow_data):
+    """Doubling constant flow exactly halves the mean residence time.
+
+    Doubling a *variable* flow does not halve the residence time exactly (the inversion
+    V_p = integral Q ds rescales differently for non-constant Q). With *constant* flow,
+    doubling Q halves both the pointwise residence time and its bin average, so the
+    ratio must be 2.0 to machine precision wherever both are valid.
+    """
+    flow_values, flow_tedges = constant_flow_data
     double_flow = flow_values * 2
     tedges_out = pd.date_range(start="2023-01-04", end="2023-01-09", freq="1D")
     pore_volume = 100.0
@@ -244,13 +252,10 @@ def test_flow_variations(sample_flow_data):
         direction="extraction_to_infiltration",
     )
 
-    # Residence times should approximately halve with double flow
-    # We need to find positions where both results have valid values
     valid_mask = ~np.isnan(result1[0]) & ~np.isnan(result2[0])
-    if np.any(valid_mask):
-        ratio = result1[0, valid_mask] / result2[0, valid_mask]
-        # Allow for some numerical imprecision
-        assert np.all(np.isclose(ratio, 2.0, rtol=0.2))
+    assert np.any(valid_mask)
+    ratio = result1[0, valid_mask] / result2[0, valid_mask]
+    np.testing.assert_allclose(ratio, 2.0, rtol=1e-12)
 
 
 def test_output_tedges_alignment():

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -287,6 +287,56 @@ def test_2d_x_edges():
     np.testing.assert_allclose(result, expected, rtol=1e-12)
 
 
+def test_linear_average_2d_y_data_basic():
+    """2D y_data computes the per-row average independently and matches looping."""
+    x_data = np.array([0.0, 1.0, 2.0, 3.0])
+    y_data_2d = np.array([
+        [0.0, 1.0, 1.0, 0.0],
+        [0.0, 2.0, 2.0, 0.0],
+        [1.0, 1.0, 1.0, 1.0],
+    ])
+    x_edges = np.array([0.0, 1.5, 3.0])
+
+    result = linear_average(x_data=x_data, y_data=y_data_2d, x_edges=x_edges)
+
+    # Compare to a loop over rows -- each row averaged independently.
+    expected = np.vstack([
+        linear_average(x_data=x_data, y_data=y_data_2d[i], x_edges=x_edges)[0] for i in range(y_data_2d.shape[0])
+    ])
+    np.testing.assert_allclose(result, expected, rtol=1e-12)
+    # Sanity check: row 2 is constant 1, so its average over any interval is 1.
+    np.testing.assert_allclose(result[2], 1.0, rtol=1e-12)
+
+
+def test_linear_average_2d_y_data_per_row_nan():
+    """2D y_data: a NaN in one row only marks bins of that row, not others."""
+    x_data = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    y_data_2d = np.array([
+        [0.0, 1.0, 2.0, 3.0, 4.0],  # ramp y = x
+        [0.0, 1.0, np.nan, 3.0, 4.0],  # NaN at x=2 in row 1 only
+    ])
+    x_edges = np.array([0.0, 1.0, 3.0, 4.0])
+
+    result = linear_average(x_data=x_data, y_data=y_data_2d, x_edges=x_edges)
+
+    # Row 0: y = x clean. Means over [0,1], [1,3], [3,4] are 0.5, 2.0, 3.5.
+    np.testing.assert_allclose(result[0], [0.5, 2.0, 3.5], rtol=1e-12)
+    # Row 1: bin [0, 1] does not touch any NaN segment -> finite. Bin [1, 3] does -> NaN.
+    # Bin [3, 4] does not -> finite (the NaN segment is [1,2] U [2,3]).
+    np.testing.assert_allclose(result[1, 0], 0.5, rtol=1e-12)
+    assert np.isnan(result[1, 1])
+    np.testing.assert_allclose(result[1, 2], 3.5, rtol=1e-12)
+
+
+def test_linear_average_2d_y_data_with_2d_x_edges_raises():
+    """Combining 2D y_data with 2D x_edges is intentionally unsupported."""
+    x_data = np.array([0.0, 1.0, 2.0])
+    y_data_2d = np.array([[0.0, 1.0, 2.0], [2.0, 1.0, 0.0]])
+    x_edges_2d = np.array([[0.0, 1.0, 2.0], [0.5, 1.0, 1.5]])
+    with pytest.raises(ValueError, match="Cannot combine 2D x_edges with 2D y_data"):
+        linear_average(x_data=x_data, y_data=y_data_2d, x_edges=x_edges_2d)
+
+
 def test_linear_average_straddling_bin_is_nan():
     """Bins partially outside the data range must be NaN, not biased low.
 


### PR DESCRIPTION
## Summary

PR 4 of 6 in the physics review series. Touches `src/gwtransport/{gamma,residence_time,utils}.py` and tests in `tests/src/`.

- **G1** -- Added a scipy-based unit test that compares `gamma.bins()['expected_values']` against `scipy.stats.gamma(alpha, scale=beta, loc=loc).expect(lambda x: x, ...)` to ~`1e-7` absolute tolerance. Tight enough to catch a coefficient swap (e.g. `alpha*beta` -> `alpha+beta`) in the closed-form conditional-mean identity used by `bins()`.
- **G2** -- Tightened `rtol=0.1-0.3` retardation- and doubled-flow tolerances to `rtol=1e-12`. Two tests had been silently using a *variable* flow fixture for the doubled-flow invariant; doubling Q only halves residence time exactly when Q is constant, so those tests now use the constant-flow fixture and document the constraint inline.
- **G3** -- `freundlich_retardation` no longer silently clamps `concentration` to `1e-12`. For `freundlich_n < 1` (where the retardation factor diverges as C -> 0), it raises `ValueError` if any concentration is non-positive. Added unit tests for the guard and for the well-defined `n >= 1` branch.
- **G4** -- Vectorized the per-pore-volume Python loop in `residence_time_mean`. Added 2D-`y_data` support to `utils.linear_average` (multiple series sharing the same `x_data` and `x_edges`), with per-row NaN-segment propagation so output bins touching a NaN segment in their own row only become NaN in that row. Three new unit tests cover the new path; the residence_time tests still pass exactly.
- **G5** -- Replaced the monotonicity check in `test_variable_flow_residence_time_analytical` with an exact comparison against the bin-by-bin backward-accumulation residence time for the function's piecewise-constant flow profile (`rtol=1e-12`). Also added a sanity check vs. the continuous closed-form `tau = ((q0+a*t) - sqrt((q0+a*t)^2 - 2*a*V_p))/a`, bounded by the documented `O(a*dt^2/Q)` bin-center bias.
- **G6** -- Fixed the misleading `bin_masses` error message ("Bin edges must be non-negative" -- the validation accepts zero) and replaced the `==` comparison in `test_bins_basic` with `np.testing.assert_allclose(..., rtol=1e-12)`.

## Test plan

- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q ruff format .` -- clean
- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q ruff check --fix .` -- all checks passed
- [x] `uv tool run -q ty check .` -- all checks passed
- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src -n auto` -- 952 passed, 8 skipped
- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/docs tests/examples -n auto` -- 19 passed, 1 skipped, 1 xfailed

## Contributor License Agreement

- [x] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.