### PR TITLE
deposition: fix row-normalization docstring, tighten tests, consolidate local validation prologues

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -65,6 +65,9 @@ convention = "numpy"
     "DOC501",  # Test functions don't need Raises docs
     "DOC502",  # Test helpers may document exceptions not directly raised
 ]
+"src/gwtransport/deposition.py" = [
+    "DOC502",  # Public entry points document ValueError; the raises happen inside _validate_deposition_inputs
+]
 "tests/**/test_*.py" = [
     "S101",    # asserts allowed in tests
     "D",

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -211,6 +211,12 @@ def deposition_to_extraction(
     gwtransport.advection.infiltration_to_extraction : For concentration transport without deposition
     :ref:`concept-transport-equation` : Flow-weighted averaging approach
 
+    Notes
+    -----
+    This is a *source* term -- positive ``dep`` raises ``cout``. Sink
+    processes (pathogen attachment, first-order decay, particle filtration)
+    require the opposite sign convention and are not modelled here.
+
     Examples
     --------
     >>> import pandas as pd
@@ -384,15 +390,23 @@ def extraction_to_deposition(
 
     Notes
     -----
+    This is a *source* term -- positive ``dep`` raises ``cout``. Sink
+    processes (pathogen attachment, first-order decay, particle filtration)
+    require the opposite sign convention and are not modelled here.
+
     The forward model is ``W @ dep = cout``, where the weight matrix ``W``
     encodes the physical relationship between deposition rates and
     concentrations. Unlike advection (where rows sum to ~1), deposition rows
-    sum to ``residence_time / (porosity * thickness)``. The system is
-    row-normalized before solving so that each observation contributes equally
-    and ``compute_reverse_target`` gives the correct scale for the
-    regularization target. Rows where the residence time cannot be computed
-    (spin-up period) contain NaN and are excluded automatically. NaN values
-    in ``cout`` are also excluded.
+    sum to ``r_i = residence_time_i / (porosity * thickness)``. Rows are
+    rescaled by ``r_i`` before solving: for systems where ``cout`` lies in
+    the column space of ``W`` this preserves the exact ``dep``, while for
+    overdetermined systems with noise it is equivalent to weighted least
+    squares with weights ``1 / r_i^2`` (shorter residence times get more
+    weight; under constant flow all ``r_i`` are equal and this reduces to
+    OLS). The rescaling exists to put ``compute_reverse_target`` on the same
+    scale as ``dep``, which controls the regularization scale. Rows where
+    the residence time cannot be computed (spin-up period) contain NaN and
+    are excluded automatically. NaN values in ``cout`` are also excluded.
 
     Examples
     --------
@@ -471,12 +485,16 @@ def extraction_to_deposition(
 
     n_dep_padded = len(weight_tedges) - 1
 
-    # Normalize weight matrix rows to sum to 1. The deposition weight matrix
-    # W has row sums equal to residence_time/(porosity*thickness), not 1 like
-    # advection. Normalizing makes each observation equally important and
-    # gives compute_reverse_target the correct scale for the target.
-    # NaN rows (spin-up), all-zero rows (zero-flow cout bins; carry no info),
-    # and NaN values in cout are excluded by solve_tikhonov.
+    # Rescale rows of W by their sum r_i = RT_i / (porosity*thickness). For
+    # systems where cout lies in the column space of W (e.g., noise-free
+    # roundtrip), this preserves the exact dep. For overdetermined systems
+    # with noise the rescaling is equivalent to weighted least squares with
+    # weights 1/r_i^2 -- shorter residence times get more weight; under
+    # constant flow all r_i are equal and this reduces to OLS. The rescaling
+    # exists to put compute_reverse_target on the same scale as dep, which
+    # controls the regularization scale. NaN rows (spin-up), all-zero rows
+    # (zero-flow cout bins; carry no info), and NaN values in cout are
+    # excluded by solve_tikhonov.
     valid_rows = ~np.isnan(deposition_weights).any(axis=1) & (np.abs(deposition_weights).sum(axis=1) > 0)
     valid_weights = deposition_weights[valid_rows]
     row_sums = valid_weights.sum(axis=1, keepdims=True)
@@ -615,6 +633,12 @@ def extraction_to_deposition_full(
     --------
     extraction_to_deposition : Recommended solver using Tikhonov regularization.
     gwtransport.utils.solve_underdetermined_system : Underlying solver.
+
+    Notes
+    -----
+    This is a *source* term -- positive ``dep`` raises ``cout``. Sink
+    processes (pathogen attachment, first-order decay, particle filtration)
+    require the opposite sign convention and are not modelled here.
     """
     tedges, cout_tedges = pd.DatetimeIndex(tedges), pd.DatetimeIndex(cout_tedges)
     cout_values, flow_values = np.asarray(cout), np.asarray(flow)

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -66,6 +66,73 @@ from gwtransport.utils import (
 )
 
 
+def _validate_deposition_inputs(
+    *,
+    tedges: pd.DatetimeIndex,
+    flow_values: np.ndarray,
+    aquifer_pore_volume: float,
+    porosity: float,
+    thickness: float,
+    cout_tedges: pd.DatetimeIndex | None = None,
+    cout_values: np.ndarray | None = None,
+    dep_values: np.ndarray | None = None,
+) -> None:
+    """Validate inputs common to deposition forward / reverse / full entry points.
+
+    Activates checks per the kwargs that are not None:
+
+    - ``dep_values`` provided => ``tedges``-parity vs ``dep`` + combined dep+flow
+      NaN-check (forward path; preserves the historical "Input arrays cannot
+      contain NaN values" message that covered both dep and flow).
+    - ``cout_values`` + ``cout_tedges`` provided => ``cout_tedges``-parity check
+      (inverse paths). ``cout_values`` itself is intentionally NOT NaN-checked
+      -- NaN in ``cout`` is allowed and excluded downstream by ``solve_tikhonov``.
+    - ``flow_values`` + ``tedges`` always => parity check + non-negative;
+      additionally, in the inverse path (``dep_values is None``), a flow-only
+      NaN-check fires with the historical "flow array cannot contain NaN
+      values" message.
+    - Physical params (``porosity``, ``thickness``, ``aquifer_pore_volume``)
+      always validated.
+
+    Every error message and f-string substitution is preserved verbatim from
+    the prior triplicate prologue so that ``match=`` regex tests do not break.
+
+    Raises
+    ------
+    ValueError
+        If any of the activated checks fails. The specific message names which
+        invariant was violated (see body for the verbatim strings).
+    """
+    if dep_values is not None and len(tedges) != len(dep_values) + 1:
+        msg = "tedges must have one more element than dep"
+        raise ValueError(msg)
+    if len(tedges) != len(flow_values) + 1:
+        msg = "tedges must have one more element than flow"
+        raise ValueError(msg)
+    if cout_values is not None and cout_tedges is not None and len(cout_tedges) != len(cout_values) + 1:
+        msg = "cout_tedges must have one more element than cout"
+        raise ValueError(msg)
+    if dep_values is not None:
+        if np.any(np.isnan(dep_values)) or np.any(np.isnan(flow_values)):
+            msg = "Input arrays cannot contain NaN values"
+            raise ValueError(msg)
+    elif np.any(np.isnan(flow_values)):
+        msg = "flow array cannot contain NaN values"
+        raise ValueError(msg)
+    if np.any(flow_values < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
+        raise ValueError(msg)
+    if not 0 < porosity < 1:
+        msg = f"Porosity must be in (0, 1), got {porosity}"
+        raise ValueError(msg)
+    if thickness <= 0:
+        msg = f"Thickness must be positive, got {thickness}"
+        raise ValueError(msg)
+    if aquifer_pore_volume <= 0:
+        msg = f"Aquifer pore volume must be positive, got {aquifer_pore_volume}"
+        raise ValueError(msg)
+
+
 def compute_deposition_weights(
     *,
     flow: npt.ArrayLike,
@@ -122,9 +189,7 @@ def compute_deposition_weights(
         retardation_factor=retardation_factor,
         direction="extraction_to_infiltration",
     )
-    # residence_time returns shape (n_pore_volumes, n_index); we pass a single
-    # pore volume so select row 0 explicitly.
-    cout_tedges_days_infiltration = cout_tedges_days - cout_rt_at_edges[0, :]
+    cout_tedges_days_infiltration = cout_tedges_days - cout_rt_at_edges.squeeze(axis=0)
 
     flow_cum = np.concatenate(([0.0], np.cumsum(flow_values * np.diff(tedges_days))))
 
@@ -132,21 +197,17 @@ def compute_deposition_weights(
     start_vol = linear_interpolate(x_ref=tedges_days, y_ref=flow_cum, x_query=cout_tedges_days_infiltration)
     end_vol = linear_interpolate(x_ref=tedges_days, y_ref=flow_cum, x_query=cout_tedges_days)
 
-    # Compute deposition weights
+    # Compute deposition weights. Zero-flow cout bins have extracted_volume == 0;
+    # np.divide with where=mask leaves those rows at the out=zeros sentinel.
     flow_cum_cout = flow_cum[None, :] - start_vol[:, None]
     volume_array = compute_average_heights(
         x_edges=tedges_days, y_edges=flow_cum_cout, y_lower=0.0, y_upper=retardation_factor * float(aquifer_pore_volume)
     )
     area_array = volume_array / (porosity * thickness)
     extracted_volume = np.diff(end_vol)
-    # Zero-flow cout bins have extracted_volume == 0 (no water extracted), so
-    # the weight row collapses to 0: no extraction contributes no deposition
-    # signature to cout. Use a sentinel divisor on those rows to avoid the
-    # division-by-zero warning before np.where discards them.
     numerator = area_array * np.diff(tedges_days)[None, :]
     mask = extracted_volume > 0
-    safe_denom = np.where(mask, extracted_volume, 1.0)[:, None]
-    return np.where(mask[:, None], numerator / safe_denom, 0.0)
+    return np.divide(numerator, extracted_volume[:, None], out=np.zeros_like(numerator), where=mask[:, None])
 
 
 def deposition_to_extraction(
@@ -240,30 +301,14 @@ def deposition_to_extraction(
     tedges, cout_tedges = pd.DatetimeIndex(tedges), pd.DatetimeIndex(cout_tedges)
     dep_values, flow_values = np.asarray(dep), np.asarray(flow)
 
-    # Validate input dimensions and values
-    if len(tedges) != len(dep_values) + 1:
-        msg = "tedges must have one more element than dep"
-        raise ValueError(msg)
-    if len(tedges) != len(flow_values) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-    if np.any(np.isnan(dep_values)) or np.any(np.isnan(flow_values)):
-        msg = "Input arrays cannot contain NaN values"
-        raise ValueError(msg)
-    if np.any(flow_values < 0):
-        msg = "flow must be non-negative (negative flow not supported)"
-        raise ValueError(msg)
-
-    # Validate physical parameters
-    if not 0 < porosity < 1:
-        msg = f"Porosity must be in (0, 1), got {porosity}"
-        raise ValueError(msg)
-    if thickness <= 0:
-        msg = f"Thickness must be positive, got {thickness}"
-        raise ValueError(msg)
-    if aquifer_pore_volume <= 0:
-        msg = f"Aquifer pore volume must be positive, got {aquifer_pore_volume}"
-        raise ValueError(msg)
+    _validate_deposition_inputs(
+        tedges=tedges,
+        flow_values=flow_values,
+        aquifer_pore_volume=aquifer_pore_volume,
+        porosity=porosity,
+        thickness=thickness,
+        dep_values=dep_values,
+    )
 
     # Apply spinup policy: optionally prepend warm-start bins to tedges/flow/dep.
     weight_tedges, weight_flow, weight_dep, _, _ = _resolve_spinup_inputs(
@@ -438,30 +483,15 @@ def extraction_to_deposition(
     tedges, cout_tedges = pd.DatetimeIndex(tedges), pd.DatetimeIndex(cout_tedges)
     cout_values, flow_values = np.asarray(cout), np.asarray(flow)
 
-    # Validate input dimensions and values
-    if len(cout_tedges) != len(cout_values) + 1:
-        msg = "cout_tedges must have one more element than cout"
-        raise ValueError(msg)
-    if len(tedges) != len(flow_values) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-    if np.any(np.isnan(flow_values)):
-        msg = "flow array cannot contain NaN values"
-        raise ValueError(msg)
-    if np.any(flow_values < 0):
-        msg = "flow must be non-negative (negative flow not supported)"
-        raise ValueError(msg)
-
-    # Validate physical parameters
-    if not 0 < porosity < 1:
-        msg = f"Porosity must be in (0, 1), got {porosity}"
-        raise ValueError(msg)
-    if thickness <= 0:
-        msg = f"Thickness must be positive, got {thickness}"
-        raise ValueError(msg)
-    if aquifer_pore_volume <= 0:
-        msg = f"Aquifer pore volume must be positive, got {aquifer_pore_volume}"
-        raise ValueError(msg)
+    _validate_deposition_inputs(
+        tedges=tedges,
+        flow_values=flow_values,
+        aquifer_pore_volume=aquifer_pore_volume,
+        porosity=porosity,
+        thickness=thickness,
+        cout_tedges=cout_tedges,
+        cout_values=cout_values,
+    )
 
     # Apply spinup policy: optionally prepend warm-start bins to tedges/flow.
     weight_tedges, weight_flow, _, _, n_pad = _resolve_spinup_inputs(
@@ -483,8 +513,6 @@ def extraction_to_deposition(
         retardation_factor=retardation_factor,
     )
 
-    n_dep_padded = len(weight_tedges) - 1
-
     # Rescale rows of W by their sum r_i = RT_i / (porosity*thickness). For
     # systems where cout lies in the column space of W (e.g., noise-free
     # roundtrip), this preserves the exact dep. For overdetermined systems
@@ -494,14 +522,14 @@ def extraction_to_deposition(
     # exists to put compute_reverse_target on the same scale as dep, which
     # controls the regularization scale. NaN rows (spin-up), all-zero rows
     # (zero-flow cout bins; carry no info), and NaN values in cout are
-    # excluded by solve_tikhonov.
+    # excluded by solve_tikhonov via its valid_rows = ~isnan(matrix).any(axis=1) & ~isnan(rhs) filter.
     valid_rows = ~np.isnan(deposition_weights).any(axis=1) & (np.abs(deposition_weights).sum(axis=1) > 0)
     valid_weights = deposition_weights[valid_rows]
     row_sums = valid_weights.sum(axis=1, keepdims=True)
     col_active = np.sum(np.abs(valid_weights), axis=0) > 0
 
     if not np.any(col_active):
-        return np.full(n_dep_padded - n_pad, np.nan)
+        return np.full(deposition_weights.shape[1] - n_pad, np.nan)
 
     # Build normalized system: W_norm @ dep = cout_norm
     w_norm = valid_weights / row_sums
@@ -524,22 +552,20 @@ def extraction_to_deposition(
             stacklevel=2,
         )
 
-    # Reconstruct full arrays with NaN for invalid rows
-    full_w_norm = np.full_like(deposition_weights, np.nan)
-    full_w_norm[valid_rows] = w_norm
-    full_cout_norm = np.full(len(cout_values), np.nan)
-    full_cout_norm[valid_rows] = cout_norm
-
     x_target = compute_reverse_target(coeff_matrix=w_norm, rhs_vector=cout_norm)
 
+    # solve_tikhonov filters NaN rows in *both* coefficient_matrix and rhs_vector
+    # (utils.py: valid_rows = ~isnan(matrix).any(axis=1) & ~isnan(rhs)).  We pass
+    # the already-pruned w_norm / cout_norm directly -- a reconstruction back to
+    # full size only to be filtered again would be dead work.
     dep_solved = solve_tikhonov(
-        coefficient_matrix=full_w_norm,
-        rhs_vector=full_cout_norm,
+        coefficient_matrix=w_norm,
+        rhs_vector=cout_norm,
         x_target=x_target,
         regularization_strength=regularization_strength,
     )
 
-    out = np.full(n_dep_padded, np.nan)
+    out = np.full(deposition_weights.shape[1], np.nan)
     out[col_active] = dep_solved[col_active]
     # Drop warm-start prefix so output aligns with the user-provided tedges.
     return out[n_pad:]
@@ -643,30 +669,15 @@ def extraction_to_deposition_full(
     tedges, cout_tedges = pd.DatetimeIndex(tedges), pd.DatetimeIndex(cout_tedges)
     cout_values, flow_values = np.asarray(cout), np.asarray(flow)
 
-    # Validate input dimensions and values
-    if len(cout_tedges) != len(cout_values) + 1:
-        msg = "cout_tedges must have one more element than cout"
-        raise ValueError(msg)
-    if len(tedges) != len(flow_values) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-    if np.any(np.isnan(flow_values)):
-        msg = "flow array cannot contain NaN values"
-        raise ValueError(msg)
-    if np.any(flow_values < 0):
-        msg = "flow must be non-negative (negative flow not supported)"
-        raise ValueError(msg)
-
-    # Validate physical parameters
-    if not 0 < porosity < 1:
-        msg = f"Porosity must be in (0, 1), got {porosity}"
-        raise ValueError(msg)
-    if thickness <= 0:
-        msg = f"Thickness must be positive, got {thickness}"
-        raise ValueError(msg)
-    if aquifer_pore_volume <= 0:
-        msg = f"Aquifer pore volume must be positive, got {aquifer_pore_volume}"
-        raise ValueError(msg)
+    _validate_deposition_inputs(
+        tedges=tedges,
+        flow_values=flow_values,
+        aquifer_pore_volume=aquifer_pore_volume,
+        porosity=porosity,
+        thickness=thickness,
+        cout_tedges=cout_tedges,
+        cout_values=cout_values,
+    )
 
     # Apply spinup policy: optionally prepend warm-start bins to tedges/flow.
     weight_tedges, weight_flow, _, _, n_pad = _resolve_spinup_inputs(

--- a/tests/src/test_deposition.py
+++ b/tests/src/test_deposition.py
@@ -20,7 +20,6 @@ from gwtransport.deposition import (
     extraction_to_deposition_full,
     spinup_duration,
 )
-from gwtransport.examples import generate_example_data, generate_example_deposition_timeseries
 from gwtransport.residence_time import residence_time
 from gwtransport.utils import compute_time_edges, solve_underdetermined_system
 
@@ -334,8 +333,8 @@ def test_zero_deposition_zero_concentration():
     )
 
     valid_results = cout_result[~np.isnan(cout_result)]
-    if len(valid_results) > 0:
-        assert np.allclose(valid_results, 0.0, atol=1e-15), "Zero deposition must give exactly zero concentration"
+    assert len(valid_results) >= 1, "Setup must produce at least one valid cout bin"
+    np.testing.assert_allclose(valid_results, 0.0, rtol=0, atol=1e-15)
 
 
 def test_linearity_exact():
@@ -628,21 +627,28 @@ def test_regularization_objectives():
     assert np.max(np.abs(result)) < 100, "Solution should be reasonable magnitude"
 
 
-def test_extraction_to_deposition_full_default():
-    """Test extraction_to_deposition_full with default nullspace objective."""
+@pytest.fixture
+def full_solver_overdetermined_setup():
+    """Shared setup for extraction_to_deposition_full machine-precision tests.
+
+    Varying deposition + non-integer RT (3.5 days) + half-day cout makes the
+    system overdetermined and full-rank, so the nullspace solver can recover
+    the original deposition to machine precision (bounded only by optimizer
+    noise).
+    """
     dates = pd.date_range("2020-01-01", "2020-01-08", freq="D")
     tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
+    cout_dates = pd.date_range("2020-01-01", "2020-01-08", freq="12h")
+    cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=len(cout_dates))
 
     params = {
-        "aquifer_pore_volume": 400.0,
+        "aquifer_pore_volume": 350.0,  # RT = 3.5 days (non-integer => full rank)
         "porosity": 0.25,
         "thickness": 4.0,
         "retardation_factor": 1.0,
     }
-
-    original_deposition = np.full(len(dates), 25.0)
+    original_deposition = np.array([10.0, 20.0, 30.0, 25.0, 15.0, 35.0, 40.0, 30.0])
     flow_values = np.full(len(dates), 100.0)
-    cout_tedges = tedges[3:]
 
     concentration = deposition_to_extraction(
         dep=original_deposition,
@@ -651,6 +657,17 @@ def test_extraction_to_deposition_full_default():
         cout_tedges=cout_tedges,
         **params,
     )
+    return tedges, cout_tedges, flow_values, original_deposition, concentration, params
+
+
+def test_extraction_to_deposition_full_default(full_solver_overdetermined_setup):
+    """Default-objective round-trip recovers the original deposition to machine precision.
+
+    The prior assertion `np.all(np.isfinite(recovered))` would pass even if
+    the solver returned constant 1e10; an absolute round-trip check pins the
+    scale.
+    """
+    tedges, cout_tedges, flow_values, original_deposition, concentration, params = full_solver_overdetermined_setup
 
     recovered = extraction_to_deposition_full(
         cout=concentration,
@@ -660,33 +677,19 @@ def test_extraction_to_deposition_full_default():
         **params,  # pyright: ignore[reportArgumentType]
     )
 
-    assert recovered.shape == original_deposition.shape
-    assert np.all(np.isfinite(recovered))
+    np.testing.assert_allclose(recovered, original_deposition, rtol=1e-10, atol=1e-10)
 
 
-def test_extraction_to_deposition_full_objectives():
-    """Test extraction_to_deposition_full with different nullspace objectives."""
-    dates = pd.date_range("2020-01-01", "2020-01-06", freq="D")
-    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
+def test_extraction_to_deposition_full_objectives(full_solver_overdetermined_setup):
+    """Round-trip recovery for both nullspace objectives.
 
-    params = {
-        "aquifer_pore_volume": 300.0,
-        "porosity": 0.25,
-        "thickness": 4.0,
-        "retardation_factor": 1.0,
-    }
-
-    original_deposition = np.full(len(dates), 20.0)
-    flow_values = np.full(len(dates), 100.0)
-    cout_tedges = tedges[2:]
-
-    concentration = deposition_to_extraction(
-        dep=original_deposition,
-        flow=flow_values,
-        tedges=tedges,
-        cout_tedges=cout_tedges,
-        **params,
-    )
+    On this overdetermined full-rank system both objectives reach max-abs
+    error ~1e-13 in their natural optimizer pairing (BFGS for the smooth
+    squared_differences, Nelder-Mead for the non-smooth summed_differences).
+    The asserted ``atol=1e-10`` is the project-wide machine-precision target;
+    the actual recovery is two orders tighter.
+    """
+    tedges, cout_tedges, flow_values, original_deposition, concentration, params = full_solver_overdetermined_setup
 
     for objective, method in [("squared_differences", "BFGS"), ("summed_differences", "Nelder-Mead")]:
         recovered = extraction_to_deposition_full(
@@ -698,32 +701,18 @@ def test_extraction_to_deposition_full_objectives():
             optimization_method=method,
             **params,  # pyright: ignore[reportArgumentType]
         )
-        assert np.all(np.isfinite(recovered)), f"Failed for objective={objective}"
+        np.testing.assert_allclose(
+            recovered,
+            original_deposition,
+            rtol=1e-10,
+            atol=1e-10,
+            err_msg=f"objective={objective} method={method}",
+        )
 
 
-def test_extraction_to_deposition_full_with_rcond():
-    """Test extraction_to_deposition_full with rcond parameter."""
-    dates = pd.date_range("2020-01-01", "2020-01-06", freq="D")
-    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
-
-    params = {
-        "aquifer_pore_volume": 300.0,
-        "porosity": 0.25,
-        "thickness": 4.0,
-        "retardation_factor": 1.0,
-    }
-
-    original_deposition = np.full(len(dates), 20.0)
-    flow_values = np.full(len(dates), 100.0)
-    cout_tedges = tedges[2:]
-
-    concentration = deposition_to_extraction(
-        dep=original_deposition,
-        flow=flow_values,
-        tedges=tedges,
-        cout_tedges=cout_tedges,
-        **params,
-    )
+def test_extraction_to_deposition_full_with_rcond(full_solver_overdetermined_setup):
+    """Setting rcond=1e-10 must not degrade the round-trip on a full-rank system."""
+    tedges, cout_tedges, flow_values, original_deposition, concentration, params = full_solver_overdetermined_setup
 
     recovered = extraction_to_deposition_full(
         cout=concentration,
@@ -734,8 +723,7 @@ def test_extraction_to_deposition_full_with_rcond():
         **params,  # pyright: ignore[reportArgumentType]
     )
 
-    assert recovered.shape == original_deposition.shape
-    assert np.all(np.isfinite(recovered))
+    np.testing.assert_allclose(recovered, original_deposition, rtol=1e-10, atol=1e-10)
 
 
 def test_roundtrip_varying_deposition():
@@ -791,96 +779,28 @@ def test_roundtrip_varying_deposition():
     )
 
 
-def test_extraction_to_deposition_sparse_weekly_sampling():
+def test_extraction_to_deposition_sparse_sampling_rank_deficient_warning():
+    """Inverse on weekly cout with weekly flow tedges fires the rank-deficient warning.
+
+    Replaces a heavy notebook-data setup with a synthetic 28-day weekly grid
+    that reproduces the same integer-RT condition: APV * R = N * Q * dt_week
+    makes the deposition weight matrix a uniform moving average with exact
+    zeros in its transfer function. The warning must fire here; sibling tests
+    assert it does NOT fire for non-integer-RT setups.
     """
-    Test extraction_to_deposition with sparse weekly sampling using exact notebook data.
-
-    Note: This test documents that while the notebook shows a failure with weekly
-    cout_tedges, the solver is more robust in the test environment and can handle
-    the same conditions successfully. This demonstrates the solver's capability
-    to handle challenging underdetermined systems.
-    """
-    # Set same random seed as notebook
-    np.random.seed(42)
-
-    # Generate exact same data as notebook
-    date_start = "2020-01-01"
-    date_end = "2022-12-31"
-    freq = "D"
-
-    # Generate example flow data (same as notebook)
-    example_df, _ = generate_example_data(date_start=date_start, date_end=date_end, date_freq=freq)
-    flow_series = example_df["flow"]
-
-    # Generate example deposition data with same parameters as notebook
-    event_dates = pd.to_datetime(["2020-06-15", "2021-03-20", "2021-09-10", "2022-07-05"]).tz_localize("UTC")
-    deposition_series, deposition_tedges = generate_example_deposition_timeseries(
-        date_start=date_start,
-        date_end=date_end,
-        seasonal_amplitude=0.3,
-        noise_scale=0.1,
-        event_magnitude=3.0,
-        event_duration=30,
-        event_decay_scale=10.0,
-        event_dates=event_dates,
-        ensure_non_negative=True,
-    )
-
-    # Use exact same parameters as notebook
-    aquifer_pore_volume = example_df.attrs["aquifer_pore_volume_gamma_mean"]
-    retardation_factor = example_df.attrs["retardation_factor"]
-    porosity = 0.25
-    thickness = 12.0
-
+    weekly_tedges = pd.date_range("2020-01-01", periods=5, freq="7D")  # 4 weekly bins
+    flow = np.full(4, 100.0)
+    dep = np.array([1.0, 2.0, 3.0, 4.0])
     params = {
-        "aquifer_pore_volume": aquifer_pore_volume,
-        "porosity": porosity,
-        "thickness": thickness,
-        "retardation_factor": retardation_factor,
+        "aquifer_pore_volume": 1400.0,  # RT = 1400/100 = 14 days = 2 weekly bins (integer RT/dt)
+        "porosity": 0.25,
+        "thickness": 12.0,
+        "retardation_factor": 1.0,
     }
 
-    # Test weekly sampling (similar to notebook case that fails)
-    weekly_extraction_dates = pd.date_range("2020-01-01", "2022-12-31", freq="7D").tz_localize("UTC")
-    weekly_cout_tedges = compute_time_edges(
-        tedges=None, tstart=None, tend=weekly_extraction_dates, number_of_bins=len(weekly_extraction_dates)
-    )
-
-    # Generate weekly concentrations using forward modeling
-    weekly_concentrations = deposition_to_extraction(
-        dep=deposition_series.to_numpy(),
-        flow=flow_series.to_numpy(),
-        tedges=deposition_tedges,
-        cout_tedges=weekly_cout_tedges,
-        aquifer_pore_volume=params["aquifer_pore_volume"],
-        porosity=params["porosity"],
-        thickness=params["thickness"],
-        retardation_factor=params["retardation_factor"],
-    )
-
-    # Prepare flow data for inverse modeling
-    weekly_flow_for_inverse = flow_series.reindex(weekly_extraction_dates, method="nearest").to_numpy()
-
-    # Test weekly inverse modeling - this should fail like in the notebook
-    # The key is using weekly_cout_tedges for both tedges and cout_tedges
-    # Should converge successfully in test environment.
-    # Rank-deficiency warning is expected for this challenging system; only
-    # that specific message is suppressed so other UserWarnings still surface.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message=".*rank-deficient.*", category=UserWarning)
-        _ = extraction_to_deposition(
-            cout=weekly_concentrations,
-            flow=weekly_flow_for_inverse,
-            tedges=weekly_cout_tedges,
-            cout_tedges=weekly_cout_tedges,
-            aquifer_pore_volume=params["aquifer_pore_volume"],
-            porosity=params["porosity"],
-            thickness=params["thickness"],
-            retardation_factor=params["retardation_factor"],
-        )
-
-    # Document that this test covers the same scenario as the notebook failure
-    assert len(weekly_extraction_dates) == 157, "Should have 157 weekly samples like in notebook"
-    assert len(weekly_cout_tedges) == 158, "Should have 158 weekly edges (157 + 1)"
+    cout = deposition_to_extraction(dep=dep, flow=flow, tedges=weekly_tedges, cout_tedges=weekly_tedges, **params)
+    with pytest.warns(UserWarning, match="rank-deficient"):
+        extraction_to_deposition(cout=cout, flow=flow, tedges=weekly_tedges, cout_tedges=weekly_tedges, **params)
 
 
 # =============================================================================
@@ -1046,10 +966,17 @@ def test_spinup_duration_with_zero_flow_plateau():
 
 
 def test_compute_deposition_weights_structure():
-    """Test that compute_deposition_weights produces correct matrix structure."""
+    """Shape, non-negativity, finiteness, and analytical row-sum invariant.
+
+    The row-sum invariant ``sum(W[i, :]) * porosity * thickness == RT_i``
+    comes directly from the function's contract (each row's sum equals
+    ``residence_time / (porosity * thickness)`` per the
+    ``extraction_to_deposition`` Notes block). Adding it makes this test
+    load-bearing -- a 1.5x scaling bug in the area integration would still
+    pass the shape/non-negativity checks but fail the row sum.
+    """
     dates = pd.date_range(start="2020-01-01", periods=50, freq="D")
     tedges = pd.date_range(start="2020-01-01", periods=51, freq="D")
-    # Start output after residence time: RT = 500/100 = 5 days
     cout_tedges = pd.date_range(start="2020-01-08", periods=41, freq="D")
 
     flow = np.ones(len(dates)) * 100.0
@@ -1068,52 +995,77 @@ def test_compute_deposition_weights_structure():
         retardation_factor=retardation_factor,
     )
 
-    # Verify shape
+    # Shape, non-negativity, finiteness
     assert weights.shape == (len(cout_tedges) - 1, len(tedges) - 1)
     assert weights.shape == (40, 50)
-
-    # Verify all weights are non-negative
     assert np.all(weights >= 0.0)
-
-    # Verify weights are finite
     assert np.all(np.isfinite(weights))
+
+    # Row-sum invariant: sum(W[i, :]) * porosity * thickness == RT_i
+    rt = residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        index=cout_tedges,
+        aquifer_pore_volumes=aquifer_pore_volume,
+        retardation_factor=retardation_factor,
+        direction="extraction_to_infiltration",
+    )[0]
+    # residence_time returns RT at each cout edge; per-bin RT is the integral
+    # across the bin width. Under constant flow RT is constant => RT_at_edge
+    # is the bin RT.
+    rt_per_bin = rt[:-1]  # length matches weights.shape[0]
+    np.testing.assert_allclose(weights.sum(axis=1) * porosity * thickness, rt_per_bin, rtol=0, atol=1e-12)
 
 
 def test_compute_deposition_weights_causality():
-    """Test that weight matrix respects causality (temporal ordering)."""
+    """Weight matrix respects strict causality: future deposition cannot affect past extraction.
+
+    Setup: APV=500, Q=100, RT=5 days; cout_tedges starts at dep_tedges[7].
+    The water extracted in cout_bin_i (covering [day 7+i, day 8+i]) was
+    infiltrated in [day 2+i, day 3+i]. Source bins j >= 4 + i correspond to
+    deposition strictly later than the latest infiltration time of any
+    parcel extracted in cout_bin_i, so the weight must be exactly zero.
+    Replaces the prior structure-only `total_weight > 0` assertion, which
+    would pass even under a 1.5x scaling mutation.
+    """
     dates = pd.date_range(start="2020-01-01", periods=50, freq="D")
     tedges = pd.date_range(start="2020-01-01", periods=51, freq="D")
-    # Start output after residence time: RT = 500/100 = 5 days
     cout_tedges = pd.date_range(start="2020-01-08", periods=31, freq="D")
-
     flow = np.ones(len(dates)) * 100.0
-    aquifer_pore_volume = 500.0  # RT = 500/100 = 5 days
-    porosity = 0.35
-    thickness = 3.0
-    retardation_factor = 1.0
 
     weights = compute_deposition_weights(
         flow=flow,
         tedges=tedges,
         cout_tedges=cout_tedges,
-        aquifer_pore_volume=aquifer_pore_volume,
-        porosity=porosity,
-        thickness=thickness,
-        retardation_factor=retardation_factor,
+        aquifer_pore_volume=500.0,
+        porosity=0.35,
+        thickness=3.0,
+        retardation_factor=1.0,
     )
 
-    # Weights should have a roughly diagonal structure
-    # (deposition at time t contributes to extraction near time t + residence_time)
-    # Most weight should be concentrated near the diagonal-like region
-    total_weight = np.sum(weights)
-    assert total_weight > 0.0
+    # cout_tedges[0] starts at dep_tedges[7] (day 7). Water extracted in
+    # cout_bin_i = [day 7+i, day 8+i] was in the aquifer from infiltration
+    # (RT=5 days back) at [day 2+i, day 3+i] through extraction at [day 7+i,
+    # day 8+i]. Source dep_bin_j fully past extraction (j >= 8+i) cannot
+    # affect cout_bin_i. Verified empirically: nonzero cols for row i are
+    # [i+2, i+7] inclusive, so weights[i, i+8:] must be exactly zero.
+    n_dep = weights.shape[1]
+    for i in range(weights.shape[0]):
+        future_start = i + 8
+        if future_start < n_dep:
+            assert np.all(weights[i, future_start:] == 0.0), (
+                f"weights[{i}, {future_start}:] should be zero; got max {weights[i, future_start:].max()}"
+            )
 
 
 def test_compute_deposition_weights_with_retardation():
-    """Test compute_deposition_weights with different retardation factors."""
+    """Row-sum scales with R: sum(W[i,:]) * porosity * thickness == RT_i at both R=1 and R=2.
+
+    Replaces the prior `not np.allclose(weights_r1, weights_r2)` diff-only
+    assertion, which a wrong-but-different implementation would pass.
+    """
     dates = pd.date_range(start="2020-01-01", periods=50, freq="D")
     tedges = pd.date_range(start="2020-01-01", periods=51, freq="D")
-    # Start output after residence time with retardation
     cout_tedges = pd.date_range(start="2020-01-12", periods=31, freq="D")
 
     flow = np.ones(len(dates)) * 100.0
@@ -1121,71 +1073,65 @@ def test_compute_deposition_weights_with_retardation():
     porosity = 0.35
     thickness = 3.0
 
-    # Test with R=1.0
-    weights_r1 = compute_deposition_weights(
-        flow=flow,
-        tedges=tedges,
-        cout_tedges=cout_tedges,
-        aquifer_pore_volume=aquifer_pore_volume,
-        porosity=porosity,
-        thickness=thickness,
-        retardation_factor=1.0,
-    )
-
-    # Test with R=2.0 (more retardation)
-    weights_r2 = compute_deposition_weights(
-        flow=flow,
-        tedges=tedges,
-        cout_tedges=cout_tedges,
-        aquifer_pore_volume=aquifer_pore_volume,
-        porosity=porosity,
-        thickness=thickness,
-        retardation_factor=2.0,
-    )
-
-    # Shapes should be the same
-    assert weights_r1.shape == weights_r2.shape
-
-    # Weight patterns should be different
-    assert not np.allclose(weights_r1, weights_r2)
+    for retardation_factor in (1.0, 2.0):
+        weights = compute_deposition_weights(
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            aquifer_pore_volume=aquifer_pore_volume,
+            porosity=porosity,
+            thickness=thickness,
+            retardation_factor=retardation_factor,
+        )
+        rt = residence_time(
+            flow=flow,
+            flow_tedges=tedges,
+            index=cout_tedges,
+            aquifer_pore_volumes=aquifer_pore_volume,
+            retardation_factor=retardation_factor,
+            direction="extraction_to_infiltration",
+        )[0]
+        rt_per_bin = rt[:-1]
+        np.testing.assert_allclose(
+            weights.sum(axis=1) * porosity * thickness,
+            rt_per_bin,
+            rtol=0,
+            atol=1e-12,
+            err_msg=f"R={retardation_factor}",
+        )
 
 
 def test_compute_deposition_weights_porosity_effect():
-    """Test that porosity affects contact area calculation in weights."""
+    """Weights scale exactly as 1/porosity (everything else fixed).
+
+    Replaces the prior `not np.allclose(weights_a, weights_b)` diff-only
+    assertion. The invariant `weights * porosity` is porosity-independent
+    follows from `area_array = volume_array / (porosity * thickness)` in
+    `compute_deposition_weights` -- the volume integration itself does not
+    depend on porosity.
+    """
     dates = pd.date_range(start="2020-01-01", periods=50, freq="D")
     tedges = pd.date_range(start="2020-01-01", periods=51, freq="D")
-    # Start output after residence time: RT = 500/100 = 5 days
     cout_tedges = pd.date_range(start="2020-01-08", periods=31, freq="D")
 
     flow = np.ones(len(dates)) * 100.0
-    aquifer_pore_volume = 500.0  # RT = 500/100 = 5 days
+    aquifer_pore_volume = 500.0
     thickness = 3.0
     retardation_factor = 1.0
+    porosity_low, porosity_high = 0.25, 0.45
 
-    # Low porosity (more contact area)
-    weights_low_por = compute_deposition_weights(
-        flow=flow,
-        tedges=tedges,
-        cout_tedges=cout_tedges,
-        aquifer_pore_volume=aquifer_pore_volume,
-        porosity=0.25,
-        thickness=thickness,
-        retardation_factor=retardation_factor,
-    )
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volume": aquifer_pore_volume,
+        "thickness": thickness,
+        "retardation_factor": retardation_factor,
+    }
+    weights_low = compute_deposition_weights(porosity=porosity_low, **common)
+    weights_high = compute_deposition_weights(porosity=porosity_high, **common)
 
-    # High porosity (less contact area)
-    weights_high_por = compute_deposition_weights(
-        flow=flow,
-        tedges=tedges,
-        cout_tedges=cout_tedges,
-        aquifer_pore_volume=aquifer_pore_volume,
-        porosity=0.45,
-        thickness=thickness,
-        retardation_factor=retardation_factor,
-    )
-
-    # Weights should be affected by porosity (different contact areas)
-    assert not np.allclose(weights_low_por, weights_high_por)
+    np.testing.assert_allclose(weights_low * porosity_low, weights_high * porosity_high, rtol=0, atol=1e-12)
 
 
 # =============================================================================
@@ -1619,3 +1565,394 @@ def test_extraction_to_deposition_spinup_constant_recovers_full_window():
     assert dep_rec.shape == (n,), "output must align with original tedges length"
     # Recovery in the interior of the box; boundaries see Tikhonov bias.
     np.testing.assert_allclose(dep_rec[14:26], 3.0, atol=0.1)
+
+
+# =============================================================================
+# Issue #171: mass conservation, variable R, zero-flow recovery, NaN
+# propagation, row-norm invariants, limit reductions
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("flow_pattern", "retardation_factor", "pulse_start", "pulse_end"),
+    [
+        ("constant", 1.0, 20, 30),
+        ("variable", 1.0, 30, 50),
+        ("constant", 2.0, 30, 40),
+    ],
+    ids=["constant_flow_R1", "variable_flow_R1", "constant_flow_R2"],
+)
+def test_mass_conservation_pulse_dep(flow_pattern, retardation_factor, pulse_start, pulse_end):
+    """Closed-window mass balance: Σ cout · Q · Δt = D · A_eff · pulse_width.
+
+    Dep is a constant pulse over [pulse_start, pulse_end] (well past spin-up),
+    zero elsewhere. The cout window matches the dep window and is long enough
+    that the entire response decays into machine-zero bins inside it. Mass
+    balance holds exactly when ``A_eff = R · V_pore / (n · b)``.
+
+    The 1/r_i^2-weighted-LS framing of row normalization (see Notes block in
+    ``extraction_to_deposition``) is a forward-pass model identity: any per-bin
+    contribution ``cout[i] = sum_j W[i,j] dep[j]`` summed against ``Q * dt``
+    recovers ``D * A_eff * pulse_width`` exactly. A 1.5x scaling bug in
+    ``compute_deposition_weights`` would fail this at the 50 percent relative level.
+    """
+    n = 80
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cout_tedges = tedges
+
+    if flow_pattern == "constant":
+        flow = np.full(n, 100.0)
+    else:
+        t = np.arange(n)
+        flow = 100.0 + 30.0 * np.sin(2 * np.pi * t / 14)
+
+    params = {
+        "aquifer_pore_volume": 500.0,
+        "porosity": 0.3,
+        "thickness": 10.0,
+        "retardation_factor": retardation_factor,
+    }
+    deposition_rate = 5.0
+    dep = np.zeros(n)
+    dep[pulse_start:pulse_end] = deposition_rate
+
+    cout = deposition_to_extraction(dep=dep, flow=flow, tedges=tedges, cout_tedges=cout_tedges, spinup=None, **params)
+
+    valid = ~np.isnan(cout)
+    mass_extracted = np.sum(cout[valid] * flow[valid] * 1.0)  # Δt_cout = 1 day
+
+    a_eff = retardation_factor * params["aquifer_pore_volume"] / (params["porosity"] * params["thickness"])
+    mass_injected = deposition_rate * a_eff * (pulse_end - pulse_start)
+
+    np.testing.assert_allclose(mass_extracted, mass_injected, rtol=1e-10)
+
+
+@pytest.mark.parametrize("retardation_factor", [2.0, 3.5], ids=["R2", "R3p5"])
+def test_roundtrip_variable_retardation(retardation_factor):
+    """Roundtrip recovery at R > 1 on overdetermined half-day cout, non-integer effective RT.
+
+    All prior roundtrip tests use R=1.0. With R=2 (RT_eff=10 days) and R=3.5
+    (RT_eff=17.5 days) the residence-time-dependent code paths
+    (``residence_time(direction="extraction_to_infiltration")``, the
+    ``y_upper=R*V_pore`` clip in ``compute_average_heights``) are exercised
+    end-to-end with a per-element machine-precision recovery check.
+    """
+    # Need tedges long enough to cover RT_eff * 3 for proper spin-up + pulse + decay.
+    # APV=500, Q=100, RT_water=5 days. RT_eff(R=3.5) = 17.5 days.
+    n = 100
+    dates = pd.date_range("2020-01-01", periods=n, freq="D")
+    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=n)
+    # Half-day cout for overdetermined system; APV=510 to keep effective RT non-integer at R=3.5
+    cout_dates = pd.date_range("2020-01-01", periods=2 * n, freq="12h")
+    cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=2 * n)
+
+    params = {
+        "aquifer_pore_volume": 510.0,  # RT_water = 5.1 days; non-integer at any R
+        "porosity": 0.25,
+        "thickness": 4.0,
+        "retardation_factor": retardation_factor,
+    }
+    original_deposition = 20.0 + 10.0 * np.sin(2 * np.pi * np.arange(n) / 20.0)
+    flow = np.full(n, 100.0)
+
+    cout = deposition_to_extraction(
+        dep=original_deposition, flow=flow, tedges=tedges, cout_tedges=cout_tedges, **params
+    )
+    recovered = extraction_to_deposition(
+        cout=cout,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        regularization_strength=1e-20,
+        **params,
+    )
+
+    valid = ~np.isnan(recovered)
+    np.testing.assert_allclose(recovered[valid], original_deposition[valid], rtol=1e-10, atol=1e-10)
+
+
+def test_zero_flow_spill_then_recovery_roundtrip():
+    """Forward + inverse roundtrip with a two-bin zero-flow gap.
+
+    Cout for cout-bins fully inside the zero-flow window must be 0 (no water
+    extracted carries no mass signature). Outside the gap, the inverse must
+    recover the original deposition to machine precision. Inside the gap,
+    deposition is unobservable and recovery is undefined (no information).
+
+    Regression coverage for #167 (deposition example notebook crash) at the
+    forward-then-inverse level rather than the example-generator level.
+    """
+    n = 50
+    dates = pd.date_range("2020-01-01", periods=n, freq="D")
+    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=n)
+    cout_dates = pd.date_range("2020-01-01", periods=2 * n, freq="12h")
+    cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=2 * n)
+
+    flow = np.full(n, 100.0)
+    gap_start, gap_end = 20, 22
+    flow[gap_start:gap_end] = 0.0
+
+    original_deposition = 10.0 + 5.0 * np.sin(2 * np.pi * np.arange(n) / 10.0)
+    params = {
+        "aquifer_pore_volume": 350.0,  # RT_water = 3.5 days, non-integer => full rank
+        "porosity": 0.25,
+        "thickness": 4.0,
+        "retardation_factor": 1.0,
+    }
+
+    cout = deposition_to_extraction(
+        dep=original_deposition, flow=flow, tedges=tedges, cout_tedges=cout_tedges, spinup=None, **params
+    )
+
+    # cout for cout-bins fully inside the zero-flow window must be 0 (no water extracted).
+    # Zero-flow window is dep tedges[20:22] = [2020-01-20, 2020-01-22). Half-day
+    # cout_tedges put cout_bins 39..42 fully inside that window: cout_bins
+    # starting at cout_tedges[39]=2020-01-20 00:00 to cout_tedges[43]=2020-01-22 00:00.
+    np.testing.assert_array_equal(cout[39:43], 0.0)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)  # rank-deficiency suppression
+        dep_rec = extraction_to_deposition(
+            cout=cout,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            regularization_strength=1e-20,
+            spinup=None,
+            **params,
+        )
+
+    # Outside the zero-flow gap, recovery is exact.
+    np.testing.assert_allclose(dep_rec[:gap_start], original_deposition[:gap_start], rtol=1e-10, atol=1e-10)
+    np.testing.assert_allclose(dep_rec[gap_end:], original_deposition[gap_end:], rtol=1e-10, atol=1e-10)
+
+
+def test_spinup_duration_first_bin_zero_flow():
+    """spinup_duration accounts for zero-flow at the start of the series.
+
+    Distinct from ``test_spinup_duration_with_zero_flow_plateau`` (which has
+    the plateau in the middle). With 3 days of zero flow followed by 100
+    m^3/day at APV=500 and R=1, the target volume R*V_pore = 500 is reached
+    at day 3 + (500 / 100) = 8.
+    """
+    n = 20
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    flow[0:3] = 0.0  # 3 days of zero flow at start
+
+    duration = spinup_duration(flow=flow, flow_tedges=tedges, aquifer_pore_volume=500.0, retardation_factor=1.0)
+    np.testing.assert_allclose(duration, 8.0, rtol=0, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    ("solver", "nan_positions"),
+    [
+        ("tikhonov", [10, 25, 40]),
+        ("tikhonov", [0, 1, 58, 59]),  # boundary NaN
+        ("full", [10, 25, 40]),
+    ],
+    ids=["tikhonov_scattered", "tikhonov_boundary", "full_scattered"],
+)
+def test_nan_cout_propagation(solver, nan_positions):
+    """Scattered / boundary NaN in cout is correctly excluded by both inverse solvers.
+
+    Forward then inject NaN at the listed positions; the inverse must (i) not
+    crash, (ii) recover the original deposition to machine precision in regions
+    bracketed by valid cout bins. Covers both Tikhonov (``extraction_to_deposition``)
+    and nullspace-based (``extraction_to_deposition_full``) solvers per
+    bas-test-reviewer's separate code path observation.
+    """
+    n = 30
+    dates = pd.date_range("2020-01-01", periods=n, freq="D")
+    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=n)
+    cout_dates = pd.date_range("2020-01-01", periods=2 * n, freq="12h")
+    cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=2 * n)
+    flow = np.full(n, 100.0)
+    original_deposition = 10.0 + 5.0 * np.sin(2 * np.pi * np.arange(n) / 8.0)
+    params = {
+        "aquifer_pore_volume": 350.0,  # RT = 3.5, non-integer
+        "porosity": 0.25,
+        "thickness": 4.0,
+        "retardation_factor": 1.0,
+    }
+
+    cout = deposition_to_extraction(
+        dep=original_deposition, flow=flow, tedges=tedges, cout_tedges=cout_tedges, **params
+    )
+    cout_with_nan = cout.copy()
+    cout_with_nan[nan_positions] = np.nan
+
+    if solver == "tikhonov":
+        dep_rec = extraction_to_deposition(
+            cout=cout_with_nan,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            regularization_strength=1e-20,
+            **params,
+        )
+    else:
+        dep_rec = extraction_to_deposition_full(
+            cout=cout_with_nan,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            **params,  # pyright: ignore[reportArgumentType]
+        )
+
+    np.testing.assert_allclose(dep_rec, original_deposition, rtol=1e-10, atol=1e-10)
+
+
+def test_row_normalization_pre_norm_row_sum_equals_rt_over_nb():
+    """Under constant flow, every valid row sums to RT / (porosity * thickness).
+
+    Direct verification of the inverse-solver docstring contract ("deposition
+    rows sum to residence_time / (porosity * thickness)"). Constant flow is
+    used because under variable flow the per-bin row sum integrates over a
+    non-uniform residence-time profile and the closed-form identity
+    ``row_sum * n * b == RT_at_one_edge`` only holds in the limit of small
+    cout bins; here the goal is the machine-precision contract pin, not a
+    variable-flow generalization.
+    """
+    n = 30
+    dates = pd.date_range("2020-01-01", periods=n, freq="D")
+    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=n)
+    cout_tedges = tedges
+    flow = np.full(n, 100.0)
+    params = {
+        "aquifer_pore_volume": 350.0,  # RT = 3.5 days, non-integer
+        "porosity": 0.25,
+        "thickness": 4.0,
+        "retardation_factor": 1.0,
+    }
+
+    weights = compute_deposition_weights(flow=flow, tedges=tedges, cout_tedges=cout_tedges, **params)
+    rt = residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        index=cout_tedges,
+        aquifer_pore_volumes=params["aquifer_pore_volume"],
+        retardation_factor=params["retardation_factor"],
+        direction="extraction_to_infiltration",
+    )[0]
+    rt_per_bin = rt[:-1]
+    valid = ~np.isnan(weights).any(axis=1) & (np.abs(weights).sum(axis=1) > 0)
+    np.testing.assert_allclose(
+        weights[valid].sum(axis=1) * params["porosity"] * params["thickness"],
+        rt_per_bin[valid],
+        rtol=0,
+        atol=1e-13,
+    )
+
+
+def test_row_normalization_zero_flow_row_excluded_not_nan():
+    """A zero-flow cout bin produces an all-zero row, not a NaN-normalized row.
+
+    The inverse solver's ``valid_rows`` mask combines NaN-row exclusion and
+    all-zero-row exclusion. Row-normalization division ``W / row_sums`` must
+    not be applied to a zero-flow cout bin (would produce NaN). This test
+    pins the contract that all-zero rows are masked out *before* the division.
+    """
+    n = 30
+    dates = pd.date_range("2020-01-01", periods=n, freq="D")
+    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=n)
+    cout_tedges = tedges
+    flow = np.full(n, 100.0)
+    flow[15] = 0.0
+    params = {
+        "aquifer_pore_volume": 350.0,
+        "porosity": 0.25,
+        "thickness": 4.0,
+        "retardation_factor": 1.0,
+    }
+    weights = compute_deposition_weights(flow=flow, tedges=tedges, cout_tedges=cout_tedges, **params)
+
+    # Row 15 corresponds to the zero-flow cout bin.
+    row_is_all_zero = bool(np.all(weights[15] == 0.0))
+    row_contains_nan = bool(np.any(np.isnan(weights[15])))
+    assert row_is_all_zero, "Zero-flow cout bin row 15 must be all-zero"
+    assert not row_contains_nan, "Zero-flow cout bin row 15 must not be NaN"
+
+
+def test_full_solver_linearity_and_roundtrip(full_solver_overdetermined_setup):
+    """Linearity AND machine-precision absolute scale for extraction_to_deposition_full.
+
+    Linearity alone (``inverse(2x) == 2 * inverse(x)``) would pass under a
+    2x scaling bug. Round-trip pins absolute scale. Together they catch
+    additive-shift and multiplicative-scale bugs in the nullspace solver path.
+    """
+    tedges, cout_tedges, flow, original_deposition, concentration, params = full_solver_overdetermined_setup
+
+    base = extraction_to_deposition_full(
+        cout=concentration,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        **params,  # pyright: ignore[reportArgumentType]
+    )
+    doubled = extraction_to_deposition_full(
+        cout=2.0 * concentration,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        **params,  # pyright: ignore[reportArgumentType]
+    )
+
+    # Linearity (would fail under a constant additive offset bug)
+    np.testing.assert_allclose(doubled, 2.0 * base, rtol=1e-10, atol=1e-10)
+    # Absolute scale (would fail under a 1.5x scaling bug that preserves linearity)
+    np.testing.assert_allclose(base, original_deposition, rtol=1e-10, atol=1e-10)
+
+
+@pytest.mark.parametrize(
+    ("limit_param", "limit_values"),
+    [
+        ("aquifer_pore_volume", [10.0, 1.0, 0.1, 0.01]),
+        ("thickness", [10.0, 100.0, 1000.0, 10000.0]),
+    ],
+    ids=["small_apv", "large_thickness"],
+)
+def test_limit_reduction_cout_approaches_zero(limit_param, limit_values):
+    """As APV → 0+ or thickness → ∞, cout → 0 monotonically.
+
+    APV → 0: contact area A = V_pore / (n·b) → 0 ⇒ no deposition transfer.
+    thickness → ∞: contact area A → 0 ⇒ no deposition transfer.
+
+    APV = 0 strictly is rejected by the input validator at deposition.py:258;
+    we instead drive APV through a small-positive sequence and verify
+    monotonic decrease toward 0.
+    """
+    n = 40
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    dep = np.full(n, 5.0)
+    base_params = {
+        "aquifer_pore_volume": 500.0,
+        "porosity": 0.3,
+        "thickness": 10.0,
+        "retardation_factor": 1.0,
+    }
+
+    cout_maxima = []
+    for v in limit_values:
+        params = {**base_params, limit_param: v}
+        cout = deposition_to_extraction(dep=dep, flow=flow, tedges=tedges, cout_tedges=tedges, spinup=None, **params)
+        # Use the last valid cout bin (past spin-up) so steady-state holds and the linear scaling
+        # in V_pore (or 1/b) is exact -- the max over a partial spin-up bin can include ramp-up.
+        valid_indices = np.flatnonzero(~np.isnan(cout))
+        cout_maxima.append(cout[valid_indices[-1]])
+
+    cout_maxima = np.array(cout_maxima)
+
+    # cout = D * RT / (n * b) = D * V_pore / (Q * n * b) under constant flow, steady state.
+    # APV-sweep: cout proportional to V_pore. thickness-sweep: cout proportional to 1/thickness.
+    # cout_max[i] / cout_max[0] == limit_values[i] / limit_values[0] (APV) or
+    # cout_max[i] / cout_max[0] == limit_values[0] / limit_values[i] (thickness).
+    if limit_param == "aquifer_pore_volume":
+        expected_ratios = np.asarray(limit_values, dtype=float) / float(limit_values[0])
+    else:  # thickness
+        expected_ratios = float(limit_values[0]) / np.asarray(limit_values, dtype=float)
+    observed_ratios = cout_maxima / cout_maxima[0]
+    np.testing.assert_allclose(observed_ratios, expected_ratios, rtol=1e-12, atol=0)
+    # And, just to be explicit, the final ratio must drop several orders.
+    assert observed_ratios[-1] < 1e-2, f"final cout ratio should be << initial: {observed_ratios[-1]}"

--- a/tests/src/test_deposition.py
+++ b/tests/src/test_deposition.py
@@ -14,6 +14,7 @@ import pandas as pd
 import pytest
 
 from gwtransport.deposition import (
+    _validate_deposition_inputs,
     compute_deposition_weights,
     deposition_to_extraction,
     extraction_to_deposition,
@@ -1956,3 +1957,134 @@ def test_limit_reduction_cout_approaches_zero(limit_param, limit_values):
     np.testing.assert_allclose(observed_ratios, expected_ratios, rtol=1e-12, atol=0)
     # And, just to be explicit, the final ratio must drop several orders.
     assert observed_ratios[-1] < 1e-2, f"final cout ratio should be << initial: {observed_ratios[-1]}"
+
+
+# =============================================================================
+# Validator helper: one parametrized block hits every ValueError branch in
+# _validate_deposition_inputs via match= regex; a silent-on-good-input test
+# pins the no-raise path. The match strings are verbatim from the prior
+# triplicate prologue -- consolidating must preserve every wording.
+# =============================================================================
+
+
+def _good_validator_inputs():
+    """Return a baseline good-input dict that passes the validator silently."""
+    n = 5
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    return {
+        "tedges": tedges,
+        "flow_values": np.full(n, 100.0),
+        "aquifer_pore_volume": 300.0,
+        "porosity": 0.3,
+        "thickness": 5.0,
+    }
+
+
+def test_validate_deposition_inputs_silent_on_good_input_forward():
+    """No exception when the forward (dep + flow) inputs are valid."""
+    kwargs = _good_validator_inputs()
+    n = len(kwargs["flow_values"])
+    _validate_deposition_inputs(**kwargs, dep_values=np.full(n, 5.0))
+
+
+def test_validate_deposition_inputs_silent_on_good_input_inverse():
+    """No exception when the inverse (cout + flow) inputs are valid (cout may contain NaN)."""
+    kwargs = _good_validator_inputs()
+    n = len(kwargs["flow_values"])
+    cout_tedges = kwargs["tedges"]
+    cout_values = np.full(n, 10.0)
+    cout_values[2] = np.nan  # NaN in cout is intentionally allowed
+    _validate_deposition_inputs(**kwargs, cout_tedges=cout_tedges, cout_values=cout_values)
+
+
+@pytest.mark.parametrize(
+    ("path", "mutate", "match_regex"),
+    [
+        # Forward path (dep_values provided)
+        (
+            "forward",
+            lambda k: {**k, "dep_values": np.full(len(k["flow_values"]) + 1, 5.0)},
+            r"tedges must have one more element than dep",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "dep_values": np.array([5.0, np.nan, 5.0, 5.0, 5.0])},
+            r"Input arrays cannot contain NaN values",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "flow_values": np.array([100.0, np.nan, 100.0, 100.0, 100.0]),
+                "dep_values": np.full(5, 5.0),
+            },
+            r"Input arrays cannot contain NaN values",
+        ),
+        # Inverse path (cout_values provided)
+        (
+            "inverse",
+            lambda k: {**k, "cout_tedges": k["tedges"], "cout_values": np.full(len(k["flow_values"]) + 1, 10.0)},
+            r"cout_tedges must have one more element than cout",
+        ),
+        (
+            "inverse",
+            lambda k: {
+                **k,
+                "flow_values": np.array([100.0, np.nan, 100.0, 100.0, 100.0]),
+                "cout_tedges": k["tedges"],
+                "cout_values": np.full(len(k["flow_values"]), 10.0),
+            },
+            r"flow array cannot contain NaN values",
+        ),
+        # Shared branches (test on forward; inverse takes identical code path)
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "flow_values": np.array([100.0, -50.0, 100.0, 100.0, 100.0]),
+                "dep_values": np.full(5, 5.0),
+            },
+            r"flow must be non-negative \(negative flow not supported\)",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "porosity": 1.5, "dep_values": np.full(len(k["flow_values"]), 5.0)},
+            r"Porosity must be in \(0, 1\), got 1\.5",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "porosity": 0.0, "dep_values": np.full(len(k["flow_values"]), 5.0)},
+            r"Porosity must be in \(0, 1\), got 0\.0",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "thickness": 0.0, "dep_values": np.full(len(k["flow_values"]), 5.0)},
+            r"Thickness must be positive, got 0\.0",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "thickness": -1.0, "dep_values": np.full(len(k["flow_values"]), 5.0)},
+            r"Thickness must be positive, got -1\.0",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "aquifer_pore_volume": 0.0, "dep_values": np.full(len(k["flow_values"]), 5.0)},
+            r"Aquifer pore volume must be positive, got 0\.0",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "aquifer_pore_volume": -10.0, "dep_values": np.full(len(k["flow_values"]), 5.0)},
+            r"Aquifer pore volume must be positive, got -10\.0",
+        ),
+    ],
+)
+def test_validate_deposition_inputs_raises_on_bad_input(path, mutate, match_regex):
+    """Each ValueError branch raises with the exact historical message string.
+
+    Locks the consolidation against accidental wording drift; the regex
+    matches the verbatim string from the prior three duplicate prologues.
+    """
+    del path  # parametrize id only; behavior already encoded in mutate
+    bad = mutate(_good_validator_inputs())
+    with pytest.raises(ValueError, match=match_regex):
+        _validate_deposition_inputs(**bad)


### PR DESCRIPTION
## Summary

Three commits, one per scope, each green on `pytest tests/src -n auto`, `ruff format`, `ruff check`, `ty check`. All deposition-module-local; the cross-module helpers in #185 / #186 / #187 are deferred to follow-up PRs.

### Scope 1 — physics & math (closes #164 headline)

- Rewrite the row-normalization explanation in both the inline comment at `extraction_to_deposition` and the `Notes` block. Prior wording ("makes each observation equally important", "preserves the LS solution") is mathematically wrong under variable flow: dividing each row by its own `r_i = RT_i / (porosity * thickness)` is equivalent to weighted least squares with weights `1/r_i^2`. The OLS minimizer is recovered only when `cout` lies in the column space of `W` (e.g. noise-free roundtrip) or when all `r_i` are equal (constant flow). The Notes block now says this explicitly.
- Reinforce the source-vs-sink disclaimer at the function level: a one-paragraph Notes block in each of `deposition_to_extraction`, `extraction_to_deposition`, and `extraction_to_deposition_full` restates the module-level "this is a source, not a sink" caveat at the API surface.

### Scope 2 — tests (closes #171)

Tightens 9 existing tests that previously accepted physics-breaking mutations:

- `test_compute_deposition_weights_structure`: add analytical row-sum invariant (`sum(W[i,:]) * porosity * thickness == RT_i`).
- `test_compute_deposition_weights_causality`: assert strict future-zero (`weights[i, i+8:] == 0`) instead of `total_weight > 0`.
- `test_compute_deposition_weights_with_retardation`, `_porosity_effect`: replace `not allclose` with analytical row-sum / `1/porosity` scaling invariants.
- `test_extraction_to_deposition_full_{default,objectives,with_rcond}`: share an overdetermined half-day-cout / non-integer-RT fixture and assert `assert_allclose(recovered, original, atol=1e-10)`. Empirically both objectives reach ~1e-13 max abs error.
- `test_zero_deposition_zero_concentration`: drop conditional guard, tighten to `atol=1e-15`.
- `test_extraction_to_deposition_sparse_weekly_sampling`: trim from 3.6s notebook-data setup to 30ms synthetic 4-bin weekly setup that hits the same integer-RT rank deficiency and asserts the warning fires.

Adds new test groups for previously uncovered invariants:

- Mass conservation: pulse-dep + constant flow / variable flow / R=2; closed-window balance `Σ cout·Q·Δt == D·A_eff·pulse_width` at `rtol=1e-10`.
- Variable-retardation roundtrip at R=2 and R=3.5 to machine precision.
- Zero-flow spill recovery (forward+inverse roundtrip; cout=0 in gap, dep recovered to `1e-10` outside).
- `spinup_duration` with first bins of zero flow.
- NaN cout propagation: scattered + boundary positions, both Tikhonov and nullspace solvers (separate code paths).
- Row-normalization invariants: row sum equals `RT/(n·b)`, all-zero rows excluded not NaN.
- Full-solver linearity + machine-precision roundtrip.
- Limit reductions: `cout ∝ V_pore` (`∝ 1/thickness`) verified to `rtol=1e-12`.
- 13 parametrized validator tests pin every `ValueError` branch and the silent-on-good-input path.

### Scope 3 — code (closes #164 leanness comment; deposition-local only)

- Consolidate three near-identical 22-line validation prologues into a single private `_validate_deposition_inputs` helper. Forward path passes `dep_values`; inverse paths pass `cout_values`/`cout_tedges`. Every historical error message and f-string substitution preserved verbatim and pinned by the new validator tests.
- Collapse the `safe_denom` sentinel + double `np.where` pattern in `compute_deposition_weights` into a single `np.divide(out=zeros, where=mask)`.
- Drop the dead `np.full_like(deposition_weights, np.nan)` + scatter reconstruction before `solve_tikhonov`. `solve_tikhonov` filters NaN rows on both `coefficient_matrix` AND `rhs_vector` (`utils.py:1643`), so the reconstruction was filtered back to the same subset. Pass `w_norm` / `cout_norm` directly.
- Inline `n_dep_padded = len(weight_tedges) - 1` as `deposition_weights.shape[1]`.
- Replace `cout_rt_at_edges[0, :]` with `.squeeze(axis=0)` and drop the two-line explanatory comment.

Not in this PR (out of scope):

- Cross-module helpers `tedges_to_days` / `cumulative_flow_volume` / shared validation atoms (#185 / #186 / #187). The local sites in `deposition.py:112,113,129,735,736+743` are intentionally left untouched for those follow-ups.
- Merging `extraction_to_deposition` with `extraction_to_deposition_full` (intentional API surface).

## Test plan

- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src -n auto` — 1084 passed, 8 skipped.
- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src/test_deposition.py -q` — 70 passed (was 41 before).
- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q ruff format .` — 64 files left unchanged.
- [x] `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q ruff check .` — All checks passed.
- [x] `uv tool run -q ty check .` — All checks passed.
- [x] bas-physics-math-reviewer — Agree.
- [x] bas-test-reviewer — Agree.
- [x] bas-code-optimizer — Agree.

Closes #164.
Closes #171.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.