### PR TITLE
gamma: address #172 test gaps and #165 leanness comment

### DIFF
--- a/src/gwtransport/gamma.py
+++ b/src/gwtransport/gamma.py
@@ -47,16 +47,12 @@ Available functions:
   custom quantile edges. Returns bin edges, expected values (mean pore volume within each
   bin), and probability masses (weight in transport calculations).
 
-- :func:`bin_masses` - Calculate probability mass for custom bin edges using the incomplete
-  gamma function. Lower-level function used internally by bins().
-
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """
 
 import numpy as np
 import numpy.typing as npt
-from scipy.special import gammainc
 from scipy.stats import gamma as gamma_dist
 
 
@@ -119,10 +115,10 @@ def parse_parameters(
         if mean is None or std is None:
             msg = "Either (alpha, beta) or (mean, std) must be provided."
             raise ValueError(msg)
-
+        # mean_std_loc_to_alpha_beta enforces std>0 and mean>loc, which together with
+        # loc>=0 guarantee alpha=(mean-loc)**2/std**2 > 0 and beta=std**2/(mean-loc) > 0.
         alpha, beta = mean_std_loc_to_alpha_beta(mean=mean, std=std, loc=loc)
-
-    if alpha <= 0 or beta <= 0:
+    elif alpha <= 0 or beta <= 0:
         msg = "Alpha and beta must be positive"
         raise ValueError(msg)
 
@@ -206,6 +202,9 @@ def alpha_beta_loc_to_mean_std(*, alpha: float, beta: float, loc: float = 0.0) -
     """
     Convert shape, scale, and location of gamma distribution to mean and standard deviation.
 
+    Parameters are validated via :func:`parse_parameters`, which raises ``ValueError`` if
+    ``alpha`` or ``beta`` are non-positive or ``loc`` is negative.
+
     Parameters
     ----------
     alpha : float
@@ -224,11 +223,6 @@ def alpha_beta_loc_to_mean_std(*, alpha: float, beta: float, loc: float = 0.0) -
         Standard deviation of the gamma distribution, equal to ``sqrt(alpha) * beta``.
         ``std`` is invariant under the ``loc`` shift.
 
-    Raises
-    ------
-    ValueError
-        If ``loc`` is negative.
-
     See Also
     --------
     mean_std_loc_to_alpha_beta : Convert mean/std/loc to shape and scale parameters.
@@ -245,12 +239,8 @@ def alpha_beta_loc_to_mean_std(*, alpha: float, beta: float, loc: float = 0.0) -
     >>> print(f"Std pore volume: {std:.0f} m³")  # doctest: +ELLIPSIS
     Std pore volume: 810... m³
     """
-    if loc < 0:
-        msg = "loc must be non-negative"
-        raise ValueError(msg)
-    mean = alpha * beta + loc
-    std = np.sqrt(alpha) * beta
-    return mean, std
+    parse_parameters(alpha=alpha, beta=beta, loc=loc)
+    return alpha * beta + loc, np.sqrt(alpha) * beta
 
 
 def bins(
@@ -313,7 +303,6 @@ def bins(
 
     See Also
     --------
-    bin_masses : Calculate probability mass for bins.
     mean_std_loc_to_alpha_beta : Convert mean/std/loc to alpha/beta parameters.
     gwtransport.advection.gamma_infiltration_to_extraction : Use bins for transport modeling.
     :ref:`concept-gamma-distribution` : Two-parameter pore volume model.
@@ -344,13 +333,10 @@ def bins(
     """
     alpha, beta, loc = parse_parameters(mean=mean, std=std, loc=loc, alpha=alpha, beta=beta)
 
-    # Calculate boundaries for equal mass bins
-    # If quantile_edges is provided, use it (n_bins is ignored)
-    # Otherwise, use n_bins (which defaults to 100)
     if quantile_edges is not None:
         n_bins = len(quantile_edges) - 1
     else:
-        quantile_edges = np.linspace(0, 1, n_bins + 1)  # includes 0 and 1
+        quantile_edges = np.linspace(0, 1, n_bins + 1)
 
     if n_bins <= 1:
         msg = "Number of bins must be greater than 1"
@@ -364,9 +350,8 @@ def bins(
     # Conditional mean within each bin for the unshifted distribution, then shift by loc.
     # E[X | a <= X < b] for X ~ Gamma(alpha, beta) uses the identity
     #     E[X * 1_{a<=X<b}] = alpha * beta * (F_{alpha+1}(b/beta) - F_{alpha+1}(a/beta))
-    # where F_{alpha+1} is the CDF of Gamma(alpha+1, beta). The bin_masses helper returns
-    # exactly those differences.
-    diff_alpha_plus_1 = bin_masses(alpha=alpha + 1, beta=beta, bin_edges=unshifted_edges)
+    # where F_{alpha+1} is the CDF of Gamma(alpha+1, beta).
+    diff_alpha_plus_1 = _bin_masses(alpha=alpha + 1, beta=beta, bin_edges=unshifted_edges)
     expected_values = beta * alpha * diff_alpha_plus_1 / probability_mass + loc
 
     return {
@@ -378,53 +363,16 @@ def bins(
     }
 
 
-def bin_masses(*, alpha: float, beta: float, bin_edges: npt.ArrayLike) -> npt.NDArray[np.floating]:
-    """
-    Calculate probability mass for each bin in a standard (unshifted) gamma distribution.
+def _bin_masses(*, alpha: float, beta: float, bin_edges: npt.ArrayLike) -> npt.NDArray[np.floating]:
+    """Probability mass per bin for the unshifted Gamma(alpha, beta).
 
-    Is the area under the Gamma(alpha, beta) PDF between the bin edges. This lower-level
-    function operates on the unshifted gamma distribution; if a location shift is needed,
-    callers should subtract ``loc`` from their physical bin edges before passing them in.
-    Because probability mass is invariant under a location shift, the result is identical
-    to that of the shifted distribution.
-
-    Parameters
-    ----------
-    alpha : float
-        Shape parameter of gamma distribution (must be > 0).
-    beta : float
-        Scale parameter of gamma distribution (must be > 0).
-    bin_edges : array-like
-        Bin edges of the unshifted distribution. Array of increasing values of size
-        ``len(bins) + 1``. Must be non-negative.
+    Internal helper. Callers must guarantee ``alpha, beta > 0`` and monotonically
+    increasing ``bin_edges >= 0`` with at least two entries.
 
     Returns
     -------
-    numpy.ndarray
-        Probability mass for each bin.
-
-    Raises
-    ------
-    ValueError
-        If ``alpha`` or ``beta`` are not positive, if ``bin_edges`` contains fewer than two
-        values, if ``bin_edges`` are not monotonically increasing, or if any ``bin_edges``
-        are negative.
+    ndarray
+        Probability mass per bin, of length ``len(bin_edges) - 1``.
     """
-    # Convert inputs to numpy arrays
-    bin_edges = np.asarray(bin_edges)
-
-    # Validate inputs
-    if alpha <= 0 or beta <= 0:
-        msg = "Alpha and beta must be positive"
-        raise ValueError(msg)
-    if len(bin_edges) < 2:  # noqa: PLR2004
-        msg = "Bin edges must contain at least two values"
-        raise ValueError(msg)
-    if np.any(np.diff(bin_edges) < 0):
-        msg = "Bin edges must be increasing"
-        raise ValueError(msg)
-    if np.any(bin_edges < 0):
-        msg = "Bin edges must be non-negative"
-        raise ValueError(msg)
-    val = gammainc(alpha, bin_edges / beta)
+    val = gamma_dist.cdf(np.asarray(bin_edges), alpha, scale=beta)
     return val[1:] - val[:-1]

--- a/tests/src/test_gamma.py
+++ b/tests/src/test_gamma.py
@@ -4,8 +4,8 @@ import pytest
 from scipy.stats import gamma as gamma_dist
 
 from gwtransport.gamma import (
+    _bin_masses,
     alpha_beta_loc_to_mean_std,
-    bin_masses,
     mean_std_loc_to_alpha_beta,
     parse_parameters,
 )
@@ -34,35 +34,21 @@ def gamma_params():
     }
 
 
-# Test bin_masses function
-def test_bin_masses_basic():
-    """Test basic functionality of bin_masses."""
-    edges = np.array([0, 1, 2, np.inf])
-    masses = bin_masses(alpha=2.0, beta=1.0, bin_edges=edges)
-
-    assert len(masses) == len(edges) - 1
+# Tests for the private _bin_masses helper. It has no input validation by design;
+# its preconditions are guaranteed by the only internal caller (bins()).
+def test_bin_masses_normalization_over_full_support():
+    """``_bin_masses`` over ``[0, inf)`` integrates to 1 exactly."""
+    masses = _bin_masses(alpha=2.0, beta=1.0, bin_edges=np.array([0, 1, 2, np.inf]))
+    assert len(masses) == 3
     assert np.all(masses >= 0)
-    assert np.isclose(np.sum(masses), 1.0, rtol=1e-10)
+    np.testing.assert_allclose(np.sum(masses), 1.0, rtol=1e-14)
 
 
-def test_bin_masses_invalid_params():
-    """Test bin_masses with invalid parameters."""
-    edges = np.array([0, 1, 2])
-
-    with pytest.raises(ValueError):
-        bin_masses(alpha=-1, beta=1.0, bin_edges=edges)
-
-    with pytest.raises(ValueError):
-        bin_masses(alpha=1.0, beta=-1, bin_edges=edges)
-
-
-def test_bin_masses_single_bin():
-    """Test bin_masses with a single bin."""
-    edges = np.array([0, np.inf])
-    masses = bin_masses(alpha=2.0, beta=1.0, bin_edges=edges)
-
+def test_bin_masses_single_bin_is_unit():
+    """A single bin spanning the full support carries the entire probability mass."""
+    masses = _bin_masses(alpha=2.0, beta=1.0, bin_edges=np.array([0, np.inf]))
     assert len(masses) == 1
-    assert np.isclose(masses[0], 1.0, rtol=1e-10)
+    np.testing.assert_allclose(masses[0], 1.0, rtol=1e-14)
 
 
 # Test bins function
@@ -112,15 +98,38 @@ def test_invalid_parameters():
         gamma_bins(alpha=1, beta=-1, n_bins=10)
 
 
-def test_numerical_stability():
-    """Test numerical stability with extreme parameters."""
-    # Test with very small alpha and beta
-    result_small = gamma_bins(alpha=1e-5, beta=1e-5, n_bins=10)
-    assert not np.any(np.isnan(result_small["expected_values"]))
+@pytest.mark.parametrize(
+    ("alpha", "beta"),
+    [
+        (0.05, 1.0),  # alpha << 1: PDF singularity at 0
+        (0.5, 1.0),  # alpha < 1
+        (0.5, 1e-3),  # alpha < 1, beta tiny
+        (1.0, 1.0),  # exponential
+        (10.0, 1.0),  # moderate
+        (1e4, 1.0),  # very large alpha
+        (1.0, 1e3),  # beta large
+    ],
+)
+def test_bins_extreme_regimes_finite_and_conservative(alpha, beta):
+    """Across extreme regimes, ``bins`` must produce finite, in-bin values and conserve mass + first moment.
 
-    # Test with very large alpha and beta
-    result_large = gamma_bins(alpha=1e5, beta=1e5, n_bins=10)
-    assert not np.any(np.isnan(result_large["expected_values"]))
+    Replaces the original ``test_numerical_stability`` (only asserted non-NaN).
+    """
+    n_bins = 10
+    r = gamma_bins(alpha=alpha, beta=beta, n_bins=n_bins)
+
+    assert np.all(np.isfinite(r["expected_values"])), f"non-finite expected_values at alpha={alpha}, beta={beta}"
+    assert np.all(r["expected_values"] > 0)
+
+    np.testing.assert_allclose(np.sum(r["probability_mass"]), 1.0, rtol=1e-14)
+
+    # sum(p_i * E[X|bin_i]) == alpha * beta to machine precision
+    total_mean = float(np.sum(r["expected_values"] * r["probability_mass"]))
+    np.testing.assert_allclose(total_mean, alpha * beta, rtol=1e-14)
+
+    # Conditional means lie strictly within their bins
+    assert np.all(r["lower_bound"] <= r["expected_values"])
+    assert np.all(r["expected_values"] <= r["upper_bound"])
 
 
 def test_gamma_mean_std_loc_to_alpha_beta_basic():
@@ -577,6 +586,88 @@ def test_bins_mean_std_loc_conservation():
     r = gamma_bins(mean=mean, std=std, loc=loc, n_bins=100)
     total_mean = float(np.sum(r["expected_values"] * r["probability_mass"]))
     np.testing.assert_allclose(total_mean, mean, rtol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("mean", "std", "loc"),
+    [
+        (10.0, 2.0, 0.0),  # alpha=25, loc=0
+        (30000.0, 8100.0, 5000.0),  # large with shift
+        (5.0, 1.5, 1.0),  # moderate
+        (2.0, 1.5, 0.0),  # alpha=(2/1.5)**2 ~ 1.78
+        (0.5, 0.5, 0.0),  # alpha=1 (exponential)
+        (0.6, 1.0, 0.0),  # alpha < 1 (PDF singularity at 0)
+        (1e6, 1.0, 0.0),  # alpha very large (1e12)
+    ],
+)
+def test_bins_parameterization_equivalence(mean, std, loc):
+    """``bins(mean=m, std=s, loc=l)`` must equal ``bins(alpha, beta, loc=l)`` bit-for-bit.
+
+    Both arms share the same converter, so the conversion *formula* (caught by
+    ``test_bins_second_moment_matches_parameterization``) is not what this test
+    targets. What it pins is the dispatcher: ``parse_parameters`` correctly forwarding
+    ``loc`` through both branches, neither branch silently dropping a default, and the
+    downstream pipeline being deterministic in ``(alpha, beta, loc)``.
+    """
+    n_bins = 20
+    r_msl = gamma_bins(mean=mean, std=std, loc=loc, n_bins=n_bins)
+    alpha, beta = mean_std_loc_to_alpha_beta(mean=mean, std=std, loc=loc)
+    r_ab = gamma_bins(alpha=alpha, beta=beta, loc=loc, n_bins=n_bins)
+
+    np.testing.assert_array_equal(r_msl["edges"], r_ab["edges"])
+    np.testing.assert_array_equal(r_msl["expected_values"], r_ab["expected_values"])
+    np.testing.assert_array_equal(r_msl["probability_mass"], r_ab["probability_mass"])
+    np.testing.assert_array_equal(r_msl["lower_bound"], r_ab["lower_bound"])
+    np.testing.assert_array_equal(r_msl["upper_bound"], r_ab["upper_bound"])
+
+
+@pytest.mark.parametrize(
+    ("mean", "std", "loc"),
+    [
+        (10.0, 2.0, 0.0),
+        (30000.0, 8100.0, 5000.0),
+        (5.0, 1.5, 1.0),
+        (2.0, 0.5, 0.5),
+    ],
+)
+def test_bins_second_moment_matches_parameterization(mean, std, loc):
+    """``std`` is the parameter that controls the variance: ``Var(Gamma) = alpha * beta**2 == std**2`` exactly.
+
+    The (mean, std, loc) parameterization sets ``alpha = (mean-loc)**2 / std**2`` and
+    ``beta = std**2 / (mean-loc)``, so ``alpha * beta**2 == std**2`` is an algebraic
+    identity. A coefficient swap (e.g. ``alpha = (mean-loc) / std**2``) would silently
+    lose this identity at machine-precision tolerance.
+    """
+    alpha, beta, loc_out = parse_parameters(mean=mean, std=std, loc=loc)
+    np.testing.assert_allclose(alpha * beta**2, std**2, rtol=1e-15)
+    np.testing.assert_allclose(gamma_dist(alpha, loc=loc_out, scale=beta).var(), std**2, rtol=1e-12)
+    np.testing.assert_allclose(gamma_dist(alpha, loc=loc_out, scale=beta).mean(), mean, rtol=1e-12)
+
+
+def test_bin_masses_quantile_inverse():
+    """``bin_masses`` applied to ``gamma.bins`` edges recovers the input quantile diff exactly.
+
+    The construction
+        edges = gamma_dist.ppf(q, alpha, scale=beta) + loc
+        bin_masses(alpha, beta, edges - loc) = diff(gammainc(alpha, ppf(q)/beta))
+                                             = diff(q)
+    holds by the CDF-PPF round-trip identity ``F(F^{-1}(q)) == q``. Catches any
+    inconsistency between the edge-construction path and the mass-computation path.
+    """
+    quantile_edges = np.array([0.0, 0.1, 0.3, 0.55, 0.85, 1.0])
+    alpha, beta, loc = 3.0, 2.0, 1.5
+    r = gamma_bins(alpha=alpha, beta=beta, loc=loc, quantile_edges=quantile_edges)
+
+    # probability_mass is constructed directly as np.diff(q) inside bins
+    np.testing.assert_array_equal(r["probability_mass"], np.diff(quantile_edges))
+
+    # _bin_masses applied to the unshifted edges must reproduce diff(q) to machine precision
+    unshifted_edges = r["edges"] - loc
+    np.testing.assert_allclose(
+        _bin_masses(alpha=alpha, beta=beta, bin_edges=unshifted_edges),
+        np.diff(quantile_edges),
+        rtol=1e-13,
+    )
 
 
 def test_bins_loc_monte_carlo_expected_values():


### PR DESCRIPTION
## Summary

Addresses the two remaining open items against the gamma module:

- **Issue #172 (gamma subsection)**: replaces `test_numerical_stability` (which only asserted non-NaN) with a parametrized regime test asserting finite values, in-bin conditional means, and mass / first-moment conservation to `rtol=1e-14`. Adds three new tests for parameterization equivalence at the bins level, the algebraic `Var = α·β² == std²` identity, and the `_bin_masses` ↔ quantile-edges inverse.
- **Issue #165 leanness comment**: removes duplicated `loc<0` validation by routing `alpha_beta_loc_to_mean_std` through `parse_parameters`, drops the dead `alpha<=0/beta<=0` check on the mean/std path of `parse_parameters`, privatizes `bin_masses` → `_bin_masses` (drops all four redundant validation branches; only internal caller is `bins()`), and swaps `scipy.special.gammainc(α, x/β)` for the bit-identical `scipy.stats.gamma.cdf(x, α, scale=β)` (drops the `gammainc` import).

**Breaking change**: `gwtransport.gamma.bin_masses` is renamed to `_bin_masses`. Repo-wide grep confirms no external caller; no source or example notebook references it. The headline items in #165 (residence_time kink, gamma docstring arithmetic) already shipped in PR #175 — only the leanness comment was outstanding.

## Test plan

- [x] `pytest tests/src/test_gamma.py` — 59 tests pass (was 42; +17 from new/parametrized cases, -1 from removing `test_bin_masses_invalid_params` since the private helper no longer validates)
- [x] `pytest tests/src -n auto` — 1085 passed, 8 skipped (no regressions across all modules)
- [x] `pytest --doctest-modules src/gwtransport/gamma.py` — 3 passed
- [x] `ruff format` / `ruff check` clean
- [x] `ty check .` clean
- [x] `bas-physics-math-reviewer` — clean sign-off (no math issues)
- [x] `bas-test-reviewer` — sign-off after tightening tolerances to `rtol=1e-14` and clarifying one docstring overclaim
- [x] `bas-code-optimizer` — sign-off after applying two Tier-3 wins (inlined single-use locals in `alpha_beta_loc_to_mean_std`, dropped stale comment block in `bins`)

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.