### PR TITLE
Unify negative-flow guards and zero-flow handling

### DIFF
--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -839,12 +839,15 @@ def infiltration_to_extraction(
     if np.any(np.isnan(flow)):
         msg = "flow contains NaN values, which are not allowed"
         raise ValueError(msg)
+    if np.any(flow < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
+        raise ValueError(msg)
     if retardation_factor < 1.0:
         msg = "retardation_factor must be >= 1.0"
         raise ValueError(msg)
 
     # Compute normalized weights (includes all pre-computation)
-    normalized_weights = _infiltration_to_extraction_weights(
+    normalized_weights, spinup_mask = _infiltration_to_extraction_weights(
         tedges=tedges,
         cout_tedges=cout_tedges,
         aquifer_pore_volumes=aquifer_pore_volumes,
@@ -852,11 +855,11 @@ def infiltration_to_extraction(
         retardation_factor=retardation_factor,
     )
 
-    # Apply to concentrations and handle NaN for periods with no contributions
+    # Apply to concentrations. Spin-up rows (no streamtube traced back into
+    # the cin range) become NaN; zero-flow rows naturally produce 0 from the
+    # zero weight row.
     out = normalized_weights.dot(cin)
-    # Set NaN where no valid pore volumes contributed
-    total_weights = np.sum(normalized_weights, axis=1)
-    out[total_weights == 0] = np.nan
+    out[spinup_mask] = np.nan
 
     return out
 
@@ -1036,7 +1039,7 @@ def extraction_to_infiltration(
     n_cin = len(tedges) - 1
 
     # Build forward weight matrix: W_forward @ cin = cout
-    w_forward = _infiltration_to_extraction_weights(
+    w_forward, _ = _infiltration_to_extraction_weights(
         tedges=tedges,
         cout_tedges=cout_tedges,
         aquifer_pore_volumes=aquifer_pore_volumes,
@@ -1107,11 +1110,11 @@ def _validate_front_tracking_inputs(
     if np.any(cin < 0):
         msg = "cin must be non-negative"
         raise ValueError(msg)
-    if np.any(flow <= 0):
-        msg = "flow must be positive"
-        raise ValueError(msg)
     if np.any(np.isnan(cin)) or np.any(np.isnan(flow)):
         msg = "cin and flow must not contain NaN"
+        raise ValueError(msg)
+    if np.any(flow < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
         raise ValueError(msg)
     if np.any(aquifer_pore_volumes <= 0):
         msg = "aquifer_pore_volumes must be positive"

--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -24,7 +24,7 @@ def _infiltration_to_extraction_weights(
     aquifer_pore_volumes: npt.NDArray[np.floating],
     flow: npt.NDArray[np.floating],
     retardation_factor: float,
-) -> npt.NDArray[np.floating]:
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.bool_]]:
     """
     Compute normalized weights for linear infiltration to extraction transformation.
 
@@ -49,8 +49,14 @@ def _infiltration_to_extraction_weights(
 
     Returns
     -------
-    numpy.ndarray
-        Normalized weight matrix. Shape: (len(cout_tedges) - 1, len(tedges) - 1)
+    weights : numpy.ndarray
+        Normalized weight matrix. Shape: (len(cout_tedges) - 1, len(tedges) - 1).
+        Rows for spin-up and zero-flow cout bins are all zero; use ``spinup_mask``
+        to distinguish spin-up (no contributing streamtube) from zero-flow
+        (contributing streamtubes all trace back into a zero-flow cin window).
+    spinup_mask : numpy.ndarray of bool
+        Shape: (len(cout_tedges) - 1,). True for cout bins where no streamtube
+        traced back into the cin time range (signal has not broken through).
     """
     # Convert time edges to days
     cin_tedges_days = ((tedges - tedges[0]) / pd.Timedelta(days=1)).values
@@ -139,4 +145,5 @@ def _infiltration_to_extraction_weights(
     valid_rows = contributing_bins > 0
     result = np.zeros_like(accumulated_weights)
     result[valid_rows, :] = accumulated_weights[valid_rows, :] / contributing_bins[valid_rows, None]
-    return result
+    spinup_mask = ~valid_rows
+    return result, spinup_mask

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -132,7 +132,14 @@ def compute_deposition_weights(
     )
     area_array = volume_array / (porosity * thickness)
     extracted_volume = np.diff(end_vol)
-    return area_array * np.diff(tedges_days)[None, :] / extracted_volume[:, None]
+    # Zero-flow cout bins have extracted_volume == 0 (no water extracted), so
+    # the weight row collapses to 0: no extraction contributes no deposition
+    # signature to cout. Use a sentinel divisor on those rows to avoid the
+    # division-by-zero warning before np.where discards them.
+    numerator = area_array * np.diff(tedges_days)[None, :]
+    mask = extracted_volume > 0
+    safe_denom = np.where(mask, extracted_volume, 1.0)[:, None]
+    return np.where(mask[:, None], numerator / safe_denom, 0.0)
 
 
 def deposition_to_extraction(
@@ -219,6 +226,9 @@ def deposition_to_extraction(
         raise ValueError(msg)
     if np.any(np.isnan(dep_values)) or np.any(np.isnan(flow_values)):
         msg = "Input arrays cannot contain NaN values"
+        raise ValueError(msg)
+    if np.any(flow_values < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
         raise ValueError(msg)
 
     # Validate physical parameters
@@ -386,6 +396,9 @@ def extraction_to_deposition(
     if np.any(np.isnan(flow_values)):
         msg = "flow array cannot contain NaN values"
         raise ValueError(msg)
+    if np.any(flow_values < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
+        raise ValueError(msg)
 
     # Validate physical parameters
     if not 0 < porosity < 1:
@@ -415,8 +428,9 @@ def extraction_to_deposition(
     # W has row sums equal to residence_time/(porosity*thickness), not 1 like
     # advection. Normalizing makes each observation equally important and
     # gives compute_reverse_target the correct scale for the target.
-    # NaN rows (spin-up) and NaN values in cout are excluded by solve_tikhonov.
-    valid_rows = ~np.isnan(deposition_weights).any(axis=1)
+    # NaN rows (spin-up), all-zero rows (zero-flow cout bins; carry no info),
+    # and NaN values in cout are excluded by solve_tikhonov.
+    valid_rows = ~np.isnan(deposition_weights).any(axis=1) & (np.abs(deposition_weights).sum(axis=1) > 0)
     valid_weights = deposition_weights[valid_rows]
     row_sums = valid_weights.sum(axis=1, keepdims=True)
     col_active = np.sum(np.abs(valid_weights), axis=0) > 0
@@ -559,6 +573,9 @@ def extraction_to_deposition_full(
         raise ValueError(msg)
     if np.any(np.isnan(flow_values)):
         msg = "flow array cannot contain NaN values"
+        raise ValueError(msg)
+    if np.any(flow_values < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
         raise ValueError(msg)
 
     # Validate physical parameters

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -759,8 +759,8 @@ def infiltration_to_extraction(
     if np.any(np.isnan(flow)):
         msg = "flow contains NaN values, which are not allowed"
         raise ValueError(msg)
-    if np.any(flow <= 0):
-        msg = "flow must be positive"
+    if np.any(flow < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
         raise ValueError(msg)
     if np.any(aquifer_pore_volumes <= 0):
         msg = "aquifer_pore_volumes must be positive"

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -199,7 +199,7 @@ def infiltration_to_extraction(
         _warn_dispersion()
 
     # Build advection weight matrix (needed in both branches)
-    w_adv = _infiltration_to_extraction_weights(
+    w_adv, spinup_mask = _infiltration_to_extraction_weights(
         tedges=tedges,
         cout_tedges=cout_tedges,
         aquifer_pore_volumes=aquifer_pore_volumes,
@@ -229,9 +229,10 @@ def infiltration_to_extraction(
         # New algorithm: advect-then-smooth (works with any tedges spacing)
         cout_unsmoothed = w_adv @ cin
 
-        # Invalid rows (no breakthrough yet) have near-zero values that would
-        # bleed into valid neighbors during smoothing. Use normalized convolution:
-        # smooth(signal * mask) / smooth(mask) to properly renormalize the kernel.
+        # Rows with zero weight sum (spin-up or zero-flow traceback) carry no
+        # signal. Flag them so the normalized convolution
+        # smooth(signal * mask) / smooth(mask) properly renormalizes the kernel
+        # instead of letting a near-zero value bleed into valid neighbors.
         total_coeff = np.sum(w_adv, axis=1)
         invalid_mask = total_coeff < _EPSILON_COEFF_SUM
         cout_unsmoothed[invalid_mask] = 0.0
@@ -256,9 +257,9 @@ def infiltration_to_extraction(
         with np.errstate(invalid="ignore"):
             cout = np.where(smoothed_validity > _EPSILON_COEFF_SUM, smoothed / smoothed_validity, np.nan)
 
-    # Mark invalid rows as NaN (where no cin has broken through)
-    total_coeff = np.sum(w_adv, axis=1)
-    cout[total_coeff < _EPSILON_COEFF_SUM] = np.nan
+    # Mark spin-up rows (signal has not broken through yet) as NaN. Zero-flow
+    # cout bins keep their 0 output from the zero weight row.
+    cout[spinup_mask] = np.nan
 
     return cout
 
@@ -397,7 +398,7 @@ def extraction_to_infiltration(
     n_cout = len(cout_tedges) - 1
 
     # Build advection weight matrix
-    w_adv = _infiltration_to_extraction_weights(
+    w_adv, _ = _infiltration_to_extraction_weights(
         tedges=tedges,
         cout_tedges=cout_tedges,
         aquifer_pore_volumes=aquifer_pore_volumes,
@@ -1159,8 +1160,8 @@ def _validate_inputs(
         if np.any(np.isnan(flow_out)):
             msg = "flow_out contains NaN values, which are not allowed"
             raise ValueError(msg)
-        if np.any(flow_out <= 0):
-            msg = "flow_out must be positive"
+        if np.any(flow_out < 0):
+            msg = "flow_out must be non-negative (negative flow not supported)"
             raise ValueError(msg)
 
 

--- a/src/gwtransport/fronttracking/solver.py
+++ b/src/gwtransport/fronttracking/solver.py
@@ -216,8 +216,8 @@ class FrontTracker:
         if np.any(cin < 0):
             msg = "cin must be non-negative"
             raise ValueError(msg)
-        if np.any(flow <= 0):
-            msg = "flow must be positive"
+        if np.any(flow < 0):
+            msg = "flow must be non-negative (negative flow not supported)"
             raise ValueError(msg)
         if aquifer_pore_volume <= 0:
             msg = "aquifer_pore_volume must be positive"

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -607,17 +607,19 @@ def partial_isin(*, bin_edges_in: npt.ArrayLike, bin_edges_out: npt.ArrayLike) -
         msg = "Both edge arrays must have at least 2 elements"
         raise ValueError(msg)
 
-    # Check ascending order, ignoring NaN values
+    # Edges must be non-decreasing (ignoring NaN). Zero-width input bins are
+    # allowed -- they arise e.g. from cumulative flow with zero-flow intervals --
+    # and produce zero overlap fractions (no water passed through).
     diffs_in = np.diff(bin_edges_in)
     valid_diffs_in = ~np.isnan(diffs_in)
-    if np.any(valid_diffs_in) and not np.all(diffs_in[valid_diffs_in] > 0):
-        msg = "bin_edges_in must be in ascending order"
+    if np.any(valid_diffs_in) and not np.all(diffs_in[valid_diffs_in] >= 0):
+        msg = "bin_edges_in must be non-decreasing"
         raise ValueError(msg)
 
     diffs_out = np.diff(bin_edges_out)
     valid_diffs_out = ~np.isnan(diffs_out)
-    if np.any(valid_diffs_out) and not np.all(diffs_out[valid_diffs_out] > 0):
-        msg = "bin_edges_out must be in ascending order"
+    if np.any(valid_diffs_out) and not np.all(diffs_out[valid_diffs_out] >= 0):
+        msg = "bin_edges_out must be non-decreasing"
         raise ValueError(msg)
 
     # Build matrix using fully vectorized approach
@@ -636,8 +638,11 @@ def partial_isin(*, bin_edges_in: npt.ArrayLike, bin_edges_out: npt.ArrayLike) -
     # Calculate overlap widths (zero where no overlap)
     overlap_widths = np.maximum(0, overlap_right - overlap_left)
 
-    # Calculate fractions (NaN widths will result in NaN fractions)
-    return overlap_widths / in_width
+    # Zero-width input bins contribute no overlap (division-safe). NaN widths still
+    # propagate as NaN fractions (preserved for spin-up handling).
+    with np.errstate(divide="ignore", invalid="ignore"):
+        result = overlap_widths / in_width
+    return np.where(in_width == 0, 0.0, result)
 
 
 def time_bin_overlap(*, tedges: npt.ArrayLike, bin_tedges: list[tuple]) -> npt.NDArray[np.floating]:

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -2554,3 +2556,96 @@ class TestFlowWeightedFrontTracking:
         dt_out = np.diff(((cout_tedges - cout_tedges[0]) / pd.Timedelta(days=1)).values)
         mass_out = np.sum(cout * flow[0] * dt_out)
         np.testing.assert_allclose(mass_out, mass_in, rtol=1e-13)
+
+
+# =============================================================================
+# Negative-flow rejection and zero-flow invariance
+# =============================================================================
+
+
+def _zero_flow_invariance_setup():
+    """Baseline and zero-flow-inserted scenarios sharing the same cout grid."""
+    n = 200
+    tedges_base = pd.date_range(start="2020-01-01", periods=n + 1, freq="D")
+    cin_base = 10.0 + np.sin(np.linspace(0, 4 * np.pi, n))
+    flow_base = np.full(n, 100.0)
+
+    k = 100  # insertion index
+    tedges_mod = pd.date_range(start="2020-01-01", periods=n + 2, freq="D")
+    cin_mod = np.insert(cin_base, k, cin_base[k - 1])
+    flow_mod = np.insert(flow_base, k, 0.0)
+
+    return {
+        "n": n,
+        "k": k,
+        "tedges_base": tedges_base,
+        "cin_base": cin_base,
+        "flow_base": flow_base,
+        "tedges_mod": tedges_mod,
+        "cin_mod": cin_mod,
+        "flow_mod": flow_mod,
+    }
+
+
+def test_infiltration_to_extraction_rejects_negative_flow():
+    """Negative flow must raise ValueError with the standard message."""
+    tedges = pd.date_range(start="2020-01-01", periods=11, freq="D")
+    cin = np.ones(10)
+    flow = np.full(10, 100.0)
+    flow[5] = -1.0
+
+    with pytest.raises(ValueError, match="flow must be non-negative"):
+        infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+        )
+
+
+def test_infiltration_to_extraction_accepts_zero_flow_without_warnings():
+    """flow == 0 is accepted; no division-by-zero warnings emitted."""
+    tedges = pd.date_range(start="2020-01-01", periods=201, freq="D")
+    cin = np.ones(200)
+    flow = np.full(200, 100.0)
+    flow[100] = 0.0
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+        )
+
+
+def test_infiltration_to_extraction_zero_flow_insertion_invariance():
+    """Insert a zero-flow bin mid-series: preserves spin-up NaN count and values."""
+    s = _zero_flow_invariance_setup()
+    apv = np.array([500.0])
+
+    cout_base = infiltration_to_extraction(
+        cin=s["cin_base"],
+        flow=s["flow_base"],
+        tedges=s["tedges_base"],
+        cout_tedges=s["tedges_base"],
+        aquifer_pore_volumes=apv,
+    )
+    cout_mod = infiltration_to_extraction(
+        cin=s["cin_mod"],
+        flow=s["flow_mod"],
+        tedges=s["tedges_mod"],
+        cout_tedges=s["tedges_mod"],
+        aquifer_pore_volumes=apv,
+    )
+
+    # Drop the inserted zero-flow output bin and check invariants:
+    cout_mod_stripped = np.delete(cout_mod, s["k"])
+    assert np.sum(np.isnan(cout_mod_stripped)) == np.sum(np.isnan(cout_base))
+
+    # Comparable values where both are finite
+    valid = ~np.isnan(cout_base) & ~np.isnan(cout_mod_stripped)
+    np.testing.assert_allclose(cout_mod_stripped[valid], cout_base[valid], atol=1e-10)

--- a/tests/src/test_advection_roundtrip.py
+++ b/tests/src/test_advection_roundtrip.py
@@ -199,7 +199,7 @@ class TestRoundtripSameGrid:
         # reconstruction error |cin_recovered - cin_original| at each bin is
         # bounded by |P_null(cin_original)| at that bin, since cin_recovered
         # and cin_original agree modulo null(W).
-        w_forward = _infiltration_to_extraction_weights(
+        w_forward, _ = _infiltration_to_extraction_weights(
             tedges=tedges,
             cout_tedges=cout_tedges,
             aquifer_pore_volumes=pore_volumes,

--- a/tests/src/test_deposition.py
+++ b/tests/src/test_deposition.py
@@ -1391,3 +1391,124 @@ def test_variable_timestep_zero_deposition():
     valid = ~np.isnan(cout_result)
     assert valid.sum() >= 1
     np.testing.assert_allclose(cout_result[valid], 0.0, atol=1e-15)
+
+
+# ===============================================================================
+# FLOW SIGN VALIDATION
+# ===============================================================================
+
+
+@pytest.fixture
+def flow_sign_setup():
+    """Shared setup for flow sign validation tests."""
+    dates = pd.date_range("2020-01-01", "2020-01-10", freq="D")
+    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
+    cout_dates = pd.date_range("2020-01-03", "2020-01-10", freq="D")
+    cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=len(cout_dates))
+    params = {
+        "aquifer_pore_volume": 200.0,
+        "porosity": 0.3,
+        "thickness": 5.0,
+        "retardation_factor": 1.0,
+    }
+    return tedges, cout_tedges, params
+
+
+def test_deposition_to_extraction_negative_flow_rejected(flow_sign_setup):
+    """Negative flow is physically invalid and must raise the standard error."""
+    tedges, cout_tedges, params = flow_sign_setup
+    n = len(tedges) - 1
+    flow = np.full(n, 100.0)
+    flow[3] = -50.0
+    with pytest.raises(ValueError, match="flow must be non-negative"):
+        deposition_to_extraction(
+            dep=np.ones(n),
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            **params,
+        )
+
+
+def test_extraction_to_deposition_negative_flow_rejected(flow_sign_setup):
+    """Negative flow is physically invalid and must raise the standard error."""
+    tedges, cout_tedges, params = flow_sign_setup
+    n = len(tedges) - 1
+    flow = np.full(n, 100.0)
+    flow[3] = -50.0
+    n_cout = len(cout_tedges) - 1
+    with pytest.raises(ValueError, match="flow must be non-negative"):
+        extraction_to_deposition(
+            cout=np.ones(n_cout) * 10.0,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            **params,
+        )
+
+
+def test_extraction_to_deposition_full_negative_flow_rejected(flow_sign_setup):
+    """Negative flow is physically invalid and must raise the standard error."""
+    tedges, cout_tedges, params = flow_sign_setup
+    n = len(tedges) - 1
+    flow = np.full(n, 100.0)
+    flow[3] = -50.0
+    n_cout = len(cout_tedges) - 1
+    with pytest.raises(ValueError, match="flow must be non-negative"):
+        extraction_to_deposition_full(
+            cout=np.ones(n_cout) * 10.0,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            **params,
+        )
+
+
+def test_deposition_to_extraction_zero_flow_accepted(flow_sign_setup):
+    """Zero flow is mathematically valid (no transport during the bin) and must not raise.
+
+    The call must emit no RuntimeWarnings (divide-by-zero / invalid-value), and
+    non-zero-flow cout bins must still produce finite output -- only cout bins
+    whose extracted volume is zero (fully inside the zero-flow window) may be NaN.
+    """
+    tedges, cout_tedges, params = flow_sign_setup
+    n = len(tedges) - 1
+    flow = np.full(n, 100.0)
+    flow[3] = 0.0
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        cout = deposition_to_extraction(
+            dep=np.ones(n),
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            **params,
+        )
+
+    assert cout.shape == (len(cout_tedges) - 1,)
+    # Zero-flow must not produce NaN. The zero-flow cout bin has no extraction
+    # so its concentration is reported as 0 (no water => no flux observed).
+    assert np.all(np.isfinite(cout))
+    assert np.all(cout >= 0.0)
+
+
+def test_extraction_to_deposition_zero_flow_accepted(flow_sign_setup):
+    """Zero flow must be accepted (no RuntimeWarnings) by the deconvolution path too."""
+    tedges, cout_tedges, params = flow_sign_setup
+    n = len(tedges) - 1
+    flow = np.full(n, 100.0)
+    flow[3] = 0.0
+    n_cout = len(cout_tedges) - 1
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", RuntimeWarning)
+        dep = extraction_to_deposition(
+            cout=np.ones(n_cout) * 10.0,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            **params,
+        )
+
+    assert dep.shape == (n,)

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -2157,3 +2157,49 @@ class TestGammaExtractionToInfiltrationDiffusion:
             rtol=1e-9,
             atol=1e-9,
         )
+
+
+# =============================================================================
+# Negative-flow rejection and zero-flow invariance
+# =============================================================================
+
+
+def test_infiltration_to_extraction_rejects_negative_flow():
+    """Negative flow must raise ValueError with the standard message."""
+    tedges = pd.date_range(start="2020-01-01", periods=11, freq="D")
+    cin = np.ones(10)
+    flow = np.full(10, 100.0)
+    flow[5] = -1.0
+
+    with pytest.raises(ValueError, match="flow must be non-negative"):
+        infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            streamline_length=np.array([80.0]),
+            molecular_diffusivity=np.array([0.03]),
+            longitudinal_dispersivity=np.array([0.0]),
+        )
+
+
+def test_infiltration_to_extraction_accepts_zero_flow_without_warnings():
+    """flow == 0 is accepted; no runtime warnings emitted."""
+    tedges = pd.date_range(start="2020-01-01", periods=201, freq="D")
+    cin = np.ones(200)
+    flow = np.full(200, 100.0)
+    flow[100] = 0.0
+
+    with warn_module.catch_warnings():
+        warn_module.simplefilter("error", RuntimeWarning)
+        infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            streamline_length=np.array([80.0]),
+            molecular_diffusivity=np.array([0.03]),
+            longitudinal_dispersivity=np.array([0.0]),
+        )

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -1519,14 +1519,14 @@ def test_flow_out_validation_nan():
         )
 
 
-def test_flow_out_validation_nonpositive():
-    """flow_out with non-positive values raises ValueError."""
+def test_flow_out_validation_negative():
+    """flow_out with negative values raises ValueError."""
     tedges, cout_tedges, flow = _make_transport_data(n_days=200)
     cin = np.full(200, 10.0)
     flow_out = np.full(200, 100.0)
-    flow_out[50] = 0.0
+    flow_out[50] = -1.0
 
-    with pytest.raises(ValueError, match="flow_out must be positive"):
+    with pytest.raises(ValueError, match="flow_out must be non-negative"):
         infiltration_to_extraction(
             cin=cin,
             flow=flow,
@@ -2030,3 +2030,85 @@ class TestGammaExtractionToInfiltrationFast:
                 mean_longitudinal_dispersivity=1.0,
                 suppress_dispersion_warning=True,
             )
+
+
+# =============================================================================
+# Negative-flow rejection and zero-flow invariance
+# =============================================================================
+
+
+def test_infiltration_to_extraction_rejects_negative_flow():
+    """Negative flow must raise ValueError with the standard message."""
+    tedges = pd.date_range(start="2020-01-01", periods=11, freq="D")
+    cin = np.ones(10)
+    flow = np.full(10, 100.0)
+    flow[5] = -1.0
+
+    with pytest.raises(ValueError, match="flow must be non-negative"):
+        infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            mean_streamline_length=80.0,
+            mean_molecular_diffusivity=0.03,
+            mean_longitudinal_dispersivity=0.0,
+        )
+
+
+def test_infiltration_to_extraction_accepts_zero_flow_without_warnings():
+    """flow == 0 is accepted; no runtime warnings emitted."""
+    tedges = pd.date_range(start="2020-01-01", periods=201, freq="D")
+    cin = np.ones(200)
+    flow = np.full(200, 100.0)
+    flow[100] = 0.0
+
+    with warn_module.catch_warnings():
+        warn_module.simplefilter("error", RuntimeWarning)
+        infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            mean_streamline_length=80.0,
+            mean_molecular_diffusivity=0.03,
+            mean_longitudinal_dispersivity=0.0,
+        )
+
+
+def test_infiltration_to_extraction_zero_flow_insertion_invariance():
+    """Insert a zero-flow bin mid-series: preserves NaN count and value pattern."""
+    n = 200
+    k = 100
+    tedges_base = pd.date_range(start="2020-01-01", periods=n + 1, freq="D")
+    cin_base = 10.0 + np.sin(np.linspace(0, 4 * np.pi, n))
+    flow_base = np.full(n, 100.0)
+
+    tedges_mod = pd.date_range(start="2020-01-01", periods=n + 2, freq="D")
+    cin_mod = np.insert(cin_base, k, cin_base[k - 1])
+    flow_mod = np.insert(flow_base, k, 0.0)
+
+    common_kwargs = {
+        "aquifer_pore_volumes": np.array([500.0]),
+        "mean_streamline_length": 80.0,
+        "mean_molecular_diffusivity": 0.03,
+        "mean_longitudinal_dispersivity": 5.0,
+    }
+
+    cout_base = infiltration_to_extraction(
+        cin=cin_base, flow=flow_base, tedges=tedges_base, cout_tedges=tedges_base, **common_kwargs
+    )
+    cout_mod = infiltration_to_extraction(
+        cin=cin_mod, flow=flow_mod, tedges=tedges_mod, cout_tedges=tedges_mod, **common_kwargs
+    )
+
+    cout_mod_stripped = np.delete(cout_mod, k)
+    assert np.sum(np.isnan(cout_mod_stripped)) == np.sum(np.isnan(cout_base))
+
+    valid = ~np.isnan(cout_base) & ~np.isnan(cout_mod_stripped)
+    # Near the inserted bin the diffusion kernel reaches across the gap, so
+    # values drift by up to a few percent of the input amplitude; farther out
+    # the signal converges back to the baseline.
+    assert_allclose(cout_mod_stripped[valid], cout_base[valid], atol=5e-2)

--- a/tests/src/test_front_tracking_solver.py
+++ b/tests/src/test_front_tracking_solver.py
@@ -126,7 +126,7 @@ class TestFrontTrackerInitialization:
         flow = np.array([100.0, -100.0])  # Negative flow
         tedges = pd.to_datetime(["2020-01-01", "2020-01-11", "2020-04-11"])
 
-        with pytest.raises(ValueError, match="flow must be positive"):
+        with pytest.raises(ValueError, match="flow must be non-negative"):
             FrontTracker(
                 cin=cin,
                 flow=flow,

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -492,13 +492,13 @@ def test_invalid_inputs():
     # Test with unsorted input edges
     bin_edges_in = np.array([30, 20, 10])  # Descending order
     bin_edges_out = np.array([5, 15, 25])
-    with pytest.raises(ValueError, match="bin_edges_in must be in ascending order"):
+    with pytest.raises(ValueError, match="bin_edges_in must be non-decreasing"):
         partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
 
     # Test with unsorted output edges
     bin_edges_in = np.array([0, 10, 20])
     bin_edges_out = np.array([25, 15, 5])  # Descending order
-    with pytest.raises(ValueError, match="bin_edges_out must be in ascending order"):
+    with pytest.raises(ValueError, match="bin_edges_out must be non-decreasing"):
         partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
 
 


### PR DESCRIPTION
## Summary

Unify flow-sign validation and zero-flow handling across transport modules.

- **Consistent validation**: `advection`, `advection` (front-tracking validator), `diffusion`, `diffusion_fast` (including `flow_out`), `deposition` (all three public entry points), and `fronttracking/solver` now reject `flow < 0` with the same message (`"flow must be non-negative (negative flow not supported)"`) and accept `flow == 0` as valid.
- **`utils.partial_isin`**: relaxed edge-ordering requirement from strictly increasing to non-decreasing so zero-width bins (a natural consequence of zero-flow intervals when working in cumulative-volume coordinates) are permitted. Zero-width input bins safely produce zero overlap fractions (no water passed through).
- **`advection_utils._infiltration_to_extraction_weights`**: now returns `(weights, spinup_mask)`. The weight matrix keeps zero rows for both spin-up (no streamtube traced back into the cin range) and zero-flow (streamtubes trace back into a zero-flow cin window) so no NaN is introduced into downstream matrix_rank, SVD, or sparse smoothing products. Callers use `spinup_mask` to NaN only spin-up rows.
- **`advection.infiltration_to_extraction`** and **`diffusion_fast.infiltration_to_extraction`**: zero-flow cout bins now produce `0` output instead of `NaN` (driven by the zero row in the weight matrix). Spin-up bins still return `NaN` via the mask.
- **`deposition.compute_deposition_weights`**: replaces an unguarded division with a `np.where` sentinel-divisor pattern so zero-flow (zero extracted volume) cout bins yield a zero weight row without emitting a `RuntimeWarning`. `deposition.extraction_to_deposition` excludes all-zero rows (carry no information) from the inverse solve alongside NaN rows.

## Test plan

- `pytest tests/src -n auto` — 967 passed, 8 skipped (3 new tests in `test_advection.py`, 5 in `test_deposition.py`, 2 in `test_diffusion.py`, 3 in `test_diffusion_fast.py`; regex updates in `test_front_tracking_solver.py` and `test_utils.py`; tuple-unpack fix in `test_advection_roundtrip.py`).
- New tests cover: negative-flow rejection (ValueError with the unified message), zero-flow acceptance without `RuntimeWarning`, and zero-flow insertion invariance (inserting a zero-flow bin preserves the NaN count and the values at equivalent bins after stripping).
- `ruff format .` and `ruff check --fix .` — clean.
- `ty check .` — clean.

## Contributor License Agreement

- [x] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.