### PR TITLE
Upgrade Sphinx to 9.x

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,8 +1,21 @@
 """Configuration file for the Sphinx documentation builder."""  # noqa: INP001
 
+import sys
 import tomllib
+import types
 from datetime import date
 from pathlib import Path
+
+# nbsphinx-link 1.3.1 imports SafeString/ErrorString from
+# docutils.utils.error_reporting, which was removed in docutils 0.22 (required
+# by Sphinx 9). Those were Python 2 unicode-coercion helpers; str() is a safe
+# Python 3 substitute. Remove once nbsphinx-link ships a fix for
+# https://github.com/vidartf/nbsphinx-link/issues/25.
+if "docutils.utils.error_reporting" not in sys.modules:
+    _shim = types.ModuleType("docutils.utils.error_reporting")
+    setattr(_shim, "SafeString", str)  # noqa: B010
+    setattr(_shim, "ErrorString", str)  # noqa: B010
+    sys.modules["docutils.utils.error_reporting"] = _shim
 
 # Read project information from pyproject.toml
 pyproject_path = Path(__file__).parent.parent.parent / "pyproject.toml"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,9 @@ docs = [
   "jupyter",
   "nbsphinx",
   "nbsphinx-link",
-  "sphinx>=7.0,<9.0",
+  "sphinx>=9.0,<10.0",
   "sphinx-autodoc-typehints",
-  "sphinx-book-theme>=1.0.0",
+  "sphinx-book-theme>=1.2.0",
   "sphinx-copybutton",
   "sphinxext-opengraph[social_cards]",
 ]


### PR DESCRIPTION
## Summary

- Bump the docs `sphinx` pin from `>=7.0,<9.0` to `>=9.0,<10.0`; resolves to Sphinx 9.1.0.
- Raise the `sphinx-book-theme` floor from `>=1.0.0` to `>=1.2.0` so the theme templates match Sphinx 9 expectations.
- Add a small compatibility shim in `docs/source/conf.py` for `nbsphinx-link`.

## Why the shim

Sphinx 9 requires docutils 0.22, which removed the legacy `docutils.utils.error_reporting` module. `nbsphinx-link` 1.3.1 (latest release, Sep 2024) still imports `SafeString` and `ErrorString` from that module and fails to load on the new docutils (upstream issue [vidartf/nbsphinx-link#25](https://github.com/vidartf/nbsphinx-link/issues/25)). The shim installs a replacement `docutils.utils.error_reporting` in `sys.modules` exposing both names as plain `str` — those were Python 2 unicode-coercion helpers and are effectively no-ops on Python 3. Removable once a fixed `nbsphinx-link` is released.

## Plugins kept as-is

No plugins were dropped. Sphinx 9 does not ship built-in replacements for `sphinx-copybutton`, `sphinxext-opengraph`, or `nbsphinx`/`nbsphinx-link`. `sphinx-autodoc-typehints` is partly redundant with core `autodoc_typehints = "description"` but still offers finer control (union-bars, defaults rendering); kept for now.

## Other doc deps

Current metadata of upstream packages already constrains the resolver to Sphinx 9-compatible versions, so no additional floors were needed:

| Package | Resolved | Notes |
|---|---|---|
| `sphinx-autodoc-typehints` | 3.10.2 | its own metadata needs `sphinx>=9.1` |
| `nbsphinx` | 0.9.8 | excludes 8.2.0/8.2.1, otherwise `>=1.8` |
| `sphinx-copybutton` | 0.5.2 | no constraint change needed |
| `sphinxext-opengraph` | 0.13.0 | no constraint change needed |
| `nbsphinx-link` | 1.3.1 | unconstrained; shim handles it |

## Test plan

- [x] `sphinx-build -b html docs/source docs/build/html` succeeds with Sphinx 9.1.0 (pre-existing 115 warnings, no new categories)
- [x] `sphinx-build -b linkcheck docs/source docs/build/linkcheck` succeeds with zero broken links
- [x] `ruff format` / `ruff check` clean on `docs/source/conf.py`
- [ ] CI `Build and Deploy Documentation` workflow green

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.