### PR TITLE
diffusion_fast: adopt diffusion-style wide-edge spinup padding for consistency

### DIFF
--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -211,6 +211,84 @@ def _resolve_spinup_mask(
     return weights, ~valid
 
 
+# Pad duration used by the wide-edges spinup mode. 100 years is overkill for
+# any reasonable groundwater residence time + Gaussian-kernel tail, but it
+# matches the analytical diffusion module's historical extension and keeps
+# the wide-bin numerics stable across pathological inputs.
+_DIFFUSION_WIDE_PAD = pd.Timedelta(days=36500)
+
+
+def _resolve_spinup_inputs_wide_edges(
+    spinup: object,
+    *,
+    tedges: pd.DatetimeIndex,
+) -> tuple[pd.DatetimeIndex, float | None]:
+    """Validate ``spinup`` and apply diffusion-style wide-edge padding.
+
+    Unlike :func:`_resolve_spinup_inputs` (which prepends ``n_pad`` uniform
+    bins for advection-only physics-precise warm-start), this helper
+    extends only the first and last edges by 100 years each. Single wide
+    boundary bins are used so the diffusion module's Gaussian kernel tail
+    is captured without the cost of many extra bins. The length of
+    ``tedges`` is preserved; cin and flow lengths are therefore also
+    preserved, and inverse-direction outputs need no slicing.
+
+    For the smooth-then-advect path in ``diffusion_fast``, the per-bin
+    sigma scales inversely with bin width, so smoothing on the (very wide)
+    warm-start bin is automatically negligible and the algorithm remains
+    self-consistent.
+
+    Parameters
+    ----------
+    spinup : None, "constant", or float in [0, 1]
+        Public spin-up policy. Same semantics as the parameter on the
+        public i2e/e2i functions.
+    tedges : pandas.DatetimeIndex
+        Original cin/flow time edges (length n_cin + 1).
+
+    Returns
+    -------
+    weight_tedges : pandas.DatetimeIndex
+        Tedges to pass to the weight-matrix computation. Same length as
+        ``tedges``; under ``"constant"``, the first and last edges are
+        shifted outward by 100 years each.
+    threshold : float in [0, 1] or None
+        Threshold for :func:`_resolve_spinup_mask`. ``None`` under
+        ``spinup`` is ``None`` or ``"constant"``.
+
+    Raises
+    ------
+    TypeError
+        If ``spinup`` has an unsupported type (notably ``bool``).
+    ValueError
+        If ``spinup`` is a string other than ``"constant"`` or a float
+        outside ``[0, 1]``, or if ``len(tedges) < 2``.
+    """
+    if spinup is None:
+        return tedges, None
+    if isinstance(spinup, str):
+        if spinup != "constant":
+            msg = f"spinup string must be 'constant'; got {spinup!r}"
+            raise ValueError(msg)
+        min_tedges = 2
+        if len(tedges) < min_tedges:
+            msg = "spinup='constant' requires len(tedges) >= 2"
+            raise ValueError(msg)
+        new_tedges = pd.DatetimeIndex([
+            tedges[0] - _DIFFUSION_WIDE_PAD,
+            *list(tedges[1:-1]),
+            tedges[-1] + _DIFFUSION_WIDE_PAD,
+        ])
+        return new_tedges, None
+    if isinstance(spinup, bool) or not isinstance(spinup, (int, float)):
+        msg = f"spinup must be None, 'constant', or float in [0, 1]; got {spinup!r}"
+        raise TypeError(msg)
+    if not (0.0 <= spinup <= 1.0):
+        msg = f"spinup float must be in [0, 1]; got {spinup!r}"
+        raise ValueError(msg)
+    return tedges, float(spinup)
+
+
 def _resolve_spinup_inputs(
     spinup: object,
     *,

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -72,7 +72,7 @@ from scipy.special import erf
 from gwtransport import gamma
 from gwtransport.advection_utils import (
     _infiltration_to_extraction_weights,
-    _resolve_spinup_inputs,
+    _resolve_spinup_inputs_wide_edges,
     _resolve_spinup_mask,
 )
 from gwtransport.residence_time import residence_time_mean
@@ -209,24 +209,18 @@ def infiltration_to_extraction(
     if n_pore_volumes > 1 and mean_longitudinal_dispersivity > 0 and not suppress_dispersion_warning:
         _warn_dispersion()
 
-    # Apply spinup policy to inputs (pad warm-start bins for "constant" mode).
-    weight_tedges, weight_flow, weight_cin, threshold, _ = _resolve_spinup_inputs(
-        spinup,
-        tedges=tedges,
-        flow=flow,
-        aquifer_pore_volumes=aquifer_pore_volumes,
-        retardation_factor=retardation_factor,
-        cin=cin,
-    )
-    # weight_cin is non-None because cin was passed into _resolve_spinup_inputs.
-    weight_cin = np.asarray(weight_cin)
+    # Apply spinup policy to inputs (extend boundary tedges for "constant").
+    # diffusion_fast uses diffusion-style wide-edge padding rather than
+    # advection's physics-precise n_pad bins, because the Gaussian smoothing
+    # kernel adds a tail that R*V_max/Q alone does not capture.
+    weight_tedges, threshold = _resolve_spinup_inputs_wide_edges(spinup, tedges=tedges)
 
     # Build advection weight matrix (needed in both branches)
     accumulated_weights, contributing_bins, zero_flow_cout = _infiltration_to_extraction_weights(
         tedges=weight_tedges,
         cout_tedges=cout_tedges,
         aquifer_pore_volumes=aquifer_pore_volumes,
-        flow=weight_flow,
+        flow=flow,
         retardation_factor=retardation_factor,
     )
     w_adv, adv_invalid_mask = _resolve_spinup_mask(
@@ -239,12 +233,14 @@ def infiltration_to_extraction(
 
     if flow_out is None:
         # Original algorithm: smooth-then-advect (requires uniform tedges).
-        # The padded ``weight_tedges`` keep the original first-bin width, so a
-        # uniform input remains uniform after warm-start padding.
-        _check_uniform_tedges(tedges=weight_tedges, suppress=suppress_uniform_tedges_check)
+        # Check uniformity against the user-supplied tedges; the wide first
+        # and last bins added by ``spinup="constant"`` are intentionally
+        # non-uniform and do not need to match the interior bin width
+        # (their sigma is automatically tiny because dt is huge).
+        _check_uniform_tedges(tedges=tedges, suppress=suppress_uniform_tedges_check)
 
         sigma_array = _compute_sigma(
-            flow=weight_flow,
+            flow=flow,
             tedges=weight_tedges,
             aquifer_pore_volumes=aquifer_pore_volumes,
             streamline_length=mean_streamline_length,
@@ -254,12 +250,12 @@ def infiltration_to_extraction(
             direction="infiltration_to_extraction",
         )
         cin_diffused = convolve_diffusion(
-            input_signal=weight_cin, sigma_array=sigma_array, asymptotic_cutoff_sigma=asymptotic_cutoff_sigma
+            input_signal=cin, sigma_array=sigma_array, asymptotic_cutoff_sigma=asymptotic_cutoff_sigma
         )
         cout = w_adv @ cin_diffused
     else:
         # New algorithm: advect-then-smooth (works with any tedges spacing)
-        cout_unsmoothed = w_adv @ weight_cin
+        cout_unsmoothed = w_adv @ cin
 
         # Rows with zero weight sum (spin-up or zero-flow cout bin) carry no
         # signal. Flag them so the normalized convolution
@@ -432,15 +428,11 @@ def extraction_to_infiltration(
     if n_pore_volumes > 1 and mean_longitudinal_dispersivity > 0 and not suppress_dispersion_warning:
         _warn_dispersion()
 
-    # Apply spinup policy: pad tedges and flow with warm-start prefix.
-    weight_tedges, weight_flow, _, threshold, n_pad = _resolve_spinup_inputs(
-        spinup,
-        tedges=tedges,
-        flow=flow,
-        aquifer_pore_volumes=aquifer_pore_volumes,
-        retardation_factor=retardation_factor,
-    )
-    n_cin_padded = len(weight_tedges) - 1
+    # Apply spinup policy: extend boundary tedges by 100 years on each side
+    # for "constant" mode (diffusion-style wide-edge padding). Lengths are
+    # preserved, so no slicing is needed on the recovered cin.
+    weight_tedges, threshold = _resolve_spinup_inputs_wide_edges(spinup, tedges=tedges)
+    n_cin = len(weight_tedges) - 1
     n_cout = len(cout_tedges) - 1
 
     # Build advection weight matrix on the (possibly padded) inputs.
@@ -448,7 +440,7 @@ def extraction_to_infiltration(
         tedges=weight_tedges,
         cout_tedges=cout_tedges,
         aquifer_pore_volumes=aquifer_pore_volumes,
-        flow=weight_flow,
+        flow=flow,
         retardation_factor=retardation_factor,
     )
     w_adv, _ = _resolve_spinup_mask(
@@ -460,11 +452,12 @@ def extraction_to_infiltration(
     )
 
     if flow_out is None:
-        # Original algorithm: G on input grid, W_forward = W_adv @ G
-        _check_uniform_tedges(tedges=weight_tedges, suppress=suppress_uniform_tedges_check)
+        # Original algorithm: G on input grid, W_forward = W_adv @ G.
+        # Check uniformity against user tedges only; wide boundary bins are OK.
+        _check_uniform_tedges(tedges=tedges, suppress=suppress_uniform_tedges_check)
 
         sigma_array = _compute_sigma(
-            flow=weight_flow,
+            flow=flow,
             tedges=weight_tedges,
             aquifer_pore_volumes=aquifer_pore_volumes,
             streamline_length=mean_streamline_length,
@@ -474,7 +467,7 @@ def extraction_to_infiltration(
             direction="infiltration_to_extraction",
         )
         g_matrix = _build_gaussian_matrix(
-            n=n_cin_padded, sigma_array=sigma_array, asymptotic_cutoff_sigma=asymptotic_cutoff_sigma
+            n=n_cin, sigma_array=sigma_array, asymptotic_cutoff_sigma=asymptotic_cutoff_sigma
         )
         # Combined forward matrix: W_adv @ G via sparse @ dense (avoids dense G allocation)
         w_forward = (g_matrix.T @ w_adv.T).T
@@ -495,15 +488,13 @@ def extraction_to_infiltration(
         )
         w_forward = g_matrix @ w_adv  # sparse @ dense
 
-    cin_padded = solve_inverse_transport(
+    return solve_inverse_transport(
         w_forward=w_forward,
         observed=cout,
-        n_output=n_cin_padded,
+        n_output=n_cin,
         regularization_strength=regularization_strength,
         warn_rank_deficient=True,
     )
-    # Drop the warm-start prefix so the output aligns with the user-provided tedges.
-    return cin_padded[n_pad:]
 
 
 def gamma_infiltration_to_extraction(


### PR DESCRIPTION
## Summary

- Follow-up to #178. The physics-based `R · V_max / flow[0]` warm-start padding adopted in `diffusion_fast` is too tight: the Gaussian smoothing kernel adds a tail (σ from `molecular_diffusivity` + `dispersivity`) that the advection-only padding silently misses. The analytical `diffusion` module already extends `tedges` by ±100 years on each side to handle this — this PR brings `diffusion_fast` in line so a user calling both modules with the same parameters sees the same boundary behavior.
- New `_resolve_spinup_inputs_wide_edges` helper in `advection_utils` shifts `tedges[0]` and `tedges[-1]` outward by 100 years (single wide boundary bin per side, length preserved). `diffusion_fast` i2e/e2i use this instead of the uniform-bin padding; cin/flow lengths are unchanged so the inverse path no longer slices off a prefix.
- `_check_uniform_tedges` now checks the user-supplied `tedges` rather than the padded ones, since the wide boundary bins are intentionally non-uniform and have a degenerate `σ_idx` (huge `dt` → tiny smoothing) that does not interfere with the kernel.

## Why 100 years

- `R · V_max / Q[0]` covers advection only. The Gaussian σ varies with diffusion/dispersion params (typically 10-30 days) and the kernel is truncated at 3σ, so the actual lookback is `R · V_max / Q + N · σ`.
- 100 years is arbitrary but greatly exceeds any reasonable groundwater residence time + Gaussian tail. Matches the existing `diffusion` module choice.
- Single wide boundary bin → O(1) overhead, not O(n_pad). No memory or compute cost.
- `advection.py` and `deposition.py` keep precise `R · V_max / Q` padding — they have no Gaussian tail and don't need the safety margin.

## Test plan

- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src -n auto` — 1011 passed, 8 skipped
- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest --doctest-modules src/gwtransport/...` — 16 passed
- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/examples -n auto` — 15 passed
- [x] `ruff format` + `ruff check` — clean
- [x] Cross-module probe: `diffusion.i2e` vs `diffusion_fast.i2e` with same parameters now produce zero NaN at boundaries in both modules; interior agreement is ≤0.12 abs diff (algorithmic difference between analytical erf and Gaussian smoothing, not boundary handling).

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.