### PR TITLE
Fix diffusion (physics review)

### DIFF
--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -47,7 +47,6 @@ import warnings
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from numpy.typing import NDArray
 from scipy import special
 
 from gwtransport import gamma
@@ -62,11 +61,11 @@ _GL_NODES, _GL_WEIGHTS = np.polynomial.legendre.leggauss(16)
 
 
 def _erf_integral_space(
-    x: NDArray[np.float64],
+    x: npt.NDArray[np.float64],
     diffusivity: npt.ArrayLike,
-    t: NDArray[np.float64],
+    t: npt.NDArray[np.float64],
     clip_to_inf: float = 6.0,
-) -> NDArray[np.float64]:
+) -> npt.NDArray[np.float64]:
     """Compute the integral of the error function at each (x[i], t[i], D[i]) point.
 
     This function computes the integral of erf from 0 to x[i] at time t[i],
@@ -138,17 +137,17 @@ def _erf_integral_space(
 
 def _erf_mean_volume(
     *,
-    step_widths: NDArray[np.float64],
-    raw_time: NDArray[np.float64],
-    rt_at_cin_edges: NDArray[np.float64],
-    diffusivity: NDArray[np.float64],
-    cumulative_volume_at_cout_tedges: NDArray[np.float64],
-    cumulative_volume_at_cin_tedges: NDArray[np.float64],
-    tedges_days: NDArray[np.float64],
+    step_widths: npt.NDArray[np.float64],
+    raw_time: npt.NDArray[np.float64],
+    rt_at_cin_edges: npt.NDArray[np.float64],
+    diffusivity: npt.NDArray[np.float64],
+    cumulative_volume_at_cout_tedges: npt.NDArray[np.float64],
+    cumulative_volume_at_cin_tedges: npt.NDArray[np.float64],
+    tedges_days: npt.NDArray[np.float64],
     r_vpv: float,
     streamline_len: float,
     asymptotic_cutoff_sigma: float | None,
-) -> NDArray[np.float64]:
+) -> npt.NDArray[np.float64]:
     r"""Compute mean erf along the physical trajectory in cumulative volume space.
 
     For each cell (cout_bin *i*, cin_edge *j*), computes the flow-weighted

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -66,7 +66,6 @@ import warnings
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from numpy.typing import NDArray
 from scipy import sparse
 from scipy.special import erf
 
@@ -94,7 +93,7 @@ def infiltration_to_extraction(
     asymptotic_cutoff_sigma: float | None = 3.0,
     flow_out: npt.ArrayLike | None = None,
     suppress_uniform_tedges_check: bool = False,
-) -> NDArray[np.floating]:
+) -> npt.NDArray[np.floating]:
     """Compute diffusion during 1D transport using fast Gaussian smoothing.
 
     Combines advection (via pore volume distribution) with diffusion (via Gaussian
@@ -156,6 +155,18 @@ def infiltration_to_extraction(
         and longitudinal_dispersivity.
     extraction_to_infiltration : Inverse operation
     :ref:`concept-dispersion-scales` : Macrodispersion vs microdispersion
+
+    Notes
+    -----
+    A single ``mean_streamline_length`` is shared across all pore volumes. This
+    assumes streamline-length heterogeneity is captured solely through the
+    pore-volume distribution: the effective cross-sectional area
+    ``A_eff = V_p / L_mean`` varies with V_p while the path length L is held
+    fixed. This is appropriate for many systems but breaks down for
+    partially-penetrating wells or wedge-shaped capture zones, where path
+    length itself varies between streamtubes. In those cases, use
+    :func:`gwtransport.diffusion.infiltration_to_extraction` with a per-streamtube
+    ``streamline_length`` array instead.
     """
     # Convert inputs
     cout_tedges = pd.DatetimeIndex(cout_tedges)
@@ -268,7 +279,7 @@ def extraction_to_infiltration(
     regularization_strength: float = 1e-10,
     flow_out: npt.ArrayLike | None = None,
     suppress_uniform_tedges_check: bool = False,
-) -> NDArray[np.floating]:
+) -> npt.NDArray[np.floating]:
     """Reconstruct infiltration concentration from extracted water via Tikhonov inversion.
 
     Inverts the forward transport model (Gaussian diffusion + advection) by building
@@ -339,6 +350,18 @@ def extraction_to_infiltration(
         that supports per-pore-volume arrays for streamline_length, molecular_diffusivity,
         and longitudinal_dispersivity.
     :ref:`concept-dispersion-scales` : Macrodispersion vs microdispersion
+
+    Notes
+    -----
+    A single ``mean_streamline_length`` is shared across all pore volumes. This
+    assumes streamline-length heterogeneity is captured solely through the
+    pore-volume distribution: the effective cross-sectional area
+    ``A_eff = V_p / L_mean`` varies with V_p while the path length L is held
+    fixed. This is appropriate for many systems but breaks down for
+    partially-penetrating wells or wedge-shaped capture zones, where path
+    length itself varies between streamtubes. In those cases, use
+    :func:`gwtransport.diffusion.extraction_to_infiltration` with a per-streamtube
+    ``streamline_length`` array instead.
     """
     # Convert inputs
     tedges = pd.DatetimeIndex(tedges)
@@ -447,7 +470,7 @@ def gamma_infiltration_to_extraction(
     asymptotic_cutoff_sigma: float | None = 3.0,
     flow_out: npt.ArrayLike | None = None,
     suppress_uniform_tedges_check: bool = False,
-) -> NDArray[np.floating]:
+) -> npt.NDArray[np.floating]:
     """
     Compute extracted concentration with fast Gaussian diffusion for gamma-distributed pore volumes.
 
@@ -607,7 +630,7 @@ def gamma_extraction_to_infiltration(
     regularization_strength: float = 1e-10,
     flow_out: npt.ArrayLike | None = None,
     suppress_uniform_tedges_check: bool = False,
-) -> NDArray[np.floating]:
+) -> npt.NDArray[np.floating]:
     """
     Reconstruct infiltration concentration from extracted water for gamma-distributed pore volumes.
 
@@ -759,7 +782,7 @@ def _compute_sigma(
     longitudinal_dispersivity: float,
     retardation_factor: float,
     direction: str,
-) -> NDArray[np.floating]:
+) -> npt.NDArray[np.floating]:
     """Compute sigma in array-index units with moment-based averaging.
 
     The per-streamtube variance of the Gaussian kernel (in index units)
@@ -831,10 +854,12 @@ def _compute_sigma(
     var_numerator = mol_var_x / mean_pv * ev3 + disp_var_x * ev2
 
     timedelta = np.diff(tedges) / pd.to_timedelta(1, unit="D")
-    dx_ref = flow * timedelta * streamline_length / retardation_factor
+    # q_dt_l_over_r = Q * dt * L / R has units m^4 (it is the squared scaling
+    # factor that converts spatial variance [m^2] into index-space variance).
+    q_dt_l_over_r = flow * timedelta * streamline_length / retardation_factor
 
     with np.errstate(invalid="ignore", divide="ignore"):
-        sigma_sq = np.where(dx_ref > 0.0, var_numerator / dx_ref**2, 0.0)
+        sigma_sq = np.where(q_dt_l_over_r > 0.0, var_numerator / q_dt_l_over_r**2, 0.0)
 
     return np.clip(np.sqrt(np.maximum(sigma_sq, 0.0)), 0.0, 100.0)
 
@@ -916,9 +941,6 @@ def _build_gaussian_matrix(
     erf_at_edges = erf(edges[np.newaxis, :] / (sigmas * sqrt2))  # (n_valid, 2*max_radius+2)
     weights = 0.5 * np.diff(erf_at_edges, axis=1)  # (n_valid, 2*max_radius+1)
 
-    # Normalize each kernel
-    weights /= np.sum(weights, axis=1)[:, np.newaxis]
-
     # Calculate absolute positions in the signal
     absolute_positions = center_positions + kernel_positions
 
@@ -943,12 +965,20 @@ def _build_gaussian_matrix(
         cols = np.concatenate([cols, zero_indices])
         data = np.concatenate([data, np.ones(len(zero_indices))])
 
-    return sparse.csr_matrix((data, (rows, cols)), shape=(n, n))
+    matrix = sparse.csr_matrix((data, (rows, cols)), shape=(n, n))
+
+    # Renormalize rows AFTER boundary clipping. Clipping folds out-of-bounds
+    # kernel positions into the first/last bins, so the post-clip row sums
+    # generally exceed 1. Dividing by the row sum ensures every row sums to
+    # exactly 1, preventing artificial mass creation at the boundaries.
+    row_sums = np.asarray(matrix.sum(axis=1)).ravel()
+    inv_row_sums = np.where(row_sums > 0, 1.0 / row_sums, 0.0)
+    return sparse.diags(inv_row_sums) @ matrix
 
 
 def convolve_diffusion(
     *, input_signal: npt.ArrayLike, sigma_array: npt.ArrayLike, asymptotic_cutoff_sigma: float | None = 3.0
-) -> NDArray[np.floating]:
+) -> npt.NDArray[np.floating]:
     """Apply Gaussian filter with position-dependent sigma values.
 
     This function extends scipy.ndimage.gaussian_filter1d by allowing the standard
@@ -1029,7 +1059,7 @@ def create_example_data(
     domain_length: float = 10.0,
     diffusivity: float = 0.1,
     seed: int | None = None,
-) -> tuple[NDArray[np.floating], NDArray[np.floating], NDArray[np.floating], NDArray[np.floating]]:
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
     """Create example data for demonstrating variable-sigma diffusion.
 
     Parameters
@@ -1116,6 +1146,9 @@ def _validate_inputs(
         raise ValueError(msg)
     if np.any(np.isnan(flow)):
         msg = "flow contains NaN values, which are not allowed"
+        raise ValueError(msg)
+    if np.any(flow <= 0):
+        msg = "flow must be positive"
         raise ValueError(msg)
     if np.any(aquifer_pore_volumes <= 0):
         msg = "aquifer_pore_volumes must be positive"

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -941,6 +941,9 @@ def _build_gaussian_matrix(
     erf_at_edges = erf(edges[np.newaxis, :] / (sigmas * sqrt2))  # (n_valid, 2*max_radius+2)
     weights = 0.5 * np.diff(erf_at_edges, axis=1)  # (n_valid, 2*max_radius+1)
 
+    # Normalize each kernel
+    weights /= np.sum(weights, axis=1)[:, np.newaxis]
+
     # Calculate absolute positions in the signal
     absolute_positions = center_positions + kernel_positions
 
@@ -965,15 +968,7 @@ def _build_gaussian_matrix(
         cols = np.concatenate([cols, zero_indices])
         data = np.concatenate([data, np.ones(len(zero_indices))])
 
-    matrix = sparse.csr_matrix((data, (rows, cols)), shape=(n, n))
-
-    # Renormalize rows AFTER boundary clipping. Clipping folds out-of-bounds
-    # kernel positions into the first/last bins, so the post-clip row sums
-    # generally exceed 1. Dividing by the row sum ensures every row sums to
-    # exactly 1, preventing artificial mass creation at the boundaries.
-    row_sums = np.asarray(matrix.sum(axis=1)).ravel()
-    inv_row_sums = np.where(row_sums > 0, 1.0 / row_sums, 0.0)
-    return sparse.diags(inv_row_sums) @ matrix
+    return sparse.csr_matrix((data, (rows, cols)), shape=(n, n))
 
 
 def convolve_diffusion(
@@ -1147,8 +1142,8 @@ def _validate_inputs(
     if np.any(np.isnan(flow)):
         msg = "flow contains NaN values, which are not allowed"
         raise ValueError(msg)
-    if np.any(flow <= 0):
-        msg = "flow must be positive"
+    if np.any(flow < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
         raise ValueError(msg)
     if np.any(aquifer_pore_volumes <= 0):
         msg = "aquifer_pore_volumes must be positive"

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -102,10 +102,12 @@ class TestInfiltrationToExtractionDiffusion:
             molecular_diffusivity=0.01,
             longitudinal_dispersivity=0.0,
         )
-        # Should be close but not identical
-        # Use atol for near-zero values where rtol would be too strict
+        # With D_m=0.01 m²/day and tau=5 days, the spatial spreading is
+        # sqrt(2*D_m*tau) ≈ 0.32 m on a 100 m streamline (< 0.4% of domain).
+        # Use atol since cin contains step transitions where the diffused
+        # values cross zero — rtol is meaningless near-zero.
         valid = ~np.isnan(cout_advection) & ~np.isnan(cout_diffusion)
-        np.testing.assert_allclose(cout_advection[valid], cout_diffusion[valid], rtol=0.1, atol=0.01)
+        np.testing.assert_allclose(cout_advection[valid], cout_diffusion[valid], atol=0.01)
 
     def test_larger_diffusivity_more_spreading(self, simple_setup):
         """Test that larger diffusivity causes more spreading."""
@@ -118,7 +120,6 @@ class TestInfiltrationToExtractionDiffusion:
             streamline_length=simple_setup["streamline_length"],
             molecular_diffusivity=0.1,
             longitudinal_dispersivity=0.0,
-            retardation_factor=2.0,
         )
         cout_large_d = infiltration_to_extraction(
             cin=simple_setup["cin"],
@@ -130,12 +131,20 @@ class TestInfiltrationToExtractionDiffusion:
             molecular_diffusivity=10.0,
             longitudinal_dispersivity=0.0,
         )
-        # With larger diffusivity, the breakthrough curve should be more spread out
-        # This means the maximum should be lower and the tails should be higher
+        # With larger diffusivity, the breakthrough curve should be more spread out.
+        # Both peaks saturate at the input plateau (1.0), so compare the variance
+        # of the breakthrough — wider spreading produces larger variance about
+        # the centre of mass of the breakthrough.
         valid = ~np.isnan(cout_small_d) & ~np.isnan(cout_large_d)
-        max_small = np.max(cout_small_d[valid])
-        max_large = np.max(cout_large_d[valid])
-        assert max_large <= max_small  # More spreading = lower peak
+        idx = np.arange(len(cout_small_d))[valid]
+        small = cout_small_d[valid]
+        large = cout_large_d[valid]
+        # Centre of mass and second moment of each breakthrough
+        com_small = np.sum(idx * small) / np.sum(small)
+        com_large = np.sum(idx * large) / np.sum(large)
+        var_small = np.sum((idx - com_small) ** 2 * small) / np.sum(small)
+        var_large = np.sum((idx - com_large) ** 2 * large) / np.sum(large)
+        assert var_large > var_small  # More spreading = larger variance
 
     def test_output_bounded_by_input(self, simple_setup):
         """Test that output concentrations are bounded by input range."""
@@ -212,6 +221,53 @@ class TestInfiltrationToExtractionDiffusion:
         # Output should be bounded
         assert np.all(cout[valid] >= 0.0 - 1e-10)
         assert np.all(cout[valid] <= 1.0 + 1e-10)
+
+    def test_heterogeneous_streamline_length(self):
+        """Heterogeneous L (per-streamtube) yields distinct breakthrough vs single mean L.
+
+        Per-streamtube L allows residence time tau = V_p / Q to be paired with
+        the corresponding L for diffusion variance sigma^2 = 2*D*tau*L^2 in
+        spatial form. A single mean L applied to all streamtubes loses this
+        coupling, so the breakthrough should differ when V_p and L vary.
+        """
+        tedges = pd.date_range(start="2020-01-01", end="2020-02-01", freq="D")
+        cout_tedges = pd.date_range(start="2020-01-01", end="2020-02-15", freq="D")
+
+        cin = np.zeros(len(tedges) - 1)
+        cin[0:5] = 1.0
+        flow = np.ones(len(tedges) - 1) * 100.0
+
+        aquifer_pore_volumes = np.array([400.0, 500.0, 600.0])
+        streamline_length_hetero = np.array([80.0, 100.0, 120.0])
+        # Single mean L applied to all streamtubes
+        streamline_length_single = np.full(3, np.mean(streamline_length_hetero))
+
+        kwargs = {
+            "cin": cin,
+            "flow": flow,
+            "tedges": tedges,
+            "cout_tedges": cout_tedges,
+            "aquifer_pore_volumes": aquifer_pore_volumes,
+            "molecular_diffusivity": 1.0,
+            "longitudinal_dispersivity": 0.0,
+        }
+
+        cout_hetero = infiltration_to_extraction(streamline_length=streamline_length_hetero, **kwargs)
+        cout_single = infiltration_to_extraction(streamline_length=streamline_length_single, **kwargs)
+
+        # Both should be valid and bounded
+        valid = ~np.isnan(cout_hetero) & ~np.isnan(cout_single)
+        assert np.sum(valid) > 0
+        assert np.all(cout_hetero[valid] >= -1e-10)
+        assert np.all(cout_single[valid] >= -1e-10)
+
+        # Heterogeneous and single-L results should be physically distinct,
+        # demonstrating the per-streamtube L coupling matters.
+        assert not np.allclose(cout_hetero[valid], cout_single[valid], atol=1e-3)
+
+        # Both outputs should be bounded by the input range (convex combination).
+        assert np.all(cout_hetero[valid] <= np.max(cin) + 1e-10)
+        assert np.all(cout_single[valid] <= np.max(cin) + 1e-10)
 
     def test_input_validation(self, simple_setup):
         """Test that invalid inputs raise appropriate errors."""
@@ -344,7 +400,7 @@ class TestInfiltrationToExtractionDiffusionPhysics:
 
         # Mass is conserved: the forward matrix rows sum to 1 for fully
         # resolved bins, and the cout grid extends beyond all breakthrough.
-        assert abs(mass_out - mass_in) / mass_in < 1e-10
+        np.testing.assert_allclose(mass_out, mass_in, rtol=1e-10)
 
     def test_retardation_delays_breakthrough(self):
         """Test that retardation factor delays the breakthrough."""
@@ -578,9 +634,9 @@ class TestDiffusionMatchesApvdCombined:
             longitudinal_dispersivity=0.0,
         )
 
-        # Should conserve mass
+        # Should conserve mass exactly (forward matrix rows sum to 1)
         mass = np.nansum(cout_zero_disp)
-        np.testing.assert_allclose(mass, 100.0, rtol=0.05, err_msg="Mass should be conserved")
+        np.testing.assert_allclose(mass, 100.0, rtol=1e-10, err_msg="Mass should be conserved")
 
     def test_increased_dispersion_broadens_curve(self):
         """Test that higher dispersion causes broader, lower-peak breakthrough."""
@@ -715,9 +771,12 @@ class TestDiffusionMatchesApvdCombined:
         # levels but means mass is not conserved until all bins are informed.
         mass_diffusion = np.nansum(cout_diffusion)
         np.testing.assert_allclose(mass_diffusion, 100.0, rtol=0.01)
-        # Check that advection mass is close to 100 (within ~10% due to spin-up amplification)
+        # The advection module's gamma_i2e amplifies mass by ~9.14% due to
+        # spin-up: it normalizes by the number of contributing bins rather than
+        # by total bins, which preserves concentration levels but inflates
+        # the integrated mass during the spin-up window.
         mass_apvd = np.nansum(cout_apvd)
-        np.testing.assert_allclose(mass_apvd, 100.0, rtol=0.15)
+        np.testing.assert_allclose(mass_apvd, 100.0, rtol=0.10)
 
 
 class TestExtractionToInfiltrationDiffusion:
@@ -794,9 +853,12 @@ class TestExtractionToInfiltrationDiffusion:
             molecular_diffusivity=0.01,
             longitudinal_dispersivity=0.0,
         )
-        # Should be close but not identical
+        # With D_m=0.01 m²/day and tau=5 days, the spatial spreading is
+        # sqrt(2*D_m*tau) ≈ 0.32 m on a 100 m streamline (< 0.4% of domain).
+        # Use atol since cout contains step transitions where the diffused
+        # values cross zero — rtol is meaningless near-zero.
         valid = ~np.isnan(cin_advection) & ~np.isnan(cin_diffusion)
-        np.testing.assert_allclose(cin_advection[valid], cin_diffusion[valid], rtol=0.1, atol=0.01)
+        np.testing.assert_allclose(cin_advection[valid], cin_diffusion[valid], atol=0.01)
 
     def test_output_bounded_by_input(self, simple_setup):
         """Test that output concentrations are bounded by input range."""

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -1219,66 +1219,6 @@ def test_diffusion_fast_vs_diffusion_same_grid():
     assert_allclose(cout_fast_step[both_valid_step], cout_exact_step[both_valid_step], atol=0.02)
 
 
-def test_boundary_clipping_then_normalize_matches_exact_at_edges():
-    """Boundary-near values agree with the exact diffusion module.
-
-    Verifies that the row-normalization in ``_build_gaussian_matrix`` is applied
-    AFTER nearest-neighbor boundary clipping. If normalization were applied
-    BEFORE clipping (the previous incorrect order), a constant input would
-    no longer be reproduced exactly near the input boundaries.
-    """
-    n_days = 200
-    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
-    cout_tedges = tedges.copy()
-    flow = np.full(n_days, 100.0)
-
-    common_kwargs = {
-        "flow": flow,
-        "tedges": tedges,
-        "cout_tedges": cout_tedges,
-        "aquifer_pore_volumes": np.array([500.0]),
-    }
-
-    # Constant input must yield constant output across every valid index,
-    # including those at and near the validity-mask boundary, because the
-    # forward matrix rows must sum to 1 after clipping AND normalization.
-    cin_const = np.full(n_days, 7.0)
-    cout_fast = infiltration_to_extraction(
-        cin=cin_const,
-        **common_kwargs,
-        mean_streamline_length=80.0,
-        mean_molecular_diffusivity=0.05,
-        mean_longitudinal_dispersivity=0.0,
-    )
-    valid_fast = ~np.isnan(cout_fast)
-    # Strict machine-precision equality at every valid index, including edges.
-    assert_allclose(cout_fast[valid_fast], 7.0, atol=1e-12)
-
-    # Cross-check against the exact module on the same grid: a smooth signal
-    # near the simulation start (where boundary clipping kicks in) must agree.
-    cin_smooth = np.sin(np.linspace(0, 4 * np.pi, n_days)) + 2.0
-    cout_fast = infiltration_to_extraction(
-        cin=cin_smooth,
-        **common_kwargs,
-        mean_streamline_length=80.0,
-        mean_molecular_diffusivity=0.05,
-        mean_longitudinal_dispersivity=0.0,
-    )
-    cout_exact = diffusion_exact(
-        cin=cin_smooth,
-        **common_kwargs,
-        streamline_length=np.array([80.0]),
-        molecular_diffusivity=0.05,
-        longitudinal_dispersivity=0.0,
-    )
-    both_valid = ~np.isnan(cout_fast) & ~np.isnan(cout_exact)
-    valid_idx = np.where(both_valid)[0]
-    # Near-boundary window: first 5 valid indices must agree to within the
-    # same Gaussian-vs-erf approximation tolerance as the bulk (no edge spike).
-    edge_idx = valid_idx[:5]
-    assert_allclose(cout_fast[edge_idx], cout_exact[edge_idx], atol=2e-3)
-
-
 # =============================================================================
 # Tests for flow_out (advect-then-smooth) algorithm
 # =============================================================================

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -1219,6 +1219,66 @@ def test_diffusion_fast_vs_diffusion_same_grid():
     assert_allclose(cout_fast_step[both_valid_step], cout_exact_step[both_valid_step], atol=0.02)
 
 
+def test_boundary_clipping_then_normalize_matches_exact_at_edges():
+    """Boundary-near values agree with the exact diffusion module.
+
+    Verifies that the row-normalization in ``_build_gaussian_matrix`` is applied
+    AFTER nearest-neighbor boundary clipping. If normalization were applied
+    BEFORE clipping (the previous incorrect order), a constant input would
+    no longer be reproduced exactly near the input boundaries.
+    """
+    n_days = 200
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    cout_tedges = tedges.copy()
+    flow = np.full(n_days, 100.0)
+
+    common_kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([500.0]),
+    }
+
+    # Constant input must yield constant output across every valid index,
+    # including those at and near the validity-mask boundary, because the
+    # forward matrix rows must sum to 1 after clipping AND normalization.
+    cin_const = np.full(n_days, 7.0)
+    cout_fast = infiltration_to_extraction(
+        cin=cin_const,
+        **common_kwargs,
+        mean_streamline_length=80.0,
+        mean_molecular_diffusivity=0.05,
+        mean_longitudinal_dispersivity=0.0,
+    )
+    valid_fast = ~np.isnan(cout_fast)
+    # Strict machine-precision equality at every valid index, including edges.
+    assert_allclose(cout_fast[valid_fast], 7.0, atol=1e-12)
+
+    # Cross-check against the exact module on the same grid: a smooth signal
+    # near the simulation start (where boundary clipping kicks in) must agree.
+    cin_smooth = np.sin(np.linspace(0, 4 * np.pi, n_days)) + 2.0
+    cout_fast = infiltration_to_extraction(
+        cin=cin_smooth,
+        **common_kwargs,
+        mean_streamline_length=80.0,
+        mean_molecular_diffusivity=0.05,
+        mean_longitudinal_dispersivity=0.0,
+    )
+    cout_exact = diffusion_exact(
+        cin=cin_smooth,
+        **common_kwargs,
+        streamline_length=np.array([80.0]),
+        molecular_diffusivity=0.05,
+        longitudinal_dispersivity=0.0,
+    )
+    both_valid = ~np.isnan(cout_fast) & ~np.isnan(cout_exact)
+    valid_idx = np.where(both_valid)[0]
+    # Near-boundary window: first 5 valid indices must agree to within the
+    # same Gaussian-vs-erf approximation tolerance as the bulk (no edge spike).
+    edge_idx = valid_idx[:5]
+    assert_allclose(cout_fast[edge_idx], cout_exact[edge_idx], atol=2e-3)
+
+
 # =============================================================================
 # Tests for flow_out (advect-then-smooth) algorithm
 # =============================================================================


### PR DESCRIPTION
## Summary

Physics review fixes for `diffusion.py` and `diffusion_fast.py` (PR 3/6 of physics-review series).

### Kept
- **F3**: Tightened tolerances; documented honest 10% tolerance for gamma_i2e advection-mass spinup amplification.
- **F5**: Renamed `dx_ref` → `q_dt_l_over_r` to reflect actual units (m^4).
- **F6**: Added Notes sections documenting the single-streamline-length assumption (`A_eff = V_p / L_mean`).
- **F7**: New `test_heterogeneous_streamline_length` regression test.
- **F8**: Removed redundant `from numpy.typing import NDArray`.

### Reverted / changed after review
- **F1 reverted**: pre-clip vs post-clip Gaussian kernel normalization is a mathematical no-op (verified machine-precision difference of 1.11e-16). The shipped regression test passed against unchanged main, so it solved a non-existent problem. `_build_gaussian_matrix` restored to main verbatim and the misleading boundary-clipping test removed.
- **F2 relaxed**: original guard `flow <= 0` rejected zero flow, but `flow == 0` is mathematically valid (no transport during the bin) and `_compute_sigma`'s `np.where` already handles it. New guard rejects only `flow < 0` with the message `"flow must be non-negative (negative flow not supported)"`. A follow-up PR will apply the same `flow < 0` rule uniformly across `advection`, `diffusion`, `deposition`, and `fronttracking`.

## Test plan

- `uv run pytest tests/src -n auto` → 953 passed, 8 skipped.
- `ruff format .` and `ruff check --fix .` clean.

## Contributor License Agreement

- [x] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.