### PR TITLE
Bump project version to 0.33.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "requests>=2.19.0",
   "scipy>=1.13.0",
 ]
-version = "0.32.0"
+version = "0.33.0"
 [project.optional-dependencies]
 test = [
   "nbconvert>=7.1.0",


### PR DESCRIPTION
## Summary

- Bump project version from 0.32.0 to 0.33.0 following the Sphinx 9 upgrade (#152) and the documentation nitpicky-warning cleanup (#151) that landed on main.

## Test plan

- [ ] CI passes on Python 3.11 (minimum deps) and 3.14 (latest deps).

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.