### PR TITLE
examples: fix deposition default crash and enforce flow floor (#167)

### DIFF
--- a/src/gwtransport/examples.py
+++ b/src/gwtransport/examples.py
@@ -108,8 +108,11 @@ def generate_example_data(
         Seasonal amplitude of infiltration concentration (only used for
         ``"synthetic"`` method).
     measurement_noise : float, default 1.0
-        Random noise level applied to both cin and cout to represent
-        measurement errors.
+        Standard deviation of the Gaussian measurement noise applied
+        independently to ``cin`` and ``cout``. Because the two noise draws are
+        independent, applying the forward operator to ``df['cin']`` does not
+        exactly reproduce ``df['cout']`` when ``measurement_noise > 0``; the
+        underlying noiseless signals remain consistent.
     aquifer_pore_volumes : array-like or None, default None
         Discrete aquifer pore volumes [m3] representing the distribution of
         residence times. When provided, the gamma distribution is bypassed and
@@ -183,7 +186,6 @@ def generate_example_data(
     # Generate flow data with seasonal pattern (higher in winter)
     seasonal_flow = flow_mean + flow_amplitude * np.sin(2 * np.pi * days / 365 + np.pi)
     flow = seasonal_flow + rng.normal(0, flow_noise, len(dates))
-    flow = np.maximum(flow, 5.0)  # Ensure flow is not too small or negative
 
     min_days_for_spills = 60
     if len(dates) > min_days_for_spills:  # Only add spills for longer time series
@@ -194,6 +196,9 @@ def generate_example_data(
             spill_magnitude = float(rng.uniform(2.0, 5.0))
 
             flow[spill_start : spill_start + spill_duration] /= spill_magnitude
+
+    # Enforce a positive flow floor after spills so residence times remain finite.
+    flow = np.maximum(flow, 5.0)
 
     # Generate infiltration concentration. nonoise is needed to compute cout.
     if cin_method == "synthetic":
@@ -488,6 +493,7 @@ def generate_example_deposition_timeseries(
     event_duration: int = 30,
     event_decay_scale: float = 10.0,
     ensure_non_negative: bool = True,
+    rng: np.random.Generator | int | None = None,
 ) -> tuple[pd.Series, pd.DatetimeIndex]:
     """
     Generate synthetic deposition timeseries for groundwater transport examples.
@@ -505,8 +511,9 @@ def generate_example_deposition_timeseries(
     noise_scale : float
         Standard deviation scale for Gaussian noise added to the signal.
     event_dates : list-like or None
-        Dates (strings or pandas-compatible) at which to place episodic events. If None,
-        a sensible default list is used.
+        Dates (strings or pandas-compatible) at which to place episodic events.
+        Time-zone-naive entries are interpreted as UTC to match the generated
+        ``dates`` index. If None, a sensible default list is used.
     event_magnitude : float
         Peak magnitude multiplier for events.
     event_duration : int
@@ -515,12 +522,19 @@ def generate_example_deposition_timeseries(
         Decay scale used in the exponential decay for event time series.
     ensure_non_negative : bool
         If True, negative values are clipped to zero.
+    rng : numpy.random.Generator, int, or None, default None
+        Source of randomness for the additive Gaussian noise. Accepted in any
+        form supported by :func:`numpy.random.default_rng`. Pass an integer
+        (or :class:`numpy.random.Generator`) for reproducible output; ``None``
+        draws fresh entropy each call.
 
     Returns
     -------
     pandas.Series
         Time series of deposition values indexed by daily timestamps.
     """
+    rng = np.random.default_rng(rng)
+
     # Create synthetic deposition time series - needs to match flow period
     dates = pd.date_range(date_start, date_end, freq=freq).tz_localize("UTC")
     n_dates = len(dates)
@@ -528,7 +542,7 @@ def generate_example_deposition_timeseries(
 
     # Base deposition rate with seasonal and event patterns
     seasonal_pattern = seasonal_amplitude * np.sin(2 * np.pi * np.arange(n_dates) / 365.25)
-    noise = noise_scale * np.random.normal(0, 1, n_dates)
+    noise = noise_scale * rng.normal(0, 1, n_dates)
 
     # Default event dates if not provided
     if event_dates is None:
@@ -540,6 +554,12 @@ def generate_example_deposition_timeseries(
         # Convert ArrayLike to list for pd.to_datetime
         event_dates_list = event_dates if isinstance(event_dates, list) else list(np.asarray(event_dates))
         event_dates_index = pd.DatetimeIndex(pd.to_datetime(event_dates_list))
+    # Match the timezone of `dates` so naive user input (and the string defaults)
+    # can be compared against the tz-aware index in `get_indexer`.
+    if event_dates_index.tz is None:
+        event_dates_index = event_dates_index.tz_localize(dates.tz)
+    else:
+        event_dates_index = event_dates_index.tz_convert(dates.tz)
 
     event = np.zeros(n_dates)
     for event_date in event_dates_index:

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytest
 import requests.exceptions
 
-from gwtransport.examples import generate_example_data
+from gwtransport.examples import generate_example_data, generate_example_deposition_timeseries
 from gwtransport.utils import (
     _diff,
     _make_strictly_monotone,
@@ -1298,3 +1298,72 @@ def test_generate_example_data_seed_changes_output():
         rng=2,
     )
     assert not np.array_equal(df_a["flow"].to_numpy(), df_b["flow"].to_numpy())
+
+
+@pytest.mark.parametrize("seed", list(range(20)))
+def test_generate_example_data_flow_floor_enforced(seed):
+    """Flow floor of 5 m3/day must hold even after the spill loop divides flow.
+
+    Regression test for issue 167: the floor was applied before spills, so
+    spill divisions could push flow well below 5 m3/day (observed min ~0.3).
+    """
+    df, _ = generate_example_data(rng=seed)
+    assert df["flow"].min() >= 5.0, f"flow min {df['flow'].min()} below 5.0 m3/day for seed={seed}"
+
+
+# =============================================================================
+# Tests for examples.generate_example_deposition_timeseries
+# =============================================================================
+
+
+def test_generate_example_deposition_timeseries_default_call():
+    """Calling with no arguments must work end-to-end.
+
+    Regression test for issue 167: the default event_dates list was tz-naive
+    while the dates index was tz-aware (UTC), causing
+    ``TypeError: Cannot compare dtypes datetime64[us, UTC] and datetime64[us]``
+    inside ``get_indexer``.
+    """
+    series, tedges = generate_example_deposition_timeseries()
+    assert len(series) == len(tedges) - 1
+    assert isinstance(series.index, pd.DatetimeIndex)
+    assert series.index.tz is not None
+    assert series.notna().all()
+
+
+def test_generate_example_deposition_timeseries_naive_event_dates():
+    """Tz-naive user event_dates must be accepted and aligned to the UTC index."""
+    series, _ = generate_example_deposition_timeseries(
+        date_start="2020-01-01",
+        date_end="2020-12-31",
+        event_dates=["2020-06-15", "2020-09-01"],
+        rng=0,
+    )
+    assert isinstance(series.index, pd.DatetimeIndex)
+    assert series.index.tz is not None
+
+
+def test_generate_example_deposition_timeseries_tz_aware_event_dates():
+    """Tz-aware event_dates in a non-UTC zone must be converted, not rejected."""
+    event_dates = pd.DatetimeIndex(["2020-06-15 02:00"]).tz_localize("Europe/Amsterdam")
+    series, _ = generate_example_deposition_timeseries(
+        date_start="2020-01-01",
+        date_end="2020-12-31",
+        event_dates=event_dates,
+        rng=0,
+    )
+    assert series.notna().all()
+
+
+def test_generate_example_deposition_timeseries_seed_reproducibility():
+    """Two calls with the same integer seed must produce identical series."""
+    s_a, _ = generate_example_deposition_timeseries(rng=12345)
+    s_b, _ = generate_example_deposition_timeseries(rng=12345)
+    np.testing.assert_array_equal(s_a.to_numpy(), s_b.to_numpy())
+
+
+def test_generate_example_deposition_timeseries_seed_changes_output():
+    """Different seeds must produce different stochastic series."""
+    s_a, _ = generate_example_deposition_timeseries(rng=1)
+    s_b, _ = generate_example_deposition_timeseries(rng=2)
+    assert not np.array_equal(s_a.to_numpy(), s_b.to_numpy())


### PR DESCRIPTION
## Summary

Closes #167. Fixes a default-invocation crash in the deposition generator, restores the documented flow floor, and tightens reproducibility/docstrings.

- `generate_example_deposition_timeseries()`: localize tz-naive `event_dates` (including the string defaults) to UTC and `tz_convert` tz-aware input. Previously the default invocation raised `TypeError: Cannot compare dtypes datetime64[us, UTC] and datetime64[us]` at `get_indexer`.
- `generate_example_deposition_timeseries()`: add `rng: np.random.Generator | int | None = None` and route noise through it instead of the global NumPy RNG.
- `generate_example_data()`: move the 5 m³/day flow floor to *after* the spill loop so spill divisions cannot push flow below the floor (observed min ≈ 0.3 m³/day on 60% of seeds before this change).
- `generate_example_data()`: docstring clarifies that `cin` and `cout` get independent noise draws, so `forward(cin) ≠ cout` when `measurement_noise > 0`.

Both bugs were confirmed against the unchanged baseline before applying the fix.

## Test plan

- [x] `pytest tests/src -n auto` — 1050 passed, 8 skipped.
- [x] `pytest tests/examples -k Deposition -n auto` — example notebook still runs.
- [x] `ruff format` + `ruff check --fix` — clean.
- [x] `ty check src/gwtransport/examples.py tests/src/test_utils.py` — clean.
- [x] New regression tests:
  - `test_generate_example_deposition_timeseries_default_call`
  - `test_generate_example_deposition_timeseries_naive_event_dates`
  - `test_generate_example_deposition_timeseries_tz_aware_event_dates`
  - `test_generate_example_deposition_timeseries_seed_reproducibility`
  - `test_generate_example_deposition_timeseries_seed_changes_output`
  - `test_generate_example_data_flow_floor_enforced` (parametrized over 20 seeds)

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.