### PR TITLE
validation: consolidate transport input-validation prologues + 4 omission fixes (#187)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -68,6 +68,12 @@ convention = "numpy"
 "src/gwtransport/deposition.py" = [
     "DOC502",  # Public entry points document ValueError; the raises happen inside _validate_deposition_inputs
 ]
+"src/gwtransport/diffusion.py" = [
+    "DOC502",  # Public entry points document ValueError; the raises happen inside _validate_diffusion_inputs
+]
+"src/gwtransport/advection.py" = [
+    "DOC502",  # Public entry points document ValueError; the raises happen inside _validate_advection_inputs
+]
 "tests/**/test_*.py" = [
     "S101",    # asserts allowed in tests
     "D",

--- a/src/gwtransport/_validation.py
+++ b/src/gwtransport/_validation.py
@@ -1,0 +1,205 @@
+"""
+Composable input-validation atoms for transport-module entry points.
+
+The public ``infiltration_to_extraction`` / ``extraction_to_infiltration`` functions in
+:mod:`gwtransport.advection`, :mod:`gwtransport.diffusion`, and
+:mod:`gwtransport.deposition` share a small set of input-validation invariants
+(bin-edge parity, NaN-free arrays, non-negative flow, positive physical
+parameters). The atoms here factor those invariants once so that each module
+exposes a single ``_validate_<module>_inputs`` wrapper composing the atoms with
+module-specific error-message wording and ordering.
+
+Each atom is keyword-only (except for the array under test) and raises
+``ValueError`` with a default message; the optional ``message`` keyword lets the
+module wrapper preserve the historical wording verbatim so that downstream
+``pytest.raises(..., match=...)`` tests keep passing without modification.
+
+This module has no public API; importers are the transport modules themselves
+plus ``tests/src/test_validation.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+def _validate_tedges_parity(
+    tedges: pd.DatetimeIndex,
+    values: npt.ArrayLike,
+    *,
+    tedges_name: str,
+    values_name: str,
+) -> None:
+    """Validate bin-edge parity: ``len(tedges) == len(values) + 1``.
+
+    Parameters
+    ----------
+    tedges : DatetimeIndex
+        Bin edges (length ``n + 1``).
+    values : array-like
+        Bin-constant values (length ``n``).
+    tedges_name, values_name : str
+        Names used in the error message, e.g. ``"tedges"`` and ``"cin"``.
+
+    Raises
+    ------
+    ValueError
+        If ``len(tedges) != len(values) + 1``.
+    """
+    n_values = np.asarray(values).shape[0]
+    if len(tedges) != n_values + 1:
+        msg = f"{tedges_name} must have one more element than {values_name}"
+        raise ValueError(msg)
+
+
+def _validate_no_nan(
+    arr: npt.ArrayLike,
+    *,
+    name: str,
+    message: str | None = None,
+) -> None:
+    """Validate that ``arr`` contains no NaN values.
+
+    Parameters
+    ----------
+    arr : array-like
+        Array to check.
+    name : str
+        Variable name used in the default error message.
+    message : str, optional
+        Override the default ``"{name} contains NaN values, which are not allowed"``
+        wording. Used by module wrappers that need to preserve historical strings
+        pinned by ``pytest.raises(..., match=...)`` tests.
+
+    Raises
+    ------
+    ValueError
+        If any element of ``arr`` is NaN.
+    """
+    if np.any(np.isnan(np.asarray(arr))):
+        msg = message if message is not None else f"{name} contains NaN values, which are not allowed"
+        raise ValueError(msg)
+
+
+def _validate_non_negative_array(
+    arr: npt.ArrayLike,
+    *,
+    name: str,
+    message: str | None = None,
+) -> None:
+    """Validate that ``arr`` has no strictly negative elements.
+
+    Zeros are allowed. The companion ``_validate_positive_array`` rejects zeros too.
+
+    Parameters
+    ----------
+    arr : array-like
+        Array to check (any shape).
+    name : str
+        Variable name used in the default error message.
+    message : str, optional
+        Override the default ``"{name} must be non-negative"`` wording.
+
+    Raises
+    ------
+    ValueError
+        If any element of ``arr`` is strictly negative.
+    """
+    if np.any(np.asarray(arr) < 0):
+        msg = message if message is not None else f"{name} must be non-negative"
+        raise ValueError(msg)
+
+
+def _validate_positive_array(
+    arr: npt.ArrayLike,
+    *,
+    name: str,
+    message: str | None = None,
+) -> None:
+    """Validate that every element of ``arr`` is strictly positive (``> 0``).
+
+    Parameters
+    ----------
+    arr : array-like
+        Array to check.
+    name : str
+        Variable name used in the default error message.
+    message : str, optional
+        Override the default ``"{name} must be positive"`` wording.
+
+    Raises
+    ------
+    ValueError
+        If any element of ``arr`` is ``<= 0``.
+    """
+    if np.any(np.asarray(arr) <= 0):
+        msg = message if message is not None else f"{name} must be positive"
+        raise ValueError(msg)
+
+
+def _validate_positive_scalar(
+    value: float,
+    *,
+    name: str,
+    message: str | None = None,
+) -> None:
+    """Validate that ``value`` is strictly positive (``> 0``).
+
+    Parameters
+    ----------
+    value : float
+        Scalar to check.
+    name : str
+        Variable name used in the default error message.
+    message : str, optional
+        Override the default ``"{name} must be positive, got {value}"`` wording.
+
+    Raises
+    ------
+    ValueError
+        If ``value <= 0``.
+    """
+    if value <= 0:
+        msg = message if message is not None else f"{name} must be positive, got {value}"
+        raise ValueError(msg)
+
+
+def _validate_scalar_or_matching_length(
+    arr: npt.ArrayLike,
+    *,
+    name: str,
+    expected_len: int,
+    ref_name: str,
+) -> None:
+    """Validate length: ``len(arr) == expected_len``.
+
+    Intended for inputs that the caller accepts as either a scalar or an
+    array matching some reference length; the caller is expected to have
+    broadcast size-1 arrays to ``expected_len`` *before* calling this atom.
+    The error message refers to the user-facing scalar-or-matching contract.
+
+    Parameters
+    ----------
+    arr : array-like
+        Array to check (already broadcast from scalar form by the caller).
+    name : str
+        Variable name used in the error message.
+    expected_len : int
+        Required length.
+    ref_name : str
+        Name of the reference array whose length is the contract.
+
+    Raises
+    ------
+    ValueError
+        If ``len(arr) != expected_len``.
+    """
+    if np.asarray(arr).shape[0] != expected_len:
+        msg = f"{name} must be a scalar or have same length as {ref_name}"
+        raise ValueError(msg)

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -74,6 +74,11 @@ import numpy.typing as npt
 import pandas as pd
 
 from gwtransport import gamma
+from gwtransport._validation import (
+    _validate_no_nan,
+    _validate_non_negative_array,
+    _validate_tedges_parity,
+)
 from gwtransport.advection_utils import (
     _infiltration_to_extraction_weights,
     _resolve_spinup_inputs,
@@ -91,6 +96,53 @@ from gwtransport.fronttracking.solver import FrontTracker
 from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
 from gwtransport.residence_time import residence_time
 from gwtransport.utils import solve_inverse_transport
+
+
+def _validate_advection_inputs(
+    *,
+    tedges: pd.DatetimeIndex,
+    flow: np.ndarray,
+    retardation_factor: float,
+    cin_values: np.ndarray | None = None,
+    cout_values: np.ndarray | None = None,
+    cout_tedges: pd.DatetimeIndex | None = None,
+) -> None:
+    """Validate inputs common to advection forward / reverse entry points.
+
+    Path selection via mutually-exclusive kwargs:
+
+    - ``cin_values`` provided => forward path. ``tedges`` parities cin and flow.
+    - ``cout_values`` + ``cout_tedges`` provided => reverse path. ``tedges`` parities
+      flow; ``cout_tedges`` parities cout.
+
+    All shared checks fire on both paths. ``flow >= 0`` is enforced in both
+    directions (the previous reverse prologue omitted this; see issue #187). Every
+    other error-message string is preserved verbatim from the prior duplicated
+    prologue so that ``match=`` regex tests do not break.
+
+    Raises
+    ------
+    ValueError
+        If any check fails. The message identifies which invariant was violated.
+    """
+    if cin_values is not None:
+        _validate_tedges_parity(tedges, cin_values, tedges_name="tedges", values_name="cin")
+        _validate_tedges_parity(tedges, flow, tedges_name="tedges", values_name="flow")
+    elif cout_values is not None and cout_tedges is not None:
+        _validate_tedges_parity(tedges, flow, tedges_name="tedges", values_name="flow")
+        _validate_tedges_parity(cout_tedges, cout_values, tedges_name="cout_tedges", values_name="cout")
+    else:
+        msg = "must provide cin_values (forward) or both cout_values and cout_tedges (reverse)"
+        raise ValueError(msg)
+    if cin_values is not None:
+        _validate_no_nan(cin_values, name="cin")
+    elif cout_values is not None:
+        _validate_no_nan(cout_values, name="cout")
+    _validate_no_nan(flow, name="flow")
+    _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
+    if retardation_factor < 1.0:
+        msg = "retardation_factor must be >= 1.0"
+        raise ValueError(msg)
 
 
 def infiltration_to_extraction_series(
@@ -864,26 +916,12 @@ def infiltration_to_extraction(
     flow = np.asarray(flow)
     aquifer_pore_volumes = np.asarray(aquifer_pore_volumes)
 
-    if len(tedges) != len(cin) + 1:
-        msg = "tedges must have one more element than cin"
-        raise ValueError(msg)
-    if len(tedges) != len(flow) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-
-    # Validate inputs do not contain NaN values
-    if np.any(np.isnan(cin)):
-        msg = "cin contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(np.isnan(flow)):
-        msg = "flow contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(flow < 0):
-        msg = "flow must be non-negative (negative flow not supported)"
-        raise ValueError(msg)
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
+    _validate_advection_inputs(
+        tedges=tedges,
+        flow=flow,
+        retardation_factor=retardation_factor,
+        cin_values=cin,
+    )
 
     weight_tedges, weight_flow, weight_cin, threshold, _ = _resolve_spinup_inputs(
         spinup,
@@ -1022,6 +1060,13 @@ def extraction_to_infiltration(
     :ref:`concept-pore-volume-distribution` : Background on aquifer heterogeneity modeling
     :ref:`concept-transport-equation` : Flow-weighted averaging approach
 
+    Notes
+    -----
+    NaN values in ``cout`` are rejected. The Tikhonov solver here does not
+    mask NaN rows, so any NaN in ``cout`` would poison the solution. This
+    differs from :func:`gwtransport.deposition.extraction_to_deposition`,
+    whose regularized solver excludes NaN ``cout`` rows by construction.
+
     Examples
     --------
     Basic usage with pandas Series:
@@ -1098,23 +1143,13 @@ def extraction_to_infiltration(
     cout = np.asarray(cout)
     flow = np.asarray(flow)
 
-    if len(tedges) != len(flow) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-    if len(cout_tedges) != len(cout) + 1:
-        msg = "cout_tedges must have one more element than cout"
-        raise ValueError(msg)
-
-    # Validate inputs do not contain NaN values
-    if np.any(np.isnan(cout)):
-        msg = "cout contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(np.isnan(flow)):
-        msg = "flow contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
+    _validate_advection_inputs(
+        tedges=tedges,
+        flow=flow,
+        retardation_factor=retardation_factor,
+        cout_values=cout,
+        cout_tedges=cout_tedges,
+    )
 
     aquifer_pore_volumes = np.asarray(aquifer_pore_volumes)
 

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -54,6 +54,12 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from gwtransport._validation import (
+    _validate_no_nan,
+    _validate_non_negative_array,
+    _validate_positive_scalar,
+    _validate_tedges_parity,
+)
 from gwtransport.advection_utils import _resolve_spinup_inputs
 from gwtransport.deposition_utils import compute_average_heights
 from gwtransport.residence_time import residence_time
@@ -73,6 +79,7 @@ def _validate_deposition_inputs(
     aquifer_pore_volume: float,
     porosity: float,
     thickness: float,
+    retardation_factor: float = 1.0,
     cout_tedges: pd.DatetimeIndex | None = None,
     cout_values: np.ndarray | None = None,
     dep_values: np.ndarray | None = None,
@@ -91,8 +98,8 @@ def _validate_deposition_inputs(
       additionally, in the inverse path (``dep_values is None``), a flow-only
       NaN-check fires with the historical "flow array cannot contain NaN
       values" message.
-    - Physical params (``porosity``, ``thickness``, ``aquifer_pore_volume``)
-      always validated.
+    - Physical params (``porosity``, ``thickness``, ``aquifer_pore_volume``,
+      ``retardation_factor``) always validated.
 
     Every error message and f-string substitution is preserved verbatim from
     the prior triplicate prologue so that ``match=`` regex tests do not break.
@@ -103,33 +110,34 @@ def _validate_deposition_inputs(
         If any of the activated checks fails. The specific message names which
         invariant was violated (see body for the verbatim strings).
     """
-    if dep_values is not None and len(tedges) != len(dep_values) + 1:
-        msg = "tedges must have one more element than dep"
-        raise ValueError(msg)
-    if len(tedges) != len(flow_values) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-    if cout_values is not None and cout_tedges is not None and len(cout_tedges) != len(cout_values) + 1:
-        msg = "cout_tedges must have one more element than cout"
-        raise ValueError(msg)
     if dep_values is not None:
+        _validate_tedges_parity(tedges, dep_values, tedges_name="tedges", values_name="dep")
+    _validate_tedges_parity(tedges, flow_values, tedges_name="tedges", values_name="flow")
+    if cout_values is not None and cout_tedges is not None:
+        _validate_tedges_parity(cout_tedges, cout_values, tedges_name="cout_tedges", values_name="cout")
+    if dep_values is not None:
+        # Compound NaN-check covers both ``dep`` and ``flow`` under one message; mapping to
+        # two separate ``_validate_no_nan`` calls would change wording and which array name
+        # surfaces first.
         if np.any(np.isnan(dep_values)) or np.any(np.isnan(flow_values)):
             msg = "Input arrays cannot contain NaN values"
             raise ValueError(msg)
-    elif np.any(np.isnan(flow_values)):
-        msg = "flow array cannot contain NaN values"
-        raise ValueError(msg)
-    if np.any(flow_values < 0):
-        msg = "flow must be non-negative (negative flow not supported)"
-        raise ValueError(msg)
+    else:
+        _validate_no_nan(flow_values, name="flow", message="flow array cannot contain NaN values")
+    _validate_non_negative_array(
+        flow_values, name="flow", message="flow must be non-negative (negative flow not supported)"
+    )
     if not 0 < porosity < 1:
         msg = f"Porosity must be in (0, 1), got {porosity}"
         raise ValueError(msg)
-    if thickness <= 0:
-        msg = f"Thickness must be positive, got {thickness}"
-        raise ValueError(msg)
-    if aquifer_pore_volume <= 0:
-        msg = f"Aquifer pore volume must be positive, got {aquifer_pore_volume}"
+    _validate_positive_scalar(thickness, name="thickness", message=f"Thickness must be positive, got {thickness}")
+    _validate_positive_scalar(
+        aquifer_pore_volume,
+        name="aquifer_pore_volume",
+        message=f"Aquifer pore volume must be positive, got {aquifer_pore_volume}",
+    )
+    if retardation_factor < 1.0:
+        msg = "retardation_factor must be >= 1.0"
         raise ValueError(msg)
 
 
@@ -307,6 +315,7 @@ def deposition_to_extraction(
         aquifer_pore_volume=aquifer_pore_volume,
         porosity=porosity,
         thickness=thickness,
+        retardation_factor=retardation_factor,
         dep_values=dep_values,
     )
 
@@ -489,6 +498,7 @@ def extraction_to_deposition(
         aquifer_pore_volume=aquifer_pore_volume,
         porosity=porosity,
         thickness=thickness,
+        retardation_factor=retardation_factor,
         cout_tedges=cout_tedges,
         cout_values=cout_values,
     )
@@ -675,6 +685,7 @@ def extraction_to_deposition_full(
         aquifer_pore_volume=aquifer_pore_volume,
         porosity=porosity,
         thickness=thickness,
+        retardation_factor=retardation_factor,
         cout_tedges=cout_tedges,
         cout_values=cout_values,
     )

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -88,6 +88,13 @@ import pandas as pd
 from scipy import special
 
 from gwtransport import gamma
+from gwtransport._validation import (
+    _validate_no_nan,
+    _validate_non_negative_array,
+    _validate_positive_array,
+    _validate_scalar_or_matching_length,
+    _validate_tedges_parity,
+)
 from gwtransport.residence_time import residence_time
 from gwtransport.utils import solve_inverse_transport
 
@@ -338,6 +345,108 @@ def _diffusion_extend_tedges_flag(spinup: object) -> bool:
         f"float thresholds are not yet implemented (got {spinup!r})"
     )
     raise NotImplementedError(msg)
+
+
+def _validate_diffusion_inputs(
+    *,
+    tedges: pd.DatetimeIndex,
+    flow: np.ndarray,
+    aquifer_pore_volumes: np.ndarray,
+    streamline_length: np.ndarray,
+    molecular_diffusivity: np.ndarray,
+    longitudinal_dispersivity: np.ndarray,
+    retardation_factor: float,
+    suppress_dispersion_warning: bool,
+    cin_values: np.ndarray | None = None,
+    cout_values: np.ndarray | None = None,
+    cout_tedges: pd.DatetimeIndex | None = None,
+) -> None:
+    """Validate inputs common to diffusion forward / reverse entry points.
+
+    Path selection via mutually-exclusive kwargs:
+
+    - ``cin_values`` provided => forward path. ``tedges`` parities cin and flow.
+    - ``cout_values`` + ``cout_tedges`` provided => reverse path. ``tedges`` parities
+      flow; ``cout_tedges`` parities cout.
+
+    All shared physical checks fire on both paths. ``retardation_factor >= 1.0``
+    and ``flow >= 0`` in reverse are new vs. the previous inline prologues (issue
+    #187 documents the omissions). Every other error-message string is preserved
+    verbatim from the prior duplicated prologue so that ``match=`` regex tests do
+    not break.
+
+    The dispersion warning (``UserWarning``) is emitted here as well since the
+    same precondition is checked alongside the validations; it is physically
+    motivated guidance about double-counting velocity heterogeneity, not an
+    input-validation rule.
+
+    Raises
+    ------
+    ValueError
+        If any check fails. The message identifies which invariant was violated.
+
+    Warns
+    -----
+    UserWarning
+        If ``n_pore_volumes > 1`` and any ``longitudinal_dispersivity > 0``
+        and ``suppress_dispersion_warning is False``.
+    """
+    n_pore_volumes = len(aquifer_pore_volumes)
+
+    if cin_values is not None:
+        _validate_tedges_parity(tedges, cin_values, tedges_name="tedges", values_name="cin")
+        _validate_tedges_parity(tedges, flow, tedges_name="tedges", values_name="flow")
+    elif cout_values is not None and cout_tedges is not None:
+        _validate_tedges_parity(tedges, flow, tedges_name="tedges", values_name="flow")
+        _validate_tedges_parity(cout_tedges, cout_values, tedges_name="cout_tedges", values_name="cout")
+    else:
+        msg = "must provide cin_values (forward) or both cout_values and cout_tedges (reverse)"
+        raise ValueError(msg)
+    if len(aquifer_pore_volumes) != len(streamline_length):
+        msg = "aquifer_pore_volumes and streamline_length must have the same length"
+        raise ValueError(msg)
+    _validate_scalar_or_matching_length(
+        molecular_diffusivity,
+        name="molecular_diffusivity",
+        expected_len=n_pore_volumes,
+        ref_name="aquifer_pore_volumes",
+    )
+    _validate_scalar_or_matching_length(
+        longitudinal_dispersivity,
+        name="longitudinal_dispersivity",
+        expected_len=n_pore_volumes,
+        ref_name="aquifer_pore_volumes",
+    )
+    _validate_non_negative_array(molecular_diffusivity, name="molecular_diffusivity")
+    _validate_non_negative_array(longitudinal_dispersivity, name="longitudinal_dispersivity")
+    if cin_values is not None:
+        _validate_no_nan(cin_values, name="cin")
+    elif cout_values is not None:
+        _validate_no_nan(cout_values, name="cout")
+    _validate_no_nan(flow, name="flow")
+    _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
+    _validate_positive_array(aquifer_pore_volumes, name="aquifer_pore_volumes")
+    _validate_positive_array(streamline_length, name="streamline_length")
+    if retardation_factor < 1.0:
+        msg = "retardation_factor must be >= 1.0"
+        raise ValueError(msg)
+
+    if n_pore_volumes > 1 and np.any(longitudinal_dispersivity > 0) and not suppress_dispersion_warning:
+        msg = (
+            "Using multiple aquifer_pore_volumes with non-zero longitudinal_dispersivity. "
+            "Both represent spreading from velocity heterogeneity at different scales.\n\n"
+            "This is appropriate when:\n"
+            "  - APVD comes from streamline analysis (explicit geometry)\n"
+            "  - You want to add unresolved microdispersion and molecular diffusion\n\n"
+            "This may double-count spreading when:\n"
+            "  - APVD was calibrated from measurements (microdispersion already included)\n\n"
+            "For gamma-parameterized APVD, consider using the 'equivalent APVD std' approach\n"
+            "from 05_Diffusion_Dispersion.ipynb to combine both effects in the faster advection\n"
+            "module. Note: this variance combination is only valid for continuous (gamma)\n"
+            "distributions, not for discrete streamline volumes.\n"
+            "Suppress this warning with suppress_dispersion_warning=True."
+        )
+        warnings.warn(msg, UserWarning, stacklevel=3)
 
 
 def _infiltration_to_extraction_coeff_matrix(
@@ -684,63 +793,17 @@ def infiltration_to_extraction(
     if longitudinal_dispersivity.size == 1:
         longitudinal_dispersivity = np.broadcast_to(longitudinal_dispersivity, (n_pore_volumes,)).copy()
 
-    # Input validation
-    if len(tedges) != len(cin) + 1:
-        msg = "tedges must have one more element than cin"
-        raise ValueError(msg)
-    if len(tedges) != len(flow) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-    if len(aquifer_pore_volumes) != len(streamline_length):
-        msg = "aquifer_pore_volumes and streamline_length must have the same length"
-        raise ValueError(msg)
-    if len(molecular_diffusivity) != n_pore_volumes:
-        msg = "molecular_diffusivity must be a scalar or have same length as aquifer_pore_volumes"
-        raise ValueError(msg)
-    if len(longitudinal_dispersivity) != n_pore_volumes:
-        msg = "longitudinal_dispersivity must be a scalar or have same length as aquifer_pore_volumes"
-        raise ValueError(msg)
-    if np.any(molecular_diffusivity < 0):
-        msg = "molecular_diffusivity must be non-negative"
-        raise ValueError(msg)
-    if np.any(longitudinal_dispersivity < 0):
-        msg = "longitudinal_dispersivity must be non-negative"
-        raise ValueError(msg)
-    if np.any(np.isnan(cin)):
-        msg = "cin contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(np.isnan(flow)):
-        msg = "flow contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(flow < 0):
-        msg = "flow must be non-negative (negative flow not supported)"
-        raise ValueError(msg)
-    if np.any(aquifer_pore_volumes <= 0):
-        msg = "aquifer_pore_volumes must be positive"
-        raise ValueError(msg)
-    if np.any(streamline_length <= 0):
-        msg = "streamline_length must be positive"
-        raise ValueError(msg)
-
-    # Check for conflicting approaches: multiple pore volumes with longitudinal dispersivity
-    # Both represent the same physical phenomenon (velocity heterogeneity) at different scales.
-    # See concept-dispersion-scales in the documentation for details.
-    if n_pore_volumes > 1 and np.any(longitudinal_dispersivity > 0) and not suppress_dispersion_warning:
-        msg = (
-            "Using multiple aquifer_pore_volumes with non-zero longitudinal_dispersivity. "
-            "Both represent spreading from velocity heterogeneity at different scales.\n\n"
-            "This is appropriate when:\n"
-            "  - APVD comes from streamline analysis (explicit geometry)\n"
-            "  - You want to add unresolved microdispersion and molecular diffusion\n\n"
-            "This may double-count spreading when:\n"
-            "  - APVD was calibrated from measurements (microdispersion already included)\n\n"
-            "For gamma-parameterized APVD, consider using the 'equivalent APVD std' approach\n"
-            "from 05_Diffusion_Dispersion.ipynb to combine both effects in the faster advection\n"
-            "module. Note: this variance combination is only valid for continuous (gamma)\n"
-            "distributions, not for discrete streamline volumes.\n"
-            "Suppress this warning with suppress_dispersion_warning=True."
-        )
-        warnings.warn(msg, UserWarning, stacklevel=2)
+    _validate_diffusion_inputs(
+        tedges=tedges,
+        flow=flow,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        streamline_length=streamline_length,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
+        suppress_dispersion_warning=suppress_dispersion_warning,
+        cin_values=cin,
+    )
 
     extend_tedges = _diffusion_extend_tedges_flag(spinup)
     coeff_matrix, valid_cout_bins = _infiltration_to_extraction_coeff_matrix(
@@ -866,6 +929,11 @@ def extraction_to_infiltration(
     using :func:`gwtransport.utils.solve_tikhonov`. This ensures mathematical
     consistency between forward and inverse operations.
 
+    NaN values in ``cout`` are rejected. The Tikhonov solver here does not
+    mask NaN rows, so any NaN in ``cout`` would poison the solution. This
+    differs from :func:`gwtransport.deposition.extraction_to_deposition`,
+    whose regularized solver excludes NaN ``cout`` rows by construction.
+
     Examples
     --------
     Basic usage with constant flow:
@@ -922,58 +990,18 @@ def extraction_to_infiltration(
     if longitudinal_dispersivity.size == 1:
         longitudinal_dispersivity = np.broadcast_to(longitudinal_dispersivity, (n_pore_volumes,)).copy()
 
-    # Input validation
-    if len(tedges) != len(flow) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-    if len(cout_tedges) != len(cout) + 1:
-        msg = "cout_tedges must have one more element than cout"
-        raise ValueError(msg)
-    if len(aquifer_pore_volumes) != len(streamline_length):
-        msg = "aquifer_pore_volumes and streamline_length must have the same length"
-        raise ValueError(msg)
-    if len(molecular_diffusivity) != n_pore_volumes:
-        msg = "molecular_diffusivity must be a scalar or have same length as aquifer_pore_volumes"
-        raise ValueError(msg)
-    if len(longitudinal_dispersivity) != n_pore_volumes:
-        msg = "longitudinal_dispersivity must be a scalar or have same length as aquifer_pore_volumes"
-        raise ValueError(msg)
-    if np.any(molecular_diffusivity < 0):
-        msg = "molecular_diffusivity must be non-negative"
-        raise ValueError(msg)
-    if np.any(longitudinal_dispersivity < 0):
-        msg = "longitudinal_dispersivity must be non-negative"
-        raise ValueError(msg)
-    if np.any(np.isnan(cout)):
-        msg = "cout contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(np.isnan(flow)):
-        msg = "flow contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(aquifer_pore_volumes <= 0):
-        msg = "aquifer_pore_volumes must be positive"
-        raise ValueError(msg)
-    if np.any(streamline_length <= 0):
-        msg = "streamline_length must be positive"
-        raise ValueError(msg)
-
-    # Check for conflicting approaches
-    if n_pore_volumes > 1 and np.any(longitudinal_dispersivity > 0) and not suppress_dispersion_warning:
-        msg = (
-            "Using multiple aquifer_pore_volumes with non-zero longitudinal_dispersivity. "
-            "Both represent spreading from velocity heterogeneity at different scales.\n\n"
-            "This is appropriate when:\n"
-            "  - APVD comes from streamline analysis (explicit geometry)\n"
-            "  - You want to add unresolved microdispersion and molecular diffusion\n\n"
-            "This may double-count spreading when:\n"
-            "  - APVD was calibrated from measurements (microdispersion already included)\n\n"
-            "For gamma-parameterized APVD, consider using the 'equivalent APVD std' approach\n"
-            "from 05_Diffusion_Dispersion.ipynb to combine both effects in the faster advection\n"
-            "module. Note: this variance combination is only valid for continuous (gamma)\n"
-            "distributions, not for discrete streamline volumes.\n"
-            "Suppress this warning with suppress_dispersion_warning=True."
-        )
-        warnings.warn(msg, UserWarning, stacklevel=2)
+    _validate_diffusion_inputs(
+        tedges=tedges,
+        flow=flow,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        streamline_length=streamline_length,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
+        suppress_dispersion_warning=suppress_dispersion_warning,
+        cout_values=cout,
+        cout_tedges=cout_tedges,
+    )
 
     n_cin = len(tedges) - 1
 

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -6,6 +6,7 @@ import pytest
 
 from gwtransport import advection as adv_mod
 from gwtransport.advection import (
+    _validate_advection_inputs,
     extraction_to_infiltration,
     extraction_to_infiltration_series,
     gamma_extraction_to_infiltration,
@@ -683,39 +684,6 @@ def test_infiltration_to_extraction_retardation_factor():
     assert cout_r2[expected_step_idx_r2 - 3] == 0.0
     # The R=2 step lags by exactly PV/flow = 2 bins
     assert expected_step_idx_r2 - expected_step_idx_r1 == int(pore_volume / 100.0)
-
-
-def test_infiltration_to_extraction_error_conditions():
-    """Test infiltration_to_extraction error conditions."""
-    dates = pd.date_range(start="2020-01-01", end="2020-01-10", freq="D")
-    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
-    cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
-
-    cin = pd.Series(np.ones(len(dates)), index=dates)
-    flow = pd.Series(np.ones(len(dates)) * 100, index=dates)
-    aquifer_pore_volumes = np.array([1000.0])
-
-    # Test mismatched tedges length
-    wrong_tedges = tedges[:-2]  # Too short
-    with pytest.raises(ValueError, match="tedges must have one more element than cin"):
-        infiltration_to_extraction(
-            cin=cin.to_numpy(),
-            flow=flow.to_numpy(),
-            tedges=wrong_tedges,
-            cout_tedges=cout_tedges,
-            aquifer_pore_volumes=aquifer_pore_volumes,
-        )
-
-    # Test mismatched flow and tedges
-    wrong_flow = flow[:-2]  # Too short
-    with pytest.raises(ValueError, match="tedges must have one more element than flow"):
-        infiltration_to_extraction(
-            cin=cin.to_numpy(),
-            flow=wrong_flow,
-            tedges=tedges,
-            cout_tedges=cout_tedges,
-            aquifer_pore_volumes=aquifer_pore_volumes,
-        )
 
 
 # ===============================================================================
@@ -1463,39 +1431,6 @@ def test_extraction_to_infiltration_retardation_factor():
     assert np.sum(valid) > 30
     np.testing.assert_allclose(cin_back_r1[valid], cin_values[valid], atol=1e-9)
     np.testing.assert_allclose(cin_back_r2[valid], cin_values[valid], atol=1e-9)
-
-
-def test_extraction_to_infiltration_error_conditions():
-    """Test extraction_to_infiltration error conditions."""
-    dates = pd.date_range(start="2020-01-01", end="2020-01-10", freq="D")
-    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
-    cin_tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
-
-    cout = pd.Series(np.ones(len(dates)), index=dates)
-    flow = pd.Series(np.ones(len(dates)) * 100, index=dates)
-    aquifer_pore_volumes = np.array([1000.0])
-
-    # Test mismatched cout_tedges length
-    wrong_cout_tedges = tedges[:-2]  # Too short
-    with pytest.raises(ValueError, match="cout_tedges must have one more element than cout"):
-        extraction_to_infiltration(
-            cout=cout.to_numpy(),
-            flow=flow.to_numpy(),
-            tedges=cin_tedges,
-            cout_tedges=wrong_cout_tedges,
-            aquifer_pore_volumes=aquifer_pore_volumes,
-        )
-
-    # Test mismatched flow and tedges
-    wrong_flow = flow[:-2]  # Too short
-    with pytest.raises(ValueError, match="tedges must have one more element than flow"):
-        extraction_to_infiltration(
-            cout=cout.to_numpy(),
-            flow=wrong_flow,
-            tedges=cin_tedges,
-            cout_tedges=tedges,
-            aquifer_pore_volumes=aquifer_pore_volumes,
-        )
 
 
 # ===============================================================================
@@ -2668,23 +2603,6 @@ def _zero_flow_invariance_setup():
     }
 
 
-def test_infiltration_to_extraction_rejects_negative_flow():
-    """Negative flow must raise ValueError with the standard message."""
-    tedges = pd.date_range(start="2020-01-01", periods=11, freq="D")
-    cin = np.ones(10)
-    flow = np.full(10, 100.0)
-    flow[5] = -1.0
-
-    with pytest.raises(ValueError, match="flow must be non-negative"):
-        infiltration_to_extraction(
-            cin=cin,
-            flow=flow,
-            tedges=tedges,
-            cout_tedges=tedges,
-            aquifer_pore_volumes=np.array([500.0]),
-        )
-
-
 def test_infiltration_to_extraction_accepts_zero_flow_without_warnings():
     """flow == 0 is accepted; no division-by-zero warnings emitted."""
     tedges = pd.date_range(start="2020-01-01", periods=201, freq="D")
@@ -3680,3 +3598,141 @@ def test_weight_matrix_rows_sum_to_one_or_zero():
     valid_rows = ~invalid
     np.testing.assert_allclose(row_sums[valid_rows], 1.0, atol=1e-13)
     np.testing.assert_allclose(row_sums[invalid], 0.0, atol=1e-13)
+
+
+# =============================================================================
+# Validator helper: parametrized snapshot pinning every ValueError branch of
+# _validate_advection_inputs. Verbatim messages from the prior duplicated
+# prologues; new branches (flow>=0 in rev) are the issue #187 omission fix.
+# =============================================================================
+
+
+def _good_advection_inputs():
+    """Baseline good-input dict that passes _validate_advection_inputs silently."""
+    n = 5
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    return {
+        "tedges": tedges,
+        "flow": np.full(n, 100.0),
+        "retardation_factor": 1.0,
+    }
+
+
+def test_validate_advection_inputs_silent_on_good_input_forward():
+    """No exception when the forward (cin) inputs are valid."""
+    kwargs = _good_advection_inputs()
+    n = len(kwargs["flow"])
+    _validate_advection_inputs(**kwargs, cin_values=np.ones(n))
+
+
+def test_validate_advection_inputs_silent_on_good_input_reverse():
+    """No exception when the reverse (cout + cout_tedges) inputs are valid."""
+    kwargs = _good_advection_inputs()
+    n = len(kwargs["flow"])
+    _validate_advection_inputs(**kwargs, cout_values=np.ones(n), cout_tedges=kwargs["tedges"])
+
+
+@pytest.mark.parametrize(
+    ("path", "mutate", "match_regex"),
+    [
+        # ---------------- forward path ----------------
+        (
+            "forward",
+            lambda k: {**k, "cin_values": np.ones(len(k["flow"]) + 1)},
+            r"tedges must have one more element than cin",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "cin_values": np.ones(len(k["flow"])),
+                "flow": np.full(len(k["flow"]) + 1, 100.0),
+            },
+            r"tedges must have one more element than flow",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "cin_values": np.array([1.0, np.nan, 1.0, 1.0, 1.0])},
+            r"cin contains NaN values, which are not allowed",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "flow": np.array([100.0, np.nan, 100.0, 100.0, 100.0]),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"flow contains NaN values, which are not allowed",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "flow": np.array([100.0, -50.0, 100.0, 100.0, 100.0]),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"flow must be non-negative \(negative flow not supported\)",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "retardation_factor": 0.5, "cin_values": np.ones(len(k["flow"]))},
+            r"retardation_factor must be >= 1\.0",
+        ),
+        # ---------------- reverse path ----------------
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "flow": np.full(len(k["flow"]) + 1, 100.0),
+                "cout_values": np.ones(len(k["flow"])),
+                "cout_tedges": k["tedges"],
+            },
+            r"tedges must have one more element than flow",
+        ),
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "cout_values": np.ones(len(k["flow"]) + 1),
+                "cout_tedges": k["tedges"],
+            },
+            r"cout_tedges must have one more element than cout",
+        ),
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "cout_values": np.array([1.0, np.nan, 1.0, 1.0, 1.0]),
+                "cout_tedges": k["tedges"],
+            },
+            r"cout contains NaN values, which are not allowed",
+        ),
+        # NEW: flow >= 0 in reverse (omission fix; symmetric with diffusion reverse)
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "flow": np.array([100.0, -50.0, 100.0, 100.0, 100.0]),
+                "cout_values": np.ones(len(k["flow"])),
+                "cout_tedges": k["tedges"],
+            },
+            r"flow must be non-negative \(negative flow not supported\)",
+        ),
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "retardation_factor": 0.5,
+                "cout_values": np.ones(len(k["flow"])),
+                "cout_tedges": k["tedges"],
+            },
+            r"retardation_factor must be >= 1\.0",
+        ),
+    ],
+)
+def test_validate_advection_inputs_raises_on_bad_input(path, mutate, match_regex):
+    """Each ValueError branch raises with the exact historical message string."""
+    del path
+    bad = mutate(_good_advection_inputs())
+    with pytest.raises(ValueError, match=match_regex):
+        _validate_advection_inputs(**bad)

--- a/tests/src/test_deposition.py
+++ b/tests/src/test_deposition.py
@@ -2076,6 +2076,26 @@ def test_validate_deposition_inputs_silent_on_good_input_inverse():
             lambda k: {**k, "aquifer_pore_volume": -10.0, "dep_values": np.full(len(k["flow_values"]), 5.0)},
             r"Aquifer pore volume must be positive, got -10\.0",
         ),
+        # NEW: retardation_factor < 1.0 (issue #187 omission fix; new validation surface)
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "retardation_factor": 0.5,
+                "dep_values": np.full(len(k["flow_values"]), 5.0),
+            },
+            r"retardation_factor must be >= 1\.0",
+        ),
+        (
+            "inverse",
+            lambda k: {
+                **k,
+                "retardation_factor": 0.5,
+                "cout_tedges": k["tedges"],
+                "cout_values": np.full(len(k["flow_values"]), 10.0),
+            },
+            r"retardation_factor must be >= 1\.0",
+        ),
     ],
 )
 def test_validate_deposition_inputs_raises_on_bad_input(path, mutate, match_regex):

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -18,6 +18,7 @@ from gwtransport.advection import (
 from gwtransport.diffusion import (
     _cfrac_mean_volume,
     _infiltration_to_extraction_coeff_matrix,
+    _validate_diffusion_inputs,
     extraction_to_infiltration,
     gamma_extraction_to_infiltration,
     infiltration_to_extraction,
@@ -267,62 +268,6 @@ class TestInfiltrationToExtractionDiffusion:
         # Both outputs should be bounded by the input range (convex combination).
         assert np.all(cout_hetero[valid] <= np.max(cin) + 1e-10)
         assert np.all(cout_single[valid] <= np.max(cin) + 1e-10)
-
-    def test_input_validation(self, simple_setup):
-        """Test that invalid inputs raise appropriate errors."""
-        # Negative molecular_diffusivity
-        with pytest.raises(ValueError, match="molecular_diffusivity must be non-negative"):
-            infiltration_to_extraction(
-                cin=simple_setup["cin"],
-                flow=simple_setup["flow"],
-                tedges=simple_setup["tedges"],
-                cout_tedges=simple_setup["cout_tedges"],
-                aquifer_pore_volumes=simple_setup["aquifer_pore_volumes"],
-                streamline_length=simple_setup["streamline_length"],
-                molecular_diffusivity=-1.0,
-                longitudinal_dispersivity=0.0,
-            )
-
-        # Negative longitudinal_dispersivity
-        with pytest.raises(ValueError, match="longitudinal_dispersivity must be non-negative"):
-            infiltration_to_extraction(
-                cin=simple_setup["cin"],
-                flow=simple_setup["flow"],
-                tedges=simple_setup["tedges"],
-                cout_tedges=simple_setup["cout_tedges"],
-                aquifer_pore_volumes=simple_setup["aquifer_pore_volumes"],
-                streamline_length=simple_setup["streamline_length"],
-                molecular_diffusivity=1.0,
-                longitudinal_dispersivity=-1.0,
-            )
-
-        # Mismatched pore volumes and travel distances
-        with pytest.raises(ValueError, match="same length"):
-            infiltration_to_extraction(
-                cin=simple_setup["cin"],
-                flow=simple_setup["flow"],
-                tedges=simple_setup["tedges"],
-                cout_tedges=simple_setup["cout_tedges"],
-                aquifer_pore_volumes=np.array([500.0, 600.0]),
-                streamline_length=np.array([100.0, 200.0, 300.0]),
-                molecular_diffusivity=1.0,
-                longitudinal_dispersivity=0.0,
-            )
-
-        # NaN in cin
-        cin_with_nan = simple_setup["cin"].copy()
-        cin_with_nan[2] = np.nan
-        with pytest.raises(ValueError, match="NaN"):
-            infiltration_to_extraction(
-                cin=cin_with_nan,
-                flow=simple_setup["flow"],
-                tedges=simple_setup["tedges"],
-                cout_tedges=simple_setup["cout_tedges"],
-                aquifer_pore_volumes=simple_setup["aquifer_pore_volumes"],
-                streamline_length=simple_setup["streamline_length"],
-                molecular_diffusivity=1.0,
-                longitudinal_dispersivity=0.0,
-            )
 
 
 class TestInfiltrationToExtractionDiffusionPhysics:
@@ -954,62 +899,6 @@ class TestExtractionToInfiltrationDiffusion:
         # significant oscillations beyond input range
         assert np.all(cin[valid] >= 0.0 - 3.0)
         assert np.all(cin[valid] <= 1.0 + 3.0)
-
-    def test_input_validation(self, simple_setup):
-        """Test that invalid inputs raise appropriate errors."""
-        # Negative molecular_diffusivity
-        with pytest.raises(ValueError, match="molecular_diffusivity must be non-negative"):
-            extraction_to_infiltration(
-                cout=simple_setup["cout"],
-                flow=simple_setup["flow_cin"],
-                tedges=simple_setup["cin_tedges"],
-                cout_tedges=simple_setup["cout_tedges"],
-                aquifer_pore_volumes=simple_setup["aquifer_pore_volumes"],
-                streamline_length=simple_setup["streamline_length"],
-                molecular_diffusivity=-1.0,
-                longitudinal_dispersivity=0.0,
-            )
-
-        # Negative longitudinal_dispersivity
-        with pytest.raises(ValueError, match="longitudinal_dispersivity must be non-negative"):
-            extraction_to_infiltration(
-                cout=simple_setup["cout"],
-                flow=simple_setup["flow_cin"],
-                tedges=simple_setup["cin_tedges"],
-                cout_tedges=simple_setup["cout_tedges"],
-                aquifer_pore_volumes=simple_setup["aquifer_pore_volumes"],
-                streamline_length=simple_setup["streamline_length"],
-                molecular_diffusivity=1.0,
-                longitudinal_dispersivity=-1.0,
-            )
-
-        # Mismatched pore volumes and travel distances
-        with pytest.raises(ValueError, match="same length"):
-            extraction_to_infiltration(
-                cout=simple_setup["cout"],
-                flow=simple_setup["flow_cin"],
-                tedges=simple_setup["cin_tedges"],
-                cout_tedges=simple_setup["cout_tedges"],
-                aquifer_pore_volumes=np.array([500.0, 600.0]),
-                streamline_length=np.array([100.0, 200.0, 300.0]),
-                molecular_diffusivity=1.0,
-                longitudinal_dispersivity=0.0,
-            )
-
-        # NaN in cout
-        cout_with_nan = simple_setup["cout"].copy()
-        cout_with_nan[2] = np.nan
-        with pytest.raises(ValueError, match="NaN"):
-            extraction_to_infiltration(
-                cout=cout_with_nan,
-                flow=simple_setup["flow_cin"],
-                tedges=simple_setup["cin_tedges"],
-                cout_tedges=simple_setup["cout_tedges"],
-                aquifer_pore_volumes=simple_setup["aquifer_pore_volumes"],
-                streamline_length=simple_setup["streamline_length"],
-                molecular_diffusivity=1.0,
-                longitudinal_dispersivity=0.0,
-            )
 
 
 class TestExtractionToInfiltrationDiffusionPhysics:
@@ -2018,7 +1907,10 @@ class TestGammaExtractionToInfiltrationDiffusion:
         n_cout = len(gamma_setup["cout_tedges"]) - 1
         cout = np.ones(n_cout) * 5.0
 
-        with pytest.warns(UserWarning, match="multiple.*pore.*volumes|velocity heterogeneity"):
+        with pytest.warns(
+            UserWarning,
+            match=r"Using multiple aquifer_pore_volumes with non-zero longitudinal_dispersivity",
+        ):
             gamma_extraction_to_infiltration(
                 cout=cout,
                 flow=gamma_setup["flow"],
@@ -2165,26 +2057,6 @@ class TestGammaExtractionToInfiltrationDiffusion:
 # =============================================================================
 
 
-def test_infiltration_to_extraction_rejects_negative_flow():
-    """Negative flow must raise ValueError with the standard message."""
-    tedges = pd.date_range(start="2020-01-01", periods=11, freq="D")
-    cin = np.ones(10)
-    flow = np.full(10, 100.0)
-    flow[5] = -1.0
-
-    with pytest.raises(ValueError, match="flow must be non-negative"):
-        infiltration_to_extraction(
-            cin=cin,
-            flow=flow,
-            tedges=tedges,
-            cout_tedges=tedges,
-            aquifer_pore_volumes=np.array([500.0]),
-            streamline_length=np.array([80.0]),
-            molecular_diffusivity=np.array([0.03]),
-            longitudinal_dispersivity=np.array([0.0]),
-        )
-
-
 def test_infiltration_to_extraction_accepts_zero_flow_without_warnings():
     """flow == 0 is accepted; no runtime warnings emitted."""
     tedges = pd.date_range(start="2020-01-01", periods=201, freq="D")
@@ -2265,3 +2137,212 @@ def test_diffusion_spinup_float_raises():
             longitudinal_dispersivity=np.array([0.0]),
             spinup=0.5,
         )
+
+
+# =============================================================================
+# Validator helper: parametrized snapshot pinning every ValueError branch of
+# _validate_diffusion_inputs. Verbatim messages from the prior duplicated
+# prologues; new branches (retardation_factor>=1 in fwd+rev, flow>=0 in rev)
+# are the issue #187 omission fixes.
+# =============================================================================
+
+
+def _good_diffusion_inputs():
+    """Baseline good-input dict that passes _validate_diffusion_inputs silently."""
+    n = 5
+    n_pv = 2
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    return {
+        "tedges": tedges,
+        "flow": np.full(n, 100.0),
+        "aquifer_pore_volumes": np.full(n_pv, 500.0),
+        "streamline_length": np.full(n_pv, 100.0),
+        "molecular_diffusivity": np.full(n_pv, 0.0),
+        "longitudinal_dispersivity": np.full(n_pv, 0.0),
+        "retardation_factor": 1.0,
+        "suppress_dispersion_warning": True,
+    }
+
+
+def test_validate_diffusion_inputs_silent_on_good_input_forward():
+    """No exception when the forward (cin) inputs are valid."""
+    kwargs = _good_diffusion_inputs()
+    n = len(kwargs["flow"])
+    _validate_diffusion_inputs(**kwargs, cin_values=np.ones(n))
+
+
+def test_validate_diffusion_inputs_silent_on_good_input_reverse():
+    """No exception when the reverse (cout + cout_tedges) inputs are valid."""
+    kwargs = _good_diffusion_inputs()
+    n = len(kwargs["flow"])
+    _validate_diffusion_inputs(**kwargs, cout_values=np.ones(n), cout_tedges=kwargs["tedges"])
+
+
+@pytest.mark.parametrize(
+    ("path", "mutate", "match_regex"),
+    [
+        # ---------------- forward path ----------------
+        (
+            "forward",
+            lambda k: {**k, "cin_values": np.ones(len(k["flow"]) + 1)},
+            r"tedges must have one more element than cin",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "cin_values": np.ones(len(k["flow"])),
+                "flow": np.full(len(k["flow"]) + 1, 100.0),
+            },
+            r"tedges must have one more element than flow",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "aquifer_pore_volumes": np.full(2, 500.0),
+                "streamline_length": np.full(3, 100.0),
+                "molecular_diffusivity": np.full(2, 0.0),
+                "longitudinal_dispersivity": np.full(2, 0.0),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"aquifer_pore_volumes and streamline_length must have the same length",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "molecular_diffusivity": np.full(3, 0.0),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"molecular_diffusivity must be a scalar or have same length as aquifer_pore_volumes",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "longitudinal_dispersivity": np.full(3, 0.0),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"longitudinal_dispersivity must be a scalar or have same length as aquifer_pore_volumes",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "molecular_diffusivity": np.array([-1.0, 0.0]),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"molecular_diffusivity must be non-negative",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "longitudinal_dispersivity": np.array([-1.0, 0.0]),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"longitudinal_dispersivity must be non-negative",
+        ),
+        (
+            "forward",
+            lambda k: {**k, "cin_values": np.array([1.0, np.nan, 1.0, 1.0, 1.0])},
+            r"cin contains NaN values, which are not allowed",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "flow": np.array([100.0, np.nan, 100.0, 100.0, 100.0]),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"flow contains NaN values, which are not allowed",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "flow": np.array([100.0, -50.0, 100.0, 100.0, 100.0]),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"flow must be non-negative \(negative flow not supported\)",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "aquifer_pore_volumes": np.array([500.0, 0.0]),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"aquifer_pore_volumes must be positive",
+        ),
+        (
+            "forward",
+            lambda k: {
+                **k,
+                "streamline_length": np.array([100.0, 0.0]),
+                "cin_values": np.ones(len(k["flow"])),
+            },
+            r"streamline_length must be positive",
+        ),
+        # NEW: retardation_factor < 1 (omission fix)
+        (
+            "forward",
+            lambda k: {**k, "retardation_factor": 0.5, "cin_values": np.ones(len(k["flow"]))},
+            r"retardation_factor must be >= 1\.0",
+        ),
+        # ---------------- reverse path ----------------
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "flow": np.full(len(k["flow"]) + 1, 100.0),
+                "cout_values": np.ones(len(k["flow"])),
+                "cout_tedges": k["tedges"],
+            },
+            r"tedges must have one more element than flow",
+        ),
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "cout_values": np.ones(len(k["flow"]) + 1),
+                "cout_tedges": k["tedges"],
+            },
+            r"cout_tedges must have one more element than cout",
+        ),
+        (
+            "reverse",
+            lambda k: {**k, "cout_values": np.array([1.0, np.nan, 1.0, 1.0, 1.0]), "cout_tedges": k["tedges"]},
+            r"cout contains NaN values, which are not allowed",
+        ),
+        # NEW: flow >= 0 in reverse (omission fix)
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "flow": np.array([100.0, -50.0, 100.0, 100.0, 100.0]),
+                "cout_values": np.ones(len(k["flow"])),
+                "cout_tedges": k["tedges"],
+            },
+            r"flow must be non-negative \(negative flow not supported\)",
+        ),
+        # NEW: retardation_factor < 1 in reverse (omission fix)
+        (
+            "reverse",
+            lambda k: {
+                **k,
+                "retardation_factor": 0.5,
+                "cout_values": np.ones(len(k["flow"])),
+                "cout_tedges": k["tedges"],
+            },
+            r"retardation_factor must be >= 1\.0",
+        ),
+    ],
+)
+def test_validate_diffusion_inputs_raises_on_bad_input(path, mutate, match_regex):
+    """Each ValueError branch raises with the exact historical message string."""
+    del path  # parametrize id only
+    bad = mutate(_good_diffusion_inputs())
+    with pytest.raises(ValueError, match=match_regex):
+        _validate_diffusion_inputs(**bad)

--- a/tests/src/test_validation.py
+++ b/tests/src/test_validation.py
@@ -1,0 +1,155 @@
+"""Tests for the input-validation atoms in :mod:`gwtransport._validation`.
+
+One pair (silent-on-good + parametrized-bad) per atom; the ``message=`` override
+path is covered for each atom that exposes it so that a future refactor cannot
+drop the override without the test catching it.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gwtransport._validation import (
+    _validate_no_nan,
+    _validate_non_negative_array,
+    _validate_positive_array,
+    _validate_positive_scalar,
+    _validate_scalar_or_matching_length,
+    _validate_tedges_parity,
+)
+
+# ---------------------------------------------------------------------------
+# _validate_tedges_parity
+# ---------------------------------------------------------------------------
+
+
+def test_tedges_parity_silent_on_good_input():
+    tedges = pd.date_range("2020-01-01", periods=6, freq="D")
+    values = np.zeros(5)
+    _validate_tedges_parity(tedges, values, tedges_name="tedges", values_name="cin")
+
+
+@pytest.mark.parametrize(
+    ("n_tedges", "n_values", "tedges_name", "values_name"),
+    [
+        (6, 4, "tedges", "cin"),  # tedges too long
+        (5, 5, "tedges", "flow"),  # tedges off-by-one
+        (4, 5, "cout_tedges", "cout"),  # tedges too short
+    ],
+)
+def test_tedges_parity_rejects_mismatch(n_tedges, n_values, tedges_name, values_name):
+    tedges = pd.date_range("2020-01-01", periods=n_tedges, freq="D")
+    values = np.zeros(n_values)
+    msg = f"{tedges_name} must have one more element than {values_name}"
+    with pytest.raises(ValueError, match=msg):
+        _validate_tedges_parity(tedges, values, tedges_name=tedges_name, values_name=values_name)
+
+
+# ---------------------------------------------------------------------------
+# _validate_no_nan
+# ---------------------------------------------------------------------------
+
+
+def test_no_nan_silent_on_good_input():
+    _validate_no_nan(np.array([0.0, 1.0, 2.0]), name="cin")
+
+
+def test_no_nan_rejects_default_message():
+    with pytest.raises(ValueError, match="cin contains NaN values, which are not allowed"):
+        _validate_no_nan(np.array([0.0, np.nan, 2.0]), name="cin")
+
+
+def test_no_nan_rejects_override_message():
+    with pytest.raises(ValueError, match="flow array cannot contain NaN values"):
+        _validate_no_nan(np.array([0.0, np.nan, 2.0]), name="flow", message="flow array cannot contain NaN values")
+
+
+# ---------------------------------------------------------------------------
+# _validate_non_negative_array
+# ---------------------------------------------------------------------------
+
+
+def test_non_negative_array_silent_on_good_input():
+    _validate_non_negative_array(np.array([0.0, 1.0, 2.0]), name="flow")
+
+
+def test_non_negative_array_silent_on_all_zeros():
+    """Zero is non-negative; the atom must NOT reject it."""
+    _validate_non_negative_array(np.zeros(5), name="flow")
+
+
+def test_non_negative_array_rejects_default_message():
+    with pytest.raises(ValueError, match="flow must be non-negative"):
+        _validate_non_negative_array(np.array([1.0, -0.5, 2.0]), name="flow")
+
+
+def test_non_negative_array_rejects_override_message():
+    with pytest.raises(ValueError, match=r"flow must be non-negative \(negative flow not supported\)"):
+        _validate_non_negative_array(
+            np.array([-1.0]),
+            name="flow",
+            message="flow must be non-negative (negative flow not supported)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# _validate_positive_array
+# ---------------------------------------------------------------------------
+
+
+def test_positive_array_silent_on_good_input():
+    _validate_positive_array(np.array([1.0, 2.0]), name="aquifer_pore_volumes")
+
+
+def test_positive_array_rejects_zero():
+    """Zero is NOT positive; ``_validate_positive_array`` must reject it."""
+    with pytest.raises(ValueError, match="aquifer_pore_volumes must be positive"):
+        _validate_positive_array(np.array([1.0, 0.0]), name="aquifer_pore_volumes")
+
+
+def test_positive_array_rejects_negative():
+    with pytest.raises(ValueError, match="streamline_length must be positive"):
+        _validate_positive_array(np.array([1.0, -0.5]), name="streamline_length")
+
+
+# ---------------------------------------------------------------------------
+# _validate_positive_scalar
+# ---------------------------------------------------------------------------
+
+
+def test_positive_scalar_silent_on_good_input():
+    _validate_positive_scalar(5.0, name="thickness")
+
+
+def test_positive_scalar_rejects_default_message():
+    with pytest.raises(ValueError, match=r"thickness must be positive, got 0\.0"):
+        _validate_positive_scalar(0.0, name="thickness")
+
+
+def test_positive_scalar_rejects_override_message():
+    """Module wrappers preserve historical capitalized phrasings via ``message=``."""
+    with pytest.raises(ValueError, match=r"Thickness must be positive, got -1\.0"):
+        _validate_positive_scalar(-1.0, name="thickness", message="Thickness must be positive, got -1.0")
+
+
+# ---------------------------------------------------------------------------
+# _validate_scalar_or_matching_length
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_or_matching_length_silent_when_matching():
+    arr = np.array([1.0, 2.0, 3.0])
+    _validate_scalar_or_matching_length(
+        arr, name="molecular_diffusivity", expected_len=3, ref_name="aquifer_pore_volumes"
+    )
+
+
+def test_scalar_or_matching_length_rejects_wrong_length():
+    arr = np.array([1.0, 2.0])
+    with pytest.raises(
+        ValueError,
+        match="molecular_diffusivity must be a scalar or have same length as aquifer_pore_volumes",
+    ):
+        _validate_scalar_or_matching_length(
+            arr, name="molecular_diffusivity", expected_len=3, ref_name="aquifer_pore_volumes"
+        )


### PR DESCRIPTION
## Summary

Closes #187. Lifts the duplicated input-validation prologues in `advection`, `diffusion`, and `deposition` into a new private module `src/gwtransport/_validation.py` containing 6 composable atoms. Each transport module exposes a single `_validate_<module>_inputs` wrapper composing the atoms; the 35-line forward / reverse prologues in diffusion and advection collapse to a single call. All historical error-message strings preserved verbatim via an optional `message=` override on each atom.

While consolidating, four pre-existing silent omissions in the validation surface became obvious and are fixed in this PR:

| # | Omission | Fix |
|---|---|---|
| a | diffusion fwd + rev missing `retardation_factor >= 1.0` | added in both wrappers |
| b | deposition missing `retardation_factor >= 1.0` (all 3 entry points) | added in `_validate_deposition_inputs` |
| c | diffusion reverse missing `flow >= 0` (forward already validated) | added |
| d | advection reverse missing `flow >= 0` (forward already validated) | added — discovered while consolidating; identical physics to (c) |

Each omission was previously silent-accept and would produce physically invalid results (`R<1` is anti-retardation, `flow<0` breaks the bin-edge bookkeeping). Now `ValueError`.

Asymmetries documented but **not** changed: NaN in `cout` is rejected by `diffusion.extraction_to_infiltration` and `advection.extraction_to_infiltration` (coefficient-matrix multiply poisons) but allowed by `deposition.extraction_to_deposition` (regularized solver excludes NaN rows via `solve_tikhonov`). Notes section added to both reverse functions explaining the asymmetry.

## Test plan

- [x] `pytest tests/src` — 1213 passed, 8 skipped
- [x] `pytest tests/src/test_validation.py` — 19 new per-atom tests pass
- [x] Snapshot test added to `test_diffusion.py` and `test_advection.py` parametrizing every `ValueError` branch with verbatim `match_regex`; deposition snapshot extended with `retardation_factor` branches
- [x] Dispersion-warning regex at `test_diffusion.py:1907` tightened from a disjunction to the exact emitted prefix
- [x] `ruff format` + `ruff check` clean (added `DOC502` per-file-ignore for `diffusion.py` / `advection.py` mirroring the existing `deposition.py` entry)
- [x] `ty check src/gwtransport` clean
- [x] Reviewed by `bas-physics-math-reviewer`, `bas-test-reviewer`, and `bas-code-optimizer` reviewer agents (plan + Phase 1, Phase 2, Phase 3 gate sign-offs)

## Out of scope (per plan)

- `tedges` monotonicity validation — new physical invariant, separate concern
- `aquifer_pore_volumes` monotonicity / non-NaN — same
- The trilogy siblings #185 (`tedges → days` consolidation) and #186 (`cumulative_flow_volume` consolidation) — separate PRs; their proposed sequencing still applies

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.