### PR TITLE
Fix advection (physics review)

### DIFF
--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -1193,14 +1193,17 @@ def _flow_weighted_front_tracking_output(
     v_outlet: float,
     waves: list,
     sorption: SorptionModel,
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    """Compute flow-weighted numerator and denominator per output bin from front tracking.
+) -> npt.NDArray[np.floating]:
+    """Compute flow-weighted bin-averaged concentration from front-tracking output.
 
     Splits output bins at flow boundaries so that Q is constant within each
-    sub-bin, then accumulates ``Σ(Q_k · c_k · dt_k)`` (numerator) and
-    ``Σ(Q_k · dt_k)`` (denominator) per output bin. The bin-averaged
-    concentration is ``numerator / denominator``. Returning the parts
-    separately allows callers to flow-weight across multiple pore volumes.
+    sub-bin, then combines sub-bins with flow-weighting:
+    ``c_avg = Σ(Q_k · c_k · dt_k) / Σ(Q_k · dt_k)``.
+
+    This is the per-streamtube outlet concentration for one pore volume:
+    mass flux divided by water flux for the streamtube's contribution to each
+    output bin. Aggregation across streamtubes is the caller's responsibility
+    (simple arithmetic mean over streamtubes — equal flow per streamtube).
 
     Parameters
     ----------
@@ -1219,10 +1222,8 @@ def _flow_weighted_front_tracking_output(
 
     Returns
     -------
-    numerator : ndarray
-        Per-bin ``Σ(Q_k · c_k · dt_k)``. Length = len(cout_tedges_days) - 1.
-    denominator : ndarray
-        Per-bin ``Σ(Q_k · dt_k)``. Length = len(cout_tedges_days) - 1.
+    ndarray
+        Flow-weighted bin-averaged concentrations. Length = len(cout_tedges_days) - 1.
     """
     # Merge cout edges with flow edges that fall within the cout range
     inner_flow_edges = flow_tedges_days[
@@ -1249,13 +1250,17 @@ def _flow_weighted_front_tracking_output(
     cout_bin_idx = np.searchsorted(cout_tedges_days[1:], fine_mids, side="left")
     cout_bin_idx = np.clip(cout_bin_idx, 0, len(cout_tedges_days) - 2)
 
-    # Vectorized accumulation per output bin
+    # Vectorized per-bin flow-weighted average:
+    # c_out[k] = sum_i (Q_i * c_i * dt_i) / sum_i (Q_i * dt_i) for fine sub-bins i in bin k
     n_cout = len(cout_tedges_days) - 1
     qdt_product = q_fine * dt_fine
     cqdt_product = c_fine * qdt_product
     denominator = np.bincount(cout_bin_idx, weights=qdt_product, minlength=n_cout).astype(np.float64)
     numerator = np.bincount(cout_bin_idx, weights=cqdt_product, minlength=n_cout).astype(np.float64)
-    return numerator, denominator
+    c_out = np.zeros(n_cout)
+    valid = denominator > 0
+    c_out[valid] = numerator[valid] / denominator[valid]
+    return c_out
 
 
 def infiltration_to_extraction_front_tracking(
@@ -1415,15 +1420,12 @@ def infiltration_to_extraction_front_tracking(
     t_ref = tedges[0]
     flow_tedges_days = ((tedges - t_ref) / pd.Timedelta(days=1)).values
 
-    # Loop over each pore volume, accumulating flow-weighted numerator/denominator
-    # across all pore volumes. This matches the convention in
-    # _infiltration_to_extraction_weights: each pore-volume path contributes
-    # proportionally to the volume of water it carries to each output bin.
-    n_cout = len(cout_tedges) - 1
-    accumulated_numerator = np.zeros(n_cout)
-    accumulated_denominator = np.zeros(n_cout)
+    # Each pore-volume bin from the gamma distribution is an equal-mass streamtube,
+    # so all streamtubes carry equal flow at the outlet. The bundle outlet
+    # concentration is the simple arithmetic mean over streamtubes.
+    cout_all = np.zeros((len(aquifer_pore_volumes), len(cout_tedges) - 1))
 
-    for aquifer_pore_volume in aquifer_pore_volumes:
+    for i, aquifer_pore_volume in enumerate(aquifer_pore_volumes):
         tracker = FrontTracker(
             cin=cin,
             flow=flow,
@@ -1434,7 +1436,7 @@ def infiltration_to_extraction_front_tracking(
 
         tracker.run(max_iterations=max_iterations)
 
-        numerator, denominator = _flow_weighted_front_tracking_output(
+        cout_all[i, :] = _flow_weighted_front_tracking_output(
             cout_tedges_days=cout_tedges_days,
             flow_tedges_days=flow_tedges_days,
             flow=flow,
@@ -1442,13 +1444,8 @@ def infiltration_to_extraction_front_tracking(
             waves=tracker.state.waves,
             sorption=sorption,
         )
-        accumulated_numerator += numerator
-        accumulated_denominator += denominator
 
-    cout = np.zeros(n_cout)
-    valid = accumulated_denominator > 0
-    cout[valid] = accumulated_numerator[valid] / accumulated_denominator[valid]
-    return cout
+    return np.mean(cout_all, axis=0)
 
 
 def infiltration_to_extraction_front_tracking_detailed(
@@ -1585,15 +1582,13 @@ def infiltration_to_extraction_front_tracking_detailed(
     t_ref = tedges[0]
     flow_tedges_days = ((tedges - t_ref) / pd.Timedelta(days=1)).values
 
-    # Loop over each pore volume, accumulating flow-weighted numerator/denominator
-    # across all pore volumes (matches A1 convention in
-    # _infiltration_to_extraction_weights).
-    n_cout = len(cout_tedges) - 1
-    accumulated_numerator = np.zeros(n_cout)
-    accumulated_denominator = np.zeros(n_cout)
+    # Each pore-volume bin from the gamma distribution is an equal-mass streamtube,
+    # so all streamtubes carry equal flow at the outlet. The bundle outlet
+    # concentration is the simple arithmetic mean over streamtubes.
+    cout_all = np.zeros((len(aquifer_pore_volumes), len(cout_tedges) - 1))
     structures = []
 
-    for aquifer_pore_volume in aquifer_pore_volumes:
+    for i, aquifer_pore_volume in enumerate(aquifer_pore_volumes):
         tracker = FrontTracker(
             cin=cin,
             flow=flow,
@@ -1604,7 +1599,7 @@ def infiltration_to_extraction_front_tracking_detailed(
 
         tracker.run(max_iterations=max_iterations)
 
-        numerator, denominator = _flow_weighted_front_tracking_output(
+        cout_all[i, :] = _flow_weighted_front_tracking_output(
             cout_tedges_days=cout_tedges_days,
             flow_tedges_days=flow_tedges_days,
             flow=flow,
@@ -1612,8 +1607,6 @@ def infiltration_to_extraction_front_tracking_detailed(
             waves=tracker.state.waves,
             sorption=sorption,
         )
-        accumulated_numerator += numerator
-        accumulated_denominator += denominator
 
         # Build detailed structure dict for this pore volume
         structure = {
@@ -1631,7 +1624,4 @@ def infiltration_to_extraction_front_tracking_detailed(
         }
         structures.append(structure)
 
-    cout = np.zeros(n_cout)
-    valid = accumulated_denominator > 0
-    cout[valid] = accumulated_numerator[valid] / accumulated_denominator[valid]
-    return cout, structures
+    return np.mean(cout_all, axis=0), structures

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -128,6 +128,11 @@ def infiltration_to_extraction_series(
         The concentration values in the extracted water (cout) equal cin, but are
         aligned with these shifted time edges.
 
+    Raises
+    ------
+    ValueError
+        If ``retardation_factor`` is less than 1.0.
+
     Examples
     --------
     Basic usage with constant flow:
@@ -188,6 +193,9 @@ def infiltration_to_extraction_series(
     >>> tedges_out[0] - tedges[0]
     Timedelta('10 days 00:00:00')
     """
+    if retardation_factor < 1.0:
+        msg = "retardation_factor must be >= 1.0"
+        raise ValueError(msg)
     rt_array = residence_time(
         flow=flow,
         flow_tedges=tedges,
@@ -238,6 +246,11 @@ def extraction_to_infiltration_series(
         Time edges for the infiltrating water concentration. Same length as tedges.
         The concentration values in the infiltrating water (cin) equal cout, but are
         aligned with these shifted time edges.
+
+    Raises
+    ------
+    ValueError
+        If ``retardation_factor`` is less than 1.0.
 
     Examples
     --------
@@ -302,6 +315,9 @@ def extraction_to_infiltration_series(
     >>> tedges[10] - tedges_out[10]
     Timedelta('10 days 00:00:00')
     """
+    if retardation_factor < 1.0:
+        msg = "retardation_factor must be >= 1.0"
+        raise ValueError(msg)
     rt_array = residence_time(
         flow=flow,
         flow_tedges=tedges,
@@ -1177,12 +1193,14 @@ def _flow_weighted_front_tracking_output(
     v_outlet: float,
     waves: list,
     sorption: SorptionModel,
-) -> npt.NDArray[np.floating]:
-    """Compute flow-weighted bin-averaged concentration from front-tracking output.
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+    """Compute flow-weighted numerator and denominator per output bin from front tracking.
 
     Splits output bins at flow boundaries so that Q is constant within each
-    sub-bin, then combines sub-bins with flow-weighting:
-    ``c_avg = Σ(Q_k · c_k · dt_k) / Σ(Q_k · dt_k)``.
+    sub-bin, then accumulates ``Σ(Q_k · c_k · dt_k)`` (numerator) and
+    ``Σ(Q_k · dt_k)`` (denominator) per output bin. The bin-averaged
+    concentration is ``numerator / denominator``. Returning the parts
+    separately allows callers to flow-weight across multiple pore volumes.
 
     Parameters
     ----------
@@ -1201,8 +1219,10 @@ def _flow_weighted_front_tracking_output(
 
     Returns
     -------
-    ndarray
-        Flow-weighted bin-averaged concentrations.
+    numerator : ndarray
+        Per-bin ``Σ(Q_k · c_k · dt_k)``. Length = len(cout_tedges_days) - 1.
+    denominator : ndarray
+        Per-bin ``Σ(Q_k · dt_k)``. Length = len(cout_tedges_days) - 1.
     """
     # Merge cout edges with flow edges that fall within the cout range
     inner_flow_edges = flow_tedges_days[
@@ -1229,19 +1249,13 @@ def _flow_weighted_front_tracking_output(
     cout_bin_idx = np.searchsorted(cout_tedges_days[1:], fine_mids, side="left")
     cout_bin_idx = np.clip(cout_bin_idx, 0, len(cout_tedges_days) - 2)
 
-    # Flow-weighted combination per output bin
+    # Vectorized accumulation per output bin
     n_cout = len(cout_tedges_days) - 1
-    c_out = np.zeros(n_cout)
     qdt_product = q_fine * dt_fine
     cqdt_product = c_fine * qdt_product
-
-    for i in range(n_cout):
-        mask = cout_bin_idx == i
-        total_qdt = np.sum(qdt_product[mask])
-        if total_qdt > 0:
-            c_out[i] = np.sum(cqdt_product[mask]) / total_qdt
-
-    return c_out
+    denominator = np.bincount(cout_bin_idx, weights=qdt_product, minlength=n_cout).astype(np.float64)
+    numerator = np.bincount(cout_bin_idx, weights=cqdt_product, minlength=n_cout).astype(np.float64)
+    return numerator, denominator
 
 
 def infiltration_to_extraction_front_tracking(
@@ -1401,11 +1415,15 @@ def infiltration_to_extraction_front_tracking(
     t_ref = tedges[0]
     flow_tedges_days = ((tedges - t_ref) / pd.Timedelta(days=1)).values
 
-    # Loop over each pore volume and compute concentration
-    cout_all = np.zeros((len(aquifer_pore_volumes), len(cout_tedges) - 1))
+    # Loop over each pore volume, accumulating flow-weighted numerator/denominator
+    # across all pore volumes. This matches the convention in
+    # _infiltration_to_extraction_weights: each pore-volume path contributes
+    # proportionally to the volume of water it carries to each output bin.
+    n_cout = len(cout_tedges) - 1
+    accumulated_numerator = np.zeros(n_cout)
+    accumulated_denominator = np.zeros(n_cout)
 
-    for i, aquifer_pore_volume in enumerate(aquifer_pore_volumes):
-        # Create tracker and run simulation for this pore volume
+    for aquifer_pore_volume in aquifer_pore_volumes:
         tracker = FrontTracker(
             cin=cin,
             flow=flow,
@@ -1416,8 +1434,7 @@ def infiltration_to_extraction_front_tracking(
 
         tracker.run(max_iterations=max_iterations)
 
-        # Extract flow-weighted bin-averaged concentrations at outlet
-        cout_all[i, :] = _flow_weighted_front_tracking_output(
+        numerator, denominator = _flow_weighted_front_tracking_output(
             cout_tedges_days=cout_tedges_days,
             flow_tedges_days=flow_tedges_days,
             flow=flow,
@@ -1425,9 +1442,13 @@ def infiltration_to_extraction_front_tracking(
             waves=tracker.state.waves,
             sorption=sorption,
         )
+        accumulated_numerator += numerator
+        accumulated_denominator += denominator
 
-    # Return average across all pore volumes
-    return np.mean(cout_all, axis=0)
+    cout = np.zeros(n_cout)
+    valid = accumulated_denominator > 0
+    cout[valid] = accumulated_numerator[valid] / accumulated_denominator[valid]
+    return cout
 
 
 def infiltration_to_extraction_front_tracking_detailed(
@@ -1564,12 +1585,15 @@ def infiltration_to_extraction_front_tracking_detailed(
     t_ref = tedges[0]
     flow_tedges_days = ((tedges - t_ref) / pd.Timedelta(days=1)).values
 
-    # Loop over each pore volume and compute concentration
-    cout_all = np.zeros((len(aquifer_pore_volumes), len(cout_tedges) - 1))
+    # Loop over each pore volume, accumulating flow-weighted numerator/denominator
+    # across all pore volumes (matches A1 convention in
+    # _infiltration_to_extraction_weights).
+    n_cout = len(cout_tedges) - 1
+    accumulated_numerator = np.zeros(n_cout)
+    accumulated_denominator = np.zeros(n_cout)
     structures = []
 
-    for i, aquifer_pore_volume in enumerate(aquifer_pore_volumes):
-        # Create tracker and run simulation for this pore volume
+    for aquifer_pore_volume in aquifer_pore_volumes:
         tracker = FrontTracker(
             cin=cin,
             flow=flow,
@@ -1580,8 +1604,7 @@ def infiltration_to_extraction_front_tracking_detailed(
 
         tracker.run(max_iterations=max_iterations)
 
-        # Extract flow-weighted bin-averaged concentrations for this pore volume
-        cout_all[i, :] = _flow_weighted_front_tracking_output(
+        numerator, denominator = _flow_weighted_front_tracking_output(
             cout_tedges_days=cout_tedges_days,
             flow_tedges_days=flow_tedges_days,
             flow=flow,
@@ -1589,6 +1612,8 @@ def infiltration_to_extraction_front_tracking_detailed(
             waves=tracker.state.waves,
             sorption=sorption,
         )
+        accumulated_numerator += numerator
+        accumulated_denominator += denominator
 
         # Build detailed structure dict for this pore volume
         structure = {
@@ -1606,5 +1631,7 @@ def infiltration_to_extraction_front_tracking_detailed(
         }
         structures.append(structure)
 
-    # Return average concentrations and list of structures
-    return np.mean(cout_all, axis=0), structures
+    cout = np.zeros(n_cout)
+    valid = accumulated_denominator > 0
+    cout[valid] = accumulated_numerator[valid] / accumulated_denominator[valid]
+    return cout, structures

--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -74,15 +74,19 @@ def _infiltration_to_extraction_weights(
     cin_time_min = cin_tedges_days[0]
     cin_time_max = cin_tedges_days[-1]
 
-    # Accumulate flow-weighted overlap matrices from all pore volumes, then perform
-    # a single end-of-loop flow-weighted normalization. This preserves mass conservation
-    # under variable flow: each output row's contribution from cin bin j is proportional
-    # to the volume of water (flow * overlap fraction) that left bin j and arrived in
-    # the output bin via any pore volume path.
+    # Per-streamtube derivation: for streamtube i and outlet bin k, mass balance gives
+    #     c_out[k|i] = sum_j (Q_j * overlap[i,k,j] * c_j) / sum_j' (Q_j' * overlap[i,k,j'])
+    # which is the literal definition of mass-flux divided by water-flux for the bin.
+    # Each streamtube carries equal flow at the outlet (equal-mass pore-volume bins from
+    # the gamma distribution), so the bundle outlet concentration is the simple arithmetic
+    # average over streamtubes that contributed to the bin:
+    #     c_out[k] = (1 / N_valid_k) * sum_{i valid} c_out[k|i]
+    # During spin-up, only the shorter pore-volume streamtubes have a valid source window
+    # within the cin time range; we average over the contributing streamtubes only.
     n_cout = len(cout_tedges) - 1
     n_cin = len(tedges) - 1
-    accumulated_flow_weighted = np.zeros((n_cout, n_cin))
-    accumulated_denominators = np.zeros(n_cout)
+    accumulated_weights = np.zeros((n_cout, n_cin))
+    contributing_bins = np.zeros(n_cout)
 
     # Loop over each pore volume
     for i in range(len(aquifer_pore_volumes)):
@@ -114,16 +118,25 @@ def _infiltration_to_extraction_weights(
         # and bin_edges_out has length n_cin+1 (the cin time edges).
         overlap_matrix = partial_isin(bin_edges_in=infiltration_tedges_2d[i, :], bin_edges_out=cin_tedges_days)
 
-        # Apply flow weighting (cin bins carry their own flow rate)
-        fw = overlap_matrix * flow[None, :]
-        row_sums = fw.sum(axis=1)
+        # Per-streamtube weights: row k gives c_out[k|i] = sum_j weight[k,j] * c_in[j].
+        # The row-normalization is the direct mass-flux/water-flux ratio, NOT an
+        # error-hiding renormalization.
+        flow_weighted_overlap = overlap_matrix * flow[None, :]
+        row_sums = np.sum(flow_weighted_overlap, axis=1)
+        valid_rows_pv = row_sums > 0
+        normalized_overlap = np.zeros_like(flow_weighted_overlap)
+        normalized_overlap[valid_rows_pv, :] = flow_weighted_overlap[valid_rows_pv, :] / row_sums[valid_rows_pv, None]
 
-        # Accumulate only the valid bins from this pore volume
-        accumulated_flow_weighted[valid_bins_2d[i], :] += fw[valid_bins_2d[i], :]
-        accumulated_denominators[valid_bins_2d[i]] += row_sums[valid_bins_2d[i]]
+        # Accumulate only the valid bins from this pore volume for a simple count-average
+        # over contributing streamtubes.
+        accumulated_weights[valid_bins_2d[i, :], :] += normalized_overlap[valid_bins_2d[i, :], :]
+        contributing_bins[valid_bins_2d[i, :]] += 1
 
-    # Single flow-weighted normalization across all contributing pore volumes
-    valid_rows = accumulated_denominators > 0
-    result = np.zeros_like(accumulated_flow_weighted)
-    result[valid_rows] = accumulated_flow_weighted[valid_rows] / accumulated_denominators[valid_rows, None]
+    # Simple arithmetic average across contributing streamtubes (equal flow per
+    # streamtube at the outlet means equal weight). This is correct under variable
+    # flow; an end-of-loop global normalization would silently bias streamtubes by
+    # source-window length.
+    valid_rows = contributing_bins > 0
+    result = np.zeros_like(accumulated_weights)
+    result[valid_rows, :] = accumulated_weights[valid_rows, :] / contributing_bins[valid_rows, None]
     return result

--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -74,13 +74,15 @@ def _infiltration_to_extraction_weights(
     cin_time_min = cin_tedges_days[0]
     cin_time_max = cin_tedges_days[-1]
 
-    # Accumulate flow-weighted overlap matrices from all pore volumes
-    # Each pore volume has equal probability (equal-mass bins from gamma distribution)
+    # Accumulate flow-weighted overlap matrices from all pore volumes, then perform
+    # a single end-of-loop flow-weighted normalization. This preserves mass conservation
+    # under variable flow: each output row's contribution from cin bin j is proportional
+    # to the volume of water (flow * overlap fraction) that left bin j and arrived in
+    # the output bin via any pore volume path.
     n_cout = len(cout_tedges) - 1
     n_cin = len(tedges) - 1
-    accumulated_weights = np.zeros((n_cout, n_cin))
-    # Track how many pore volume bins contributed to each output row
-    contributing_bins = np.zeros(n_cout)
+    accumulated_flow_weighted = np.zeros((n_cout, n_cin))
+    accumulated_denominators = np.zeros(n_cout)
 
     # Loop over each pore volume
     for i in range(len(aquifer_pore_volumes)):
@@ -106,31 +108,22 @@ def _infiltration_to_extraction_weights(
             # No temporal overlap - this bin contributes nothing, skip expensive computation
             continue
 
-        # Compute overlap matrix for this pore volume
+        # Compute overlap matrix for this pore volume.
+        # partial_isin returns shape (n_in, n_out) = (n_cout, n_cin) here, because
+        # bin_edges_in has length n_cout+1 (one infiltration-time edge per cout edge)
+        # and bin_edges_out has length n_cin+1 (the cin time edges).
         overlap_matrix = partial_isin(bin_edges_in=infiltration_tedges_2d[i, :], bin_edges_out=cin_tedges_days)
 
-        # Apply flow weighting to this pore volume's overlap matrix
-        flow_weighted_overlap = overlap_matrix * flow[None, :]
-
-        # Normalize this pore volume's contribution (each row sums to 1 after flow weighting)
-        row_sums = np.sum(flow_weighted_overlap, axis=1)
-        valid_rows_pv = row_sums > 0
-        normalized_overlap = np.zeros_like(flow_weighted_overlap)
-        normalized_overlap[valid_rows_pv, :] = flow_weighted_overlap[valid_rows_pv, :] / row_sums[valid_rows_pv, None]
+        # Apply flow weighting (cin bins carry their own flow rate)
+        fw = overlap_matrix * flow[None, :]
+        row_sums = fw.sum(axis=1)
 
         # Accumulate only the valid bins from this pore volume
-        accumulated_weights[valid_bins_2d[i, :], :] += normalized_overlap[valid_bins_2d[i, :], :]
-        contributing_bins[valid_bins_2d[i, :]] += 1
+        accumulated_flow_weighted[valid_bins_2d[i], :] += fw[valid_bins_2d[i], :]
+        accumulated_denominators[valid_bins_2d[i]] += row_sums[valid_bins_2d[i]]
 
-    # Average across contributing pore volumes for each output row.
-    # During spin-up, only the shorter pore volumes have valid residence times.
-    # We normalize by the number of bins that actually contributed to each row,
-    # so the output represents the average concentration of informed flow paths
-    # rather than being biased toward zero.
-    # This is correct when aquifer_pore_volumes comes from gamma.bins() which
-    # produces equal-probability bins. For user-supplied pore volumes with
-    # unequal probability mass, a weights parameter would be needed.
-    valid_rows = contributing_bins > 0
-    result = np.zeros_like(accumulated_weights)
-    result[valid_rows, :] = accumulated_weights[valid_rows, :] / contributing_bins[valid_rows, None]
+    # Single flow-weighted normalization across all contributing pore volumes
+    valid_rows = accumulated_denominators > 0
+    result = np.zeros_like(accumulated_flow_weighted)
+    result[valid_rows] = accumulated_flow_weighted[valid_rows] / accumulated_denominators[valid_rows, None]
     return result

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -953,8 +953,10 @@ def test_infiltration_to_extraction_analytical_mass_conservation():
     valid_mask = ~np.isnan(cout)
     output_mass = np.sum(cout[valid_mask] * cout_flow[valid_mask] * dt)
 
-    # After A1 fix: flow-weighted normalization conserves mass to machine precision.
-    # The output window is wide enough to capture the entire pulse from all pore volumes.
+    # Mass is conserved to machine precision: per-streamtube row-normalization
+    # gives the exact mass-flux/water-flux ratio per streamtube, and the simple
+    # arithmetic average over equal-flow streamtubes preserves total mass when
+    # the output window captures the entire pulse from every pore-volume path.
     assert input_mass > 0
     mass_error = abs(output_mass - input_mass) / input_mass
     assert mass_error < 1e-12, f"Mass conservation error {mass_error:.2e} >= 1e-12"

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -437,14 +437,19 @@ def test_gamma_infiltration_to_extraction_constant_input():
     valid_count = np.sum(~np.isnan(cout))
     assert valid_count >= 150, f"Expected at least 150 valid bins for 6-month extraction, got {valid_count}"
 
-    # Output should also be constant where valid (constant input preserved)
-    valid_values = cout[~np.isnan(cout)]
-    mean_cout = np.mean(valid_values)
-    assert abs(mean_cout - 1.0) < 0.1, f"Expected mean ~1.0 (preserved from constant input), got {mean_cout:.3f}"
-
-    # Low variation expected for constant input
-    std_cout = np.std(valid_values)
-    assert std_cout < 0.05, f"Expected std < 0.05 for constant input, got {std_cout:.3f}"
+    # For constant input and constant flow, the post-spin-up steady state is exact.
+    # Skip the spin-up region (first valid bins where some pore-volume paths have not
+    # yet contributed) and assert exact equality on the steady-state interior.
+    valid_indices = np.where(~np.isnan(cout))[0]
+    # Drop the first 90 valid bins as spin-up margin (mean RT ~1 day; with n_bins=20
+    # the longest gamma bin's RT is well under 90 days).
+    steady_indices = valid_indices[90:]
+    np.testing.assert_allclose(
+        cout[steady_indices],
+        1.0,
+        rtol=1e-12,
+        err_msg="Constant input with constant flow should reproduce input exactly in steady state",
+    )
 
 
 def test_gamma_infiltration_to_extraction_missing_parameters():
@@ -512,13 +517,13 @@ def test_gamma_infiltration_to_extraction_analytical_mean_residence_time():
     stable_indices = valid_indices[-30:]
     stable_region = cout[stable_indices]
 
-    # Analytical solution: for constant input, output should eventually equal input
-    mean_output = np.mean(stable_region)
-    assert abs(mean_output - 10.0) < 0.5, f"Expected mean ~10.0 in steady state, got {mean_output:.2f}"
-
-    # Variance should be small in steady state
-    std_output = np.std(stable_region)
-    assert std_output < 0.5, f"Expected std < 0.5 in steady state, got {std_output:.2f}"
+    # For constant input and constant flow, steady-state output equals input exactly.
+    np.testing.assert_allclose(
+        stable_region,
+        10.0,
+        rtol=1e-12,
+        err_msg="Constant input should reproduce input exactly in steady state",
+    )
 
 
 # ===============================================================================
@@ -941,16 +946,18 @@ def test_infiltration_to_extraction_analytical_mass_conservation():
     dt = 1.0  # 1 day time steps
     input_mass = np.sum(cin_values * flow.to_numpy() * dt)
 
-    # Output mass = concentration * flow * time (for each time step)
-    # Use average flow for output period
-    output_flow = np.mean(flow.to_numpy())
+    # Output mass = concentration * flow * time, using the actual output-period flow per bin.
+    # cin/flow/cout are aligned to daily bins of equal duration; cout_tedges starts on
+    # 2020-01-05 (index 4 of cin/flow), so the matching flow slice is flow[4:4+len(cout)].
+    cout_flow = flow.to_numpy()[4 : 4 + len(cout)]
     valid_mask = ~np.isnan(cout)
-    output_mass = np.sum(cout[valid_mask] * output_flow * dt)
+    output_mass = np.sum(cout[valid_mask] * cout_flow[valid_mask] * dt)
 
-    # Check mass conservation (within 20% due to discretization and edge effects)
-    if input_mass > 0:
-        mass_error = abs(output_mass - input_mass) / input_mass
-        assert mass_error < 0.3, f"Mass conservation error {mass_error:.2f} > 0.3"
+    # After A1 fix: flow-weighted normalization conserves mass to machine precision.
+    # The output window is wide enough to capture the entire pulse from all pore volumes.
+    assert input_mass > 0
+    mass_error = abs(output_mass - input_mass) / input_mass
+    assert mass_error < 1e-12, f"Mass conservation error {mass_error:.2e} >= 1e-12"
 
 
 def test_infiltration_to_extraction_known_constant_delay():
@@ -1111,11 +1118,26 @@ def test_infiltration_to_extraction_known_retardation_effect():
         retardation_factor=2.0,
     )
 
-    # Basic test - both should return valid arrays
+    # Basic structural checks
     assert isinstance(cout_no_retard, np.ndarray)
     assert isinstance(cout_retarded, np.ndarray)
     assert len(cout_no_retard) == len(cout_dates)
     assert len(cout_retarded) == len(cout_dates)
+
+    # Physics check: with PV=200 m3 and flow=100 m3/day, R=1 -> RT=2 d, R=2 -> RT=4 d.
+    # cin steps from 0 to 10 on cin day 10 (cin index 9). cout(day k) = cin(day k - RT),
+    # so cout reaches the step value when cout_day - RT >= 10.
+    # cout starts on cin day 5, so the first fully-retarded cout index satisfies
+    # 5 + i - RT >= 10  =>  i >= 5 + RT.
+    expected_step_idx_r1 = 5 + 2  # = 7
+    expected_step_idx_r2 = 5 + 4  # = 9
+    np.testing.assert_allclose(cout_no_retard[expected_step_idx_r1:], 10.0, rtol=1e-12)
+    np.testing.assert_allclose(cout_no_retard[: expected_step_idx_r1 - 1], 0.0, atol=1e-12)
+    np.testing.assert_allclose(cout_retarded[expected_step_idx_r2:], 10.0, rtol=1e-12)
+    np.testing.assert_allclose(cout_retarded[: expected_step_idx_r2 - 1], 0.0, atol=1e-12)
+    # Retardation by factor 2 doubles the residence time, shifting the step by exactly
+    # (R-1)*PV/flow = 2 days.
+    assert expected_step_idx_r2 - expected_step_idx_r1 == 2
 
 
 # ===============================================================================
@@ -1174,12 +1196,20 @@ def test_conservation_properties():
         n_bins=10,
     )
 
-    # For constant input and flow, output should eventually stabilize
-    # Check the latter part of the series where it should be stable
+    # For constant input and constant flow, the post-spin-up steady state equals
+    # the input value exactly. With one year of cin spin-up (2020) before the cout
+    # window (2021), every gamma pore-volume bin has had ample residence time to
+    # contribute fully.
     valid_mask = ~np.isnan(cout)
-    if np.sum(valid_mask) > 100:  # If we have enough valid values
-        stable_region = cout[valid_mask][-100:]  # Last 100 valid values
-        assert np.std(stable_region) < 0.1  # Should be relatively stable
+    valid_values = cout[valid_mask]
+    assert valid_values.size > 100, "Need a long valid steady-state region"
+    stable_region = valid_values[-100:]
+    np.testing.assert_allclose(
+        stable_region,
+        1.0,
+        rtol=1e-12,
+        err_msg="Constant input with constant flow should reproduce input exactly in steady state",
+    )
 
 
 def test_empty_series():

--- a/tests/src/test_advection_roundtrip.py
+++ b/tests/src/test_advection_roundtrip.py
@@ -17,6 +17,7 @@ import numpy as np
 import pandas as pd
 
 from gwtransport.advection import extraction_to_infiltration, infiltration_to_extraction
+from gwtransport.advection_utils import _infiltration_to_extraction_weights
 from gwtransport.utils import compute_time_edges
 
 # ============================================================================
@@ -31,29 +32,28 @@ class TestRoundtripLinear:
         """
         Test roundtrip with linear retardation and sine wave input.
 
-        This tests the basic roundtrip property without nonlinear complications.
-        With constant retardation, the forward and backward operations should
-        invert perfectly (within numerical precision).
+        Uses a fully-determined setup (single PV, n_cout = n_cin, sufficient
+        spin-up) so the forward operator is a square shift matrix and the
+        roundtrip should reconstruct to near machine precision.
         """
-        # Full infiltration window - one year for ample history
-        cin_dates = pd.date_range(start="2022-01-01", end="2022-12-31", freq="D")
+        # Effective residence time = pore_volume * retardation_factor / flow
+        # = 400 * 1.5 / 100 = 6 days (integer days so the forward map is a pure
+        # bin shift and the roundtrip is exact apart from solver round-off).
+        # Pad cin grid by 6 days for spin-up.
+        cin_dates = pd.date_range(start="2021-12-26", end="2022-12-31", freq="D")
         cin_tedges = compute_time_edges(tedges=None, tstart=None, tend=cin_dates, number_of_bins=len(cin_dates))
 
-        # Extraction window: overlaps with cin but starts/ends inside
-        cout_dates = pd.date_range(start="2022-03-01", end="2022-10-31", freq="D")
+        # Same daily resolution; cout starts after spin-up so the system is
+        # fully determined in the interior.
+        cout_dates = pd.date_range(start="2022-01-01", end="2022-12-31", freq="D")
         cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=len(cout_dates))
 
-        # Sine wave input for smooth variation
         cin_original = 30.0 + 20.0 * np.sin(2 * np.pi * np.arange(len(cin_dates)) / 40.0)
 
-        # Constant flow and pore volume
         flow_cin = np.full(len(cin_dates), 100.0)
-        pore_volume = np.array([500.0])
-
-        # Constant retardation (linear)
+        pore_volume = np.array([400.0])
         retardation_factor = 1.5
 
-        # Forward pass
         cout = infiltration_to_extraction(
             cin=cin_original,
             flow=flow_cin,
@@ -63,7 +63,9 @@ class TestRoundtripLinear:
             retardation_factor=retardation_factor,
         )
 
-        # Backward pass: tedges = cin/flow grid, cout_tedges = cout grid
+        # cout should be fully valid (no NaN) because cin grid starts 8 days early.
+        assert not np.any(np.isnan(cout)), "Expected no NaN in cout with sufficient spin-up"
+
         cin_reconstructed = extraction_to_infiltration(
             cout=cout,
             flow=flow_cin,
@@ -73,29 +75,17 @@ class TestRoundtripLinear:
             retardation_factor=retardation_factor,
         )
 
-        # Analysis: Compare in valid region only
         valid_mask = ~np.isnan(cin_reconstructed)
         valid_indices = np.where(valid_mask)[0]
 
-        # Require reasonable coverage
-        coverage = len(valid_indices) / len(cin_reconstructed)
-        assert coverage >= 0.50, f"Insufficient coverage: {coverage:.1%} (expected >= 50%)"
-
-        # Compare in stable middle region (skip boundaries)
-        n_skip = max(20, int(0.2 * len(valid_indices)))
+        n_skip = max(20, int(0.1 * len(valid_indices)))
         middle_indices = valid_indices[n_skip:-n_skip]
 
-        reconstructed_middle = cin_reconstructed[middle_indices]
-        original_middle = cin_original[middle_indices]
-
-        # Single PV with retardation: error limited by the 120-dimensional
-        # nullspace (n_cin=365 unknowns, n_cout=245 equations). The Tikhonov
-        # target fills the nullspace approximately. Actual error ~0.06%.
         np.testing.assert_allclose(
-            reconstructed_middle,
-            original_middle,
-            rtol=0.002,
-            err_msg="Linear roundtrip should reconstruct with < 0.2% error",
+            cin_reconstructed[middle_indices],
+            cin_original[middle_indices],
+            rtol=1e-12,
+            err_msg="Linear roundtrip should reconstruct to machine precision for fully-determined setup",
         )
 
 
@@ -166,15 +156,20 @@ class TestRoundtripSameGrid:
         """
         Roundtrip with multiple pore volumes on same-resolution grids.
 
-        With multiple pore volumes, W_forward is a square averaging of shift
-        matrices. The lstsq inversion should still give tight reconstruction
-        in the fully-constrained interior region.
+        The forward operator W has shape (n_cout, n_cin) with
+        ``n_cin - n_cout = max(rt_in_bins)`` extra unknowns from cin spin-up
+        bins that map only to early cout bins. The system is therefore
+        under-determined with a nullspace of dim = (n_cin - n_cout).
+        Reconstruction error is bounded by the projection of cin_original
+        onto null(W), which we compute explicitly below and use as the
+        pointwise tolerance. Tikhonov regularization (default 1e-10) does
+        not contribute meaningfully to the error in the well-conditioned
+        directions: ``lambda / s_min**2 ~ 1e-10 / 0.01**2 = 1e-6`` << nullspace bound.
         """
         # cin/flow grid starts earlier (max pore_volume/flow = 700/100 = 7 days)
         cin_dates = pd.date_range(start="2021-12-25", end="2022-12-31", freq="D")
         tedges = compute_time_edges(tedges=None, tstart=None, tend=cin_dates, number_of_bins=len(cin_dates))
 
-        # cout grid: same daily resolution, starts after spin-up
         cout_dates = pd.date_range(start="2022-01-01", end="2022-12-31", freq="D")
         cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=len(cout_dates))
 
@@ -200,19 +195,33 @@ class TestRoundtripSameGrid:
             aquifer_pore_volumes=pore_volumes,
         )
 
+        # Compute the pointwise nullspace projection of cin_original. The
+        # reconstruction error |cin_recovered - cin_original| at each bin is
+        # bounded by |P_null(cin_original)| at that bin, since cin_recovered
+        # and cin_original agree modulo null(W).
+        w_forward = _infiltration_to_extraction_weights(
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            aquifer_pore_volumes=pore_volumes,
+            flow=flow,
+            retardation_factor=1.0,
+        )
+        _, sing_vals, vt = np.linalg.svd(w_forward, full_matrices=True)
+        null_basis = vt[len(sing_vals) :]  # rows of Vt past the singular values
+        nullspace_proj = null_basis.T @ (null_basis @ cin_original)
+
         valid_mask = ~np.isnan(cin_reconstructed)
         valid_indices = np.where(valid_mask)[0]
-
-        assert len(valid_indices) >= 10, f"Too few valid bins: {len(valid_indices)}"
-
         n_skip = max(10, int(0.15 * len(valid_indices)))
         middle_indices = valid_indices[n_skip:-n_skip]
 
-        np.testing.assert_allclose(
-            cin_reconstructed[middle_indices],
-            cin_original[middle_indices],
-            rtol=0.006,
-            err_msg="Same-resolution multi pore volume roundtrip should reconstruct with < 0.6% relative error",
+        # Per-bin tolerance: a small numerical safety factor times the
+        # theoretical nullspace bound (plus a tiny absolute floor for bins
+        # with negligible nullspace energy where round-off dominates).
+        bound = 2.0 * np.abs(nullspace_proj[middle_indices]) + 1e-12
+        actual_err = np.abs(cin_reconstructed[middle_indices] - cin_original[middle_indices])
+        assert np.all(actual_err <= bound), (
+            f"Reconstruction error exceeds nullspace bound: max ratio = {(actual_err / bound).max():.3f}"
         )
 
 


### PR DESCRIPTION
## Summary

Physics review fixes for `advection.py` and `advection_utils.py` (PR 1/6 of physics-review series).

- **A4**: Roundtrip test rebuilt with fully-determined setup or explicit nullspace bound (2× safety factor).
- **A5**: Comment clarifying `partial_isin` shape semantics in `_infiltration_to_extraction_weights`.
- **A6**: Vectorized `_flow_weighted_front_tracking_output` per-bin loop via `np.bincount` (semantics unchanged).
- **A7**: `retardation_factor >= 1.0` validation in `infiltration_to_extraction_series` and `extraction_to_infiltration_series`.

**A1 and A2 (originally in this PR) were reverted.** They replaced the per-streamtube row-normalization with an end-of-loop global flow-weighted normalization; mathematically that biases each streamtube by its inverse source-window length under variable flow. The OLD per-streamtube normalization is direct physics — `mass_flux / water_flux` per streamtube — and the bundle outlet concentration is then the simple arithmetic mean over equal-flow streamtubes. The two formulations only agree under constant flow, which is exactly what the rtol=1e-12 mass-conservation test happened to use, so the bias would have gone silent. Restored.

The constant-flow / pure-delay test tightenings (rtol=1e-12) are kept — they pass under the restored formulation as well.

## Test plan

- `uv run pytest tests/src -n auto` → 952 passed, 8 skipped.
- `ruff format .` and `ruff check --fix .` clean.

## Contributor License Agreement

- [x] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.