### PR TITLE
Bump project version to 0.32.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "requests>=2.19.0",
   "scipy>=1.13.0",
 ]
-version = "0.31.0"
+version = "0.32.0"
 [project.optional-dependencies]
 test = [
   "nbconvert>=7.1.0",


### PR DESCRIPTION
## Summary

Bump project version from 0.31.0 to 0.32.0 in `pyproject.toml` to release the changes merged since 0.31.0:

- Unify negative-flow guards and zero-flow handling across modules (#146)
- Fix front tracking physics review (#144)
- Fix diffusion physics review (#143)
- Fix deposition physics review (#142)
- Fix advection physics review (#141)
- Fix gamma + residence_time physics review (#140)
- Fix utils, logremoval, examples physics review (#139)
- Clarify CLA rationale and add LLM-bug-hallucination guardrails (#147)
- Bump actions/upload-pages-artifact from 4 to 5 (#145)

## Test plan

- [ ] CI pipeline passes on Python 3.11 and 3.14

## Contributor License Agreement

- [x] I have read the [CLA](../CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.