### PR TITLE
Clarify CLA rationale and add LLM-bug-hallucination guardrails

### DIFF
--- a/.claude/agents/gwtransport-reviewer.md
+++ b/.claude/agents/gwtransport-reviewer.md
@@ -99,6 +99,7 @@ Any change to:
 4. **Explain _why_, briefly.** A one-line physical or convention-based justification per finding is enough — don't lecture.
 5. **Check what's missing, not only what's there.** Flag absent tests, missing docstring updates, unupdated cross-references, and notebooks that depend on a changed signature.
 6. **Verify before recommending.** If you cite a function or file, confirm it exists in the current tree — don't recommend from stale memory.
-7. **End with a one-line verdict**: _ready to merge_, _ready after blockers fixed_, or _needs rework_.
+7. **Test before claiming a bug exists.** LLM reviewers routinely hallucinate plausible-sounding bugs. For any `BLOCKER` or `SHOULD FIX` finding, write a failing test against the current code first; if it passes, you invented the bug — drop the finding.
+8. **End with a one-line verdict**: _ready to merge_, _ready after blockers fixed_, or _needs rework_.
 
 Stay terse — the author reads the diff, not a monograph.

--- a/.github/agents/gwtransport-reviewer.agent.md
+++ b/.github/agents/gwtransport-reviewer.agent.md
@@ -96,6 +96,7 @@ Any change to:
 4. **Explain _why_, briefly.** A one-line physical or convention-based justification per finding is enough — don't lecture.
 5. **Check what's missing, not only what's there.** Flag absent tests, missing docstring updates, unupdated cross-references, and notebooks that depend on a changed signature.
 6. **Verify before recommending.** If you cite a function or file, confirm it exists in the current tree — don't recommend from stale memory.
-7. **End with a one-line verdict**: _ready to merge_, _ready after blockers fixed_, or _needs rework_.
+7. **Test before claiming a bug exists.** LLM reviewers routinely hallucinate plausible-sounding bugs. For any `BLOCKER` or `SHOULD FIX` finding, write a failing test against the current code first; if it passes, you invented the bug — drop the finding.
+8. **End with a one-line verdict**: _ready to merge_, _ready after blockers fixed_, or _needs rework_.
 
 Stay terse — the author reads the diff, not a monograph.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,7 @@ def function_name(*, flow: npt.ArrayLike, tedges: pd.DatetimeIndex) -> npt.NDArr
 - **Bin-edge pattern**: Time is represented as `tedges` (`pd.DatetimeIndex`, n+1 edges) with n values constant over each interval `[tedges[i], tedges[i+1])`. Same pattern for spatial dimension (`xedges`).
 - **Input/output semantics**: Input values (`flow`, `cin` for infiltration-to-extraction; `flow`, `cout` for extraction-to-infiltration) are constant per bin. Output concentration/temperature is a flow-weighted bin average.
 - **Paired operations**: Functions come in forward (infiltration-to-extraction) and reverse (extraction-to-infiltration) variants.
-- **Multiple parameterizations**: Gamma distributions support both (alpha, beta) and (mean, std).
+- **Multiple parameterizations**: Gamma distributions support both (alpha, beta, loc) and (mean, std, loc).
 - **Retardation**: All transport functions account for sorption via retardation factors.
 - **Units**: Must be consistent within a calculation. The package does not enforce units -- the user is responsible.
 
@@ -101,10 +101,12 @@ def function_name(*, flow: npt.ArrayLike, tedges: pd.DatetimeIndex) -> npt.NDArr
 - Validate physical correctness: conservation laws, boundary conditions, limiting cases.
 - Tests MUST be meaningful -- not trivial identity checks. Use analytical solutions for validation when possible.
 - Run specific tests with: `uv run pytest tests/src/test_diffusion.py -v` or `uv run pytest tests/src -k "advection" -v`
+- LLM reviewers (including this one) routinely flag plausible-sounding bugs that do not actually exist; before applying any non-trivial suggested change, write a regression test for the claimed bug and run it against the unchanged baseline -- only proceed if the baseline test fails.
 
 ## Git
 
 - Do NOT include Claude-related signatures in commit messages or PR descriptions.
+- Base your PR message on the template at `.github/pull_request_template.md`.
 - Run formatting, linting, and type checking before committing.
 
 ## Cross-References

--- a/CLA.md
+++ b/CLA.md
@@ -2,7 +2,9 @@
 
 ## Why this exists
 
-`gwtransport` is released under AGPL-3.0 so the code stays open. Some organizations can't use AGPL — internal policy, license incompatibility, SaaS concerns — so I also offer commercial licenses to them. That revenue funds continued development of the open project.
+`gwtransport` is released under AGPL-3.0 so the code stays open. AGPL-3.0 requires anyone who modifies the code — including for internal or networked use — to release their modifications back under the same license. That share-back requirement is the point: it keeps improvements flowing into the open project.
+
+Some organizations can't meet that requirement — internal policy, license incompatibility with proprietary stacks, or SaaS deployments where exposing modifications isn't feasible. For them I offer a commercial license that lifts the share-back obligation. The fees support my open-source work, including but not limited to this project.
 
 This CLA is what makes the dual path possible: instead of chasing down every past contributor each time a commercial license is negotiated, contributors agree up front that their code can ship under both AGPL-3.0 and other terms.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ def function_name(*, flow: npt.ArrayLike, tedges: pd.DatetimeIndex) -> npt.NDArr
 - **Bin-edge pattern**: Time is represented as `tedges` (`pd.DatetimeIndex`, n+1 edges) with n values constant over each interval `[tedges[i], tedges[i+1])`. Same pattern for spatial dimension (`xedges`).
 - **Input/output semantics**: Input values (`flow`, `cin` for infiltration-to-extraction; `flow`, `cout` for extraction-to-infiltration) are constant per bin. Output concentration/temperature is a flow-weighted bin average.
 - **Paired operations**: Functions come in forward (infiltration-to-extraction) and reverse (extraction-to-infiltration) variants.
-- **Multiple parameterizations**: Gamma distributions support both (alpha, beta) and (mean, std).
+- **Multiple parameterizations**: Gamma distributions support both (alpha, beta, loc) and (mean, std, loc).
 - **Retardation**: All transport functions account for sorption via retardation factors.
 - **Units**: Must be consistent within a calculation. The package does not enforce units -- the user is responsible.
 
@@ -101,10 +101,12 @@ def function_name(*, flow: npt.ArrayLike, tedges: pd.DatetimeIndex) -> npt.NDArr
 - Validate physical correctness: conservation laws, boundary conditions, limiting cases.
 - Tests MUST be meaningful -- not trivial identity checks. Use analytical solutions for validation when possible.
 - Run specific tests with: `uv run pytest tests/src/test_diffusion.py -v` or `uv run pytest tests/src -k "advection" -v`
+- LLM reviewers (including this one) routinely flag plausible-sounding bugs that do not actually exist; before applying any non-trivial suggested change, write a regression test for the claimed bug and run it against the unchanged baseline -- only proceed if the baseline test fails.
 
 ## Git
 
 - Do NOT include Claude-related signatures in commit messages or PR descriptions.
+- Base your PR message on the template at `.github/pull_request_template.md`.
 - Run formatting, linting, and type checking before committing.
 
 ## Cross-References


### PR DESCRIPTION
## Summary

- **CLA.md**: Spell out that AGPL's share-back obligation is the point of the license, and that the commercial license exists for organizations that can't meet that obligation (internal policy, license incompatibility, SaaS deployments).
- **CLAUDE.md + `.claude/agents/gwtransport-reviewer.md`**: Require writing a regression test against the unchanged baseline before applying any non-trivial "fix" suggested by an LLM reviewer. If the baseline test passes, the reported bug doesn't exist — drop the finding.
- **CLAUDE.md**: Note that gamma parameterizations include `loc` (was missing from the convention summary), and point PR authors at the existing PR template.

No code or test changes — docs and agent instructions only.

## Test plan

- [x] `git diff` reviewed; only Markdown changed.
- [ ] No code paths affected; CI doc/lint checks should suffice.

## Contributor License Agreement

- [x] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.