### PR TITLE
Fix deposition (physics review)

### DIFF
--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -1,12 +1,16 @@
 """
 Deposition Analysis for 1D Aquifer Systems.
 
-This module analyzes compound transport by deposition in aquifer systems with tools for
-computing concentrations and deposition rates based on aquifer properties. The model assumes
-1D groundwater flow where compound deposition occurs along the flow path, enriching the water.
-Deposition processes include pathogen attachment to aquifer matrix, particle filtration, or
-chemical precipitation. The module follows advection module patterns for consistency in
-forward (deposition to extraction) and reverse (extraction to deposition) calculations.
+This module models compound *source enrichment* in 1D groundwater flow: a deposition rate
+[ng/m²/day] supplies mass from the aquifer matrix into the water along the flow path,
+increasing the extracted concentration. The model is a *source* term (positive deposition
+adds mass to the water); it does NOT model removal processes such as pathogen attachment,
+particle filtration, or chemical precipitation, which would remove mass from the water and
+require an opposite sign convention. Example physical scenarios: dissolution of a sparingly
+soluble mineral coating from the matrix, leaching of a stored solute, mass release from a
+distributed contaminant source on the matrix surface. The module follows advection module
+patterns for consistency in forward (deposition to extraction) and reverse (extraction to
+deposition) calculations.
 
 Available functions:
 
@@ -32,10 +36,12 @@ Available functions:
   extraction_to_deposition (reverse). Calculates contact area between water parcels and aquifer
   matrix based on streamline geometry and residence times.
 
-- :func:`spinup_duration` - Compute spinup duration for deposition modeling. Returns residence
-  time at first time step, representing time needed for system to become fully informed. Before
-  this duration, extracted concentration lacks complete deposition history. Useful for determining
-  valid analysis period and identifying when boundary effects are negligible.
+- :func:`spinup_duration` - Compute spinup duration for deposition modeling. Returns the
+  earliest extraction time at which the extracted water was infiltrated at the start of the
+  flow series (equivalently, the time at which cumulative flow first reaches
+  ``retardation_factor * aquifer_pore_volume``). Before this duration the extracted
+  concentration lacks complete deposition history. Useful for determining the valid analysis
+  period and identifying when boundary effects are negligible.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
@@ -101,7 +107,7 @@ def compute_deposition_weights(
 
     # Compute residence times and cumulative flow
     flow_values = np.asarray(flow)
-    rt_edges = residence_time(
+    cout_rt_at_edges = residence_time(
         flow=flow_values,
         flow_tedges=tedges,
         index=cout_tedges,
@@ -109,7 +115,9 @@ def compute_deposition_weights(
         retardation_factor=retardation_factor,
         direction="extraction_to_infiltration",
     )
-    cout_tedges_days_infiltration = cout_tedges_days - rt_edges[0]
+    # residence_time returns shape (n_pore_volumes, n_index); we pass a single
+    # pore volume so select row 0 explicitly.
+    cout_tedges_days_infiltration = cout_tedges_days - cout_rt_at_edges[0, :]
 
     flow_cum = np.concatenate(([0.0], np.cumsum(flow_values * np.diff(tedges_days))))
 
@@ -595,9 +603,13 @@ def spinup_duration(
     """
     Compute the spinup duration for deposition modeling.
 
-    The spinup duration is the residence time at the first time step, representing
-    the time needed for the system to become fully informed. Before this duration,
-    the extracted concentration lacks complete deposition history.
+    The spinup duration is the smallest extraction time ``t*`` (relative to
+    ``flow_tedges[0]``) at which the extracted water was infiltrated exactly
+    at ``flow_tedges[0]``: equivalently, the time at which the cumulative
+    flow first reaches ``retardation_factor * aquifer_pore_volume``. For
+    extraction times earlier than ``t*`` the extracted concentration lacks
+    complete deposition history. Under constant flow this equals
+    ``aquifer_pore_volume * retardation_factor / flow``.
 
     Parameters
     ----------
@@ -618,20 +630,33 @@ def spinup_duration(
     Raises
     ------
     ValueError
-        If the residence time at the first time step is NaN, indicating the
-        flow timeseries is too short to fully characterise the aquifer.
+        If the cumulative flow over the entire ``flow_tedges`` window does
+        not reach ``retardation_factor * aquifer_pore_volume``, indicating
+        the flow timeseries is too short to fully characterise the aquifer.
     """
-    rt = residence_time(
-        flow=flow,
-        flow_tedges=flow_tedges,
-        aquifer_pore_volumes=aquifer_pore_volume,
-        retardation_factor=retardation_factor,
-        direction="infiltration_to_extraction",
-    )
-    rt_value: float = float(np.asarray(rt[0, 0]))
+    # Spin-up is the residence time of water *currently being extracted*: how
+    # far back in history we must know deposition to fully characterise the
+    # extracted concentration. This uses the ``extraction_to_infiltration``
+    # direction. Under variable flow this differs from
+    # ``infiltration_to_extraction`` (which would describe how long ahead
+    # water infiltrated at the first time step will take to be extracted, a
+    # forward-in-time question that is not what spin-up means).
+    #
+    # The smallest extraction time t* at which the extracted water was
+    # infiltrated exactly at flow_tedges[0] satisfies
+    # ``flow_cum(t*) = R * V_pore``; the spin-up duration is then
+    # ``t* - 0 = t*``. Inverting the cumulative flow gives this value
+    # exactly (no quantisation to flow_tedges spacing). Under constant flow
+    # this matches V*R/Q.
+    flow_arr = np.asarray(flow)
+    flow_tedges_days = np.asarray((flow_tedges - flow_tedges[0]) / np.timedelta64(1, "D"))
+    flow_cum = np.concatenate(([0.0], np.cumsum(flow_arr * np.diff(flow_tedges_days))))
+    target_cum = retardation_factor * float(aquifer_pore_volume)
+    if not flow_cum[-1] >= target_cum:
+        msg = "Residence time at the first time step is NaN. This indicates that the aquifer is not fully informed: flow timeseries too short."
+        raise ValueError(msg)
+    rt_value = float(linear_interpolate(x_ref=flow_cum, y_ref=flow_tedges_days, x_query=target_cum))
     if np.isnan(rt_value):
         msg = "Residence time at the first time step is NaN. This indicates that the aquifer is not fully informed: flow timeseries too short."
         raise ValueError(msg)
-
-    # Return the first residence time value
     return rt_value

--- a/src/gwtransport/deposition_utils.py
+++ b/src/gwtransport/deposition_utils.py
@@ -45,6 +45,10 @@ def _positive_part_integral(
     only_b_pos = (b > 0) & ~both_pos
 
     abs_diff = np.abs(a - b)
+    # Sentinel ``1.0`` avoids division by zero in the ``excess**2 / (2*safe_diff)``
+    # branch when a == b; the surrounding ``np.where`` discards this branch
+    # whenever both endpoints have the same sign (where the trapezoid formula
+    # is used instead), so the sentinel value is never observed in the output.
     safe_diff = np.where(abs_diff > 0, abs_diff, 1.0)
 
     excess = np.where(only_a_pos, a, np.where(only_b_pos, b, 0.0))

--- a/tests/src/test_deposition.py
+++ b/tests/src/test_deposition.py
@@ -82,9 +82,7 @@ def test_exact_analytical_constant_deposition():
 
     assert len(valid_result) >= 1, "Must have at least one valid result"
 
-    for actual, exp in zip(valid_result, valid_expected, strict=False):
-        rel_error = abs(actual - exp) / exp
-        assert rel_error < 1e-12, f"Expected {exp:.12f}, got {actual:.12f}, rel_error={rel_error:.2e}"
+    np.testing.assert_allclose(valid_result, valid_expected, rtol=1e-12, atol=0)
 
 
 def test_exact_analytical_varying_flow():
@@ -135,10 +133,16 @@ def test_exact_analytical_varying_flow():
     valid_expected = expected[: len(valid_result)]
 
     if len(valid_result) >= 1:
-        for actual, exp in zip(valid_result, valid_expected, strict=False):
-            rel_error = abs(actual - exp) / exp
-            # Slightly relaxed tolerance for varying flow
-            assert rel_error < 1e-6, f"Expected {exp:.6f}, got {actual:.6f}, rel_error={rel_error:.2e}"
+        # The analytical formula C = rt * D / (porosity * thickness) is exact
+        # for constant deposition: cout is the flow-weighted bin average and
+        # for constant D this reduces to D * <flow*rt>/<flow> / (porosity*
+        # thickness). In this test the cout bin lies entirely within the
+        # constant-flow tail of the series, so rt is constant within the
+        # bin and the formula collapses to rt[edge] * D / (porosity*
+        # thickness) at machine precision. There is no genuine numerical
+        # noise specific to varying flow, so a tight machine-precision
+        # tolerance is appropriate.
+        np.testing.assert_allclose(valid_result, valid_expected, rtol=1e-12, atol=0)
 
 
 def test_exact_analytical_retardation_factor():
@@ -191,9 +195,13 @@ def test_exact_analytical_retardation_factor():
         valid_expected = expected[: len(valid_result)]
 
         if len(valid_result) >= 1:
-            for actual, exp in zip(valid_result, valid_expected, strict=False):
-                rel_error = abs(actual - exp) / exp
-                assert rel_error < 1e-12, f"R={retardation_factor}: Expected {exp:.12f}, got {actual:.12f}"
+            np.testing.assert_allclose(
+                valid_result,
+                valid_expected,
+                rtol=1e-12,
+                atol=0,
+                err_msg=f"R={retardation_factor}",
+            )
 
 
 def test_perfect_roundtrip_varying_deposition_short():
@@ -374,10 +382,7 @@ def test_linearity_exact():
 
     min_len = min(len(valid_base), len(valid_double))
     if min_len >= 1:
-        for i in range(min_len):
-            expected_double = 2.0 * valid_base[i]
-            rel_error = abs(valid_double[i] - expected_double) / max(abs(expected_double), 1e-12)
-            assert rel_error < 1e-12, f"Linearity failed: 2×{valid_base[i]:.6f} ≠ {valid_double[i]:.6f}"
+        np.testing.assert_allclose(valid_double[:min_len], 2.0 * valid_base[:min_len], rtol=1e-12, atol=0)
 
 
 def test_negative_deposition_linearity():
@@ -423,10 +428,7 @@ def test_negative_deposition_linearity():
 
     min_len = min(len(valid_pos), len(valid_neg))
     if min_len >= 1:
-        for i in range(min_len):
-            expected_negative = -valid_pos[i]
-            rel_error = abs(valid_neg[i] - expected_negative) / max(abs(expected_negative), 1e-12)
-            assert rel_error < 1e-12, f"Sign reversal failed: -{valid_pos[i]:.6f} ≠ {valid_neg[i]:.6f}"
+        np.testing.assert_allclose(valid_neg[:min_len], -valid_pos[:min_len], rtol=1e-12, atol=0)
 
 
 def test_parameter_scaling_exact():
@@ -861,9 +863,10 @@ def test_extraction_to_deposition_sparse_weekly_sampling():
     # Test weekly inverse modeling - this should fail like in the notebook
     # The key is using weekly_cout_tedges for both tedges and cout_tedges
     # Should converge successfully in test environment.
-    # Rank-deficiency warning is expected for this challenging system.
+    # Rank-deficiency warning is expected for this challenging system; only
+    # that specific message is suppressed so other UserWarnings still surface.
     with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
+        warnings.filterwarnings("ignore", message=".*rank-deficient.*", category=UserWarning)
         _ = extraction_to_deposition(
             cout=weekly_concentrations,
             flow=weekly_flow_for_inverse,
@@ -899,8 +902,9 @@ def test_spinup_duration_constant_flow():
 
     # Spinup should equal residence time at first time point
     # RT = pore_volume * retardation / flow = 5000 * 1.0 / 100 = 50 days
+    # Under constant flow, V*R/Q is algebraically exact.
     expected_duration = pore_volume * retardation_factor / flow[0]
-    assert duration == pytest.approx(expected_duration, rel=0.01)
+    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
 
 
 def test_spinup_duration_with_retardation():
@@ -919,7 +923,7 @@ def test_spinup_duration_with_retardation():
     # Spinup should be longer with retardation
     # RT = 5000 * 2.0 / 100 = 100 days
     expected_duration = pore_volume * retardation_factor / flow[0]
-    assert duration == pytest.approx(expected_duration, rel=0.01)
+    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
     assert duration > 50.0  # Longer than without retardation
 
 
@@ -937,7 +941,7 @@ def test_spinup_duration_high_flow():
 
     # RT = 5000 * 1.0 / 500 = 10 days
     expected_duration = pore_volume * retardation_factor / flow[0]
-    assert duration == pytest.approx(expected_duration, rel=0.01)
+    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
     assert duration < 20.0  # Short spinup with high flow
 
 
@@ -956,7 +960,7 @@ def test_spinup_duration_low_flow():
 
     # RT = 5000 * 1.0 / 20 = 250 days
     expected_duration = pore_volume * retardation_factor / flow[0]
-    assert duration == pytest.approx(expected_duration, rel=0.01)
+    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
     assert duration > 200.0  # Long spinup with low flow
 
 
@@ -975,7 +979,43 @@ def test_spinup_duration_large_pore_volume():
 
     # RT = 20000 * 1.5 / 100 = 300 days
     expected_duration = pore_volume * retardation_factor / flow[0]
-    assert duration == pytest.approx(expected_duration, rel=0.01)
+    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
+
+
+def test_spinup_duration_variable_flow_uses_extraction_direction():
+    """Spin-up under variable flow uses extraction_to_infiltration direction.
+
+    Spin-up is the residence time of water *currently being extracted* at
+    the first valid extraction edge: the time t* such that the integrated
+    flow equals R*V_pore. The (incorrect) infiltration_to_extraction
+    direction at the first time step would describe how long water
+    infiltrated at t=0 takes to be extracted, which differs under variable
+    flow when the two endpoints span different flow regimes.
+    """
+    tedges = pd.date_range(start="2020-01-01", periods=101, freq="D")
+    pore_volume = 5000.0
+    retardation_factor = 1.0
+
+    # Slow first half (50 m³/day for 50 days -> cum=2500), fast second half
+    # (200 m³/day). Need 5000 m³ total -> 50 + (5000-2500)/200 = 62.5 days.
+    slow_then_fast = np.concatenate([np.full(50, 50.0), np.full(50, 200.0)])
+    duration = spinup_duration(
+        flow=slow_then_fast,
+        flow_tedges=tedges,
+        aquifer_pore_volume=pore_volume,
+        retardation_factor=retardation_factor,
+    )
+    np.testing.assert_allclose(duration, 62.5, rtol=0, atol=1e-12)
+
+    # Fast first half (200 m³/day) drains 5000 m³ in 25 days -> spin-up = 25.
+    fast_then_slow = np.concatenate([np.full(50, 200.0), np.full(50, 50.0)])
+    duration_asym = spinup_duration(
+        flow=fast_then_slow,
+        flow_tedges=tedges,
+        aquifer_pore_volume=pore_volume,
+        retardation_factor=retardation_factor,
+    )
+    np.testing.assert_allclose(duration_asym, 25.0, rtol=0, atol=1e-12)
 
 
 # =============================================================================

--- a/tests/src/test_deposition_utils.py
+++ b/tests/src/test_deposition_utils.py
@@ -1,5 +1,4 @@
 import numpy as np
-from numpy.testing import assert_almost_equal, assert_array_almost_equal
 
 from gwtransport.deposition_utils import compute_average_heights
 
@@ -14,7 +13,7 @@ def test_rectangle_no_clipping():
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=-1, y_upper=4)
 
     # Analytical: area = width * height = 2 * 3 = 6, avg_height = area/width = 3
-    assert_almost_equal(avg_heights[0, 0], 3.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 3.0, rtol=0, atol=1e-12)
 
 
 def test_rectangle_full_clipping():
@@ -24,11 +23,11 @@ def test_rectangle_full_clipping():
 
     # Clip completely above
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=4, y_upper=5)
-    assert_almost_equal(avg_heights[0, 0], 0.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 0.0, rtol=0, atol=1e-12)
 
     # Clip completely below
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=-2, y_upper=-1)
-    assert_almost_equal(avg_heights[0, 0], 0.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 0.0, rtol=0, atol=1e-12)
 
 
 def test_rectangle_partial_clipping():
@@ -42,11 +41,11 @@ def test_rectangle_partial_clipping():
 
     # Analytical: clipped area = width * clipped_height = 2 * 2 = 4
     # avg_height = area/width = 4/2 = 2
-    assert_almost_equal(avg_heights[0, 0], 2.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 2.0, rtol=0, atol=1e-12)
 
     # Clip top half: keep y from 0 to 2
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=-1, y_upper=2)
-    assert_almost_equal(avg_heights[0, 0], 2.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 2.0, rtol=0, atol=1e-12)
 
 
 def test_trapezoid_no_clipping():
@@ -59,7 +58,7 @@ def test_trapezoid_no_clipping():
 
     # Analytical: trapezoid area = 0.5 * (left + right) * width = 0.5 * (4 + 2) * 3 = 9
     # avg_height = area/width = 9/3 = 3
-    assert_almost_equal(avg_heights[0, 0], 3.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 3.0, rtol=0, atol=1e-12)
 
 
 def test_trapezoid_with_clipping():
@@ -74,7 +73,7 @@ def test_trapezoid_with_clipping():
     # Analytical: The original trapezoid has a sloped top edge from (0,6) to (2,4)
     # When clipped at y=5, this creates a pentagonal region with area = 7.5
     # Average height = 7.5 / 2 = 3.75
-    assert_almost_equal(avg_heights[0, 0], 3.75)
+    np.testing.assert_allclose(avg_heights[0, 0], 3.75, rtol=0, atol=1e-12)
 
 
 def test_triangle_cases():
@@ -102,7 +101,7 @@ def test_multiple_quads():
     # Top row: quads from y=1 to y=2, clipped to y=1 to y=1.5 (height=0.5)
     # Bottom row: quads from y=0 to y=1, clipped to y=0.5 to y=1 (height=0.5)
     expected = 0.5 * np.ones((2, 2))
-    assert_array_almost_equal(avg_heights, expected)
+    np.testing.assert_allclose(avg_heights, expected, rtol=0, atol=1e-12)
 
 
 def test_zero_width_handling():
@@ -115,7 +114,7 @@ def test_zero_width_handling():
     # First column: zero width produces NaN (area/0), check if properly handled
     assert np.isnan(avg_heights[0, 0]) or avg_heights[0, 0] == 0
     # Second column: normal rectangle
-    assert_almost_equal(avg_heights[0, 1], 2.0)
+    np.testing.assert_allclose(avg_heights[0, 1], 2.0, rtol=0, atol=1e-12)
 
 
 def test_edge_case_bounds():
@@ -125,15 +124,15 @@ def test_edge_case_bounds():
 
     # Bounds exactly match quad
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=0, y_upper=2)
-    assert_almost_equal(avg_heights[0, 0], 2.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 2.0, rtol=0, atol=1e-12)
 
     # Lower bound exactly at bottom
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=0, y_upper=3)
-    assert_almost_equal(avg_heights[0, 0], 2.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 2.0, rtol=0, atol=1e-12)
 
     # Upper bound exactly at top
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=-1, y_upper=2)
-    assert_almost_equal(avg_heights[0, 0], 2.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 2.0, rtol=0, atol=1e-12)
 
 
 def test_sloped_quad():
@@ -149,7 +148,7 @@ def test_sloped_quad():
     # With corners: (0,1), (2,2), (2,4), (0,3)
     # area = 0.5 * |0*(2-3) + 2*(4-1) + 2*(3-2) + 0*(1-4)| = 0.5 * |0 + 6 + 2 + 0| = 4
     # avg_height = area/width = 4/2 = 2
-    assert_almost_equal(avg_heights[0, 0], 2.0)
+    np.testing.assert_allclose(avg_heights[0, 0], 2.0, rtol=0, atol=1e-12)
 
 
 def test_conservation_property():
@@ -165,7 +164,7 @@ def test_conservation_property():
     upper_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=2, y_upper=4)
 
     # Conservation: lower + upper should equal full
-    assert_almost_equal(lower_heights[0, 0] + upper_heights[0, 0], full_heights[0, 0])
+    np.testing.assert_allclose(lower_heights[0, 0] + upper_heights[0, 0], full_heights[0, 0], rtol=0, atol=1e-12)
 
 
 def test_upper_clip_left_to_right_crossing():
@@ -180,7 +179,7 @@ def test_upper_clip_left_to_right_crossing():
 
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=0, y_upper=5)
 
-    assert_almost_equal(avg_heights[0, 0], 4.5)
+    np.testing.assert_allclose(avg_heights[0, 0], 4.5, rtol=0, atol=1e-12)
 
 
 def test_lower_clip_crossing():
@@ -205,7 +204,7 @@ def test_lower_clip_crossing():
 
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=0, y_upper=10)
 
-    assert_almost_equal(avg_heights[0, 0], 1.5)
+    np.testing.assert_allclose(avg_heights[0, 0], 1.5, rtol=0, atol=1e-12)
 
 
 def test_upper_clip_right_to_left_crossing():
@@ -219,4 +218,4 @@ def test_upper_clip_right_to_left_crossing():
 
     avg_heights = compute_average_heights(x_edges=x_edges, y_edges=y_edges, y_lower=0, y_upper=5)
 
-    assert_almost_equal(avg_heights[0, 0], 4.5)
+    np.testing.assert_allclose(avg_heights[0, 0], 4.5, rtol=0, atol=1e-12)


### PR DESCRIPTION
## Summary

Physics review fixes for `deposition.py` and `deposition_utils.py` (PR 2/6 of physics-review series).

- **D1**: `spinup_duration` now uses extraction-to-infiltration semantics — returns smallest extraction time t* where flow_cum(t*) = R*aquifer_pore_volume (was previously misnamed and using forward semantics).
- **D2**: Tightened varying-flow tolerance from 1e-6 to 1e-12.
- **D3**: Rewrote module docstring to clarify it models source enrichment (not removal).
- **D4**: Renamed `rt_edges` → `cout_rt_at_edges`; added explicit `[0, :]` indexing for clarity.
- **D5**: Tightened test tolerances; vectorized zip + relative-error loops.
- **D6**: Documented `safe_diff` sentinel; scoped `warnings.simplefilter`.

## Test plan

- `uv run pytest tests/src -n auto` — all tests pass (machine-precision tolerances).
- `uv run pytest tests/examples -n auto` — example notebooks pass.
- `ruff format .` and `ruff check --fix .` clean.

## Contributor License Agreement

- [x] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.