### PR TITLE
examples: tests + vectorize event-decay loop + input validation (#200)

### DIFF
--- a/src/gwtransport/examples.py
+++ b/src/gwtransport/examples.py
@@ -532,7 +532,20 @@ def generate_example_deposition_timeseries(
     -------
     pandas.Series
         Time series of deposition values indexed by daily timestamps.
+
+    Raises
+    ------
+    ValueError
+        If ``event_decay_scale`` or ``event_duration`` is not positive, or if any
+        ``event_dates`` entry falls outside the generated ``dates`` range.
     """
+    if event_decay_scale <= 0:
+        msg = f"event_decay_scale must be positive, got {event_decay_scale}"
+        raise ValueError(msg)
+    if event_duration <= 0:
+        msg = f"event_duration must be positive, got {event_duration}"
+        raise ValueError(msg)
+
     rng = np.random.default_rng(rng)
 
     # Create synthetic deposition time series - needs to match flow period
@@ -561,12 +574,25 @@ def generate_example_deposition_timeseries(
     else:
         event_dates_index = event_dates_index.tz_convert(dates.tz)
 
+    out_of_range = (event_dates_index < dates[0]) | (event_dates_index > dates[-1])
+    if out_of_range.any():
+        msg = (
+            f"event_dates contains {out_of_range.sum()} date(s) outside the dates range "
+            f"[{dates[0]}, {dates[-1]}]: {event_dates_index[out_of_range].tolist()}"
+        )
+        raise ValueError(msg)
+
+    # Vectorized event accumulation. For each event start, scatter a ``(n_events, event_duration)``
+    # decay block into ``event`` via ``np.add.at`` so overlapping events sum correctly. The
+    # boundary mask drops indices that fall past the end of the series (preserves the loop's
+    # ``min(event_idx + event_duration, n_dates)`` clipping).
+    starts = dates.get_indexer(event_dates_index, method="nearest")
+    cols = np.arange(event_duration)
+    flat_indices = starts[:, None] + cols[None, :]
+    valid = flat_indices < n_dates
+    decay_block = np.broadcast_to(event_magnitude * np.exp(-cols / event_decay_scale), flat_indices.shape)
     event = np.zeros(n_dates)
-    for event_date in event_dates_index:
-        event_idx = dates.get_indexer([event_date], method="nearest")[0]
-        event_indices = np.arange(event_idx, min(event_idx + event_duration, n_dates))
-        decay_pattern = event_magnitude * np.exp(-np.arange(len(event_indices)) / event_decay_scale)
-        event[event_indices] += decay_pattern
+    np.add.at(event, flat_indices[valid], decay_block[valid])
 
     # Combine all components
     total = base + seasonal_pattern + noise + event

--- a/tests/src/test_examples.py
+++ b/tests/src/test_examples.py
@@ -1,0 +1,116 @@
+"""Tests for `gwtransport.examples` synthetic data generators."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gwtransport.examples import (
+    generate_ec_example_data,
+    generate_example_data,
+    generate_example_deposition_timeseries,
+    generate_temperature_example_data,
+)
+
+GENERATORS = [
+    generate_example_data,
+    generate_temperature_example_data,
+    generate_ec_example_data,
+    generate_example_deposition_timeseries,
+]
+
+
+@pytest.mark.parametrize("generator", GENERATORS, ids=lambda g: g.__name__)
+def test_each_public_generator_runs_with_defaults(generator):
+    """Smoke test: every public generator must run with default kwargs."""
+    df, tedges = generator()
+    assert df is not None
+    assert tedges is not None
+
+
+@pytest.mark.parametrize("generator", GENERATORS, ids=lambda g: g.__name__)
+def test_generated_arrays_match_bin_edge_convention(generator):
+    """tedges has one more element than the data series and is a DatetimeIndex."""
+    df, tedges = generator()
+    assert isinstance(tedges, pd.DatetimeIndex)
+    assert len(tedges) == len(df) + 1
+
+
+def test_event_dates_outside_range_raises():
+    """Out-of-range event_dates must raise ValueError rather than silently mapping to the nearest edge."""
+    with pytest.raises(ValueError, match="outside the dates range"):
+        generate_example_deposition_timeseries(event_dates=["2099-01-01"])
+
+
+def test_aquifer_pore_volumes_and_gamma_mutually_exclusive():
+    """Passing both discrete pore volumes and gamma parameters must raise ValueError."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        generate_example_data(
+            aquifer_pore_volumes=np.array([100.0, 200.0]),
+            aquifer_pore_volume_gamma_mean=500.0,
+        )
+
+
+def test_event_decay_scale_zero_raises():
+    """event_decay_scale=0 produced silent NaN before; pin the new explicit ValueError."""
+    with pytest.raises(ValueError, match="event_decay_scale must be positive"):
+        generate_example_deposition_timeseries(event_decay_scale=0.0)
+
+
+def test_event_duration_zero_raises():
+    """event_duration=0 has no meaningful behaviour; pin the explicit ValueError."""
+    with pytest.raises(ValueError, match="event_duration must be positive"):
+        generate_example_deposition_timeseries(event_duration=0)
+
+
+def _event_loop_reference(*, dates, event_dates_index, event_magnitude, event_duration, event_decay_scale):
+    """Reference implementation: the per-event Python loop the vectorization replaced."""
+    n_dates = len(dates)
+    event = np.zeros(n_dates)
+    for event_date in event_dates_index:
+        event_idx = dates.get_indexer([event_date], method="nearest")[0]
+        event_indices = np.arange(event_idx, min(event_idx + event_duration, n_dates))
+        decay_pattern = event_magnitude * np.exp(-np.arange(len(event_indices)) / event_decay_scale)
+        event[event_indices] += decay_pattern
+    return event
+
+
+@pytest.mark.parametrize("event_duration", [5, 30, 90])
+@pytest.mark.parametrize("seed", [0, 7, 42])
+def test_vectorized_event_accumulation_matches_loop(seed, event_duration):
+    """Byte-for-byte equality of the vectorised event-decay block versus the original loop.
+
+    Isolates the event component by zeroing base / seasonal / noise / non-negative clipping.
+    Includes events near the end of the series (to exercise the boundary clip) and overlapping
+    events (to exercise ``np.add.at``'s repeat-index accumulation).
+    """
+    date_start = "2018-01-01"
+    date_end = "2018-06-30"
+
+    # Mix of in-range, near-end, and overlapping event dates.
+    event_dates = ["2018-01-05", "2018-03-15", "2018-03-16", "2018-06-25"]
+
+    actual_series, _ = generate_example_deposition_timeseries(
+        date_start=date_start,
+        date_end=date_end,
+        base=0.0,
+        seasonal_amplitude=0.0,
+        noise_scale=0.0,
+        event_dates=event_dates,
+        event_duration=event_duration,
+        event_decay_scale=10.0,
+        event_magnitude=3.0,
+        ensure_non_negative=False,
+        rng=seed,
+    )
+
+    dates = pd.date_range(date_start, date_end, freq="D").tz_localize("UTC")
+    event_dates_index = pd.DatetimeIndex(pd.to_datetime(event_dates)).tz_localize(dates.tz)
+    expected = _event_loop_reference(
+        dates=dates,
+        event_dates_index=event_dates_index,
+        event_magnitude=3.0,
+        event_duration=event_duration,
+        event_decay_scale=10.0,
+    )
+
+    np.testing.assert_array_equal(actual_series.to_numpy(), expected)


### PR DESCRIPTION
## Summary

Closes #200. Test-reviewer and code-optimizer both mutation-verified and approved before push.

**Phase 2 — tests (`tests/src/test_examples.py`, new file, 7 tests):**
- `test_each_public_generator_runs_with_defaults` — parametrize over the 4 public generators.
- `test_generated_arrays_match_bin_edge_convention` — `len(tedges) == len(df) + 1` and `DatetimeIndex`.
- `test_event_dates_outside_range_raises` — pins new `ValueError` (was silently mapped to nearest via `get_indexer(method=\"nearest\")`).
- `test_aquifer_pore_volumes_and_gamma_mutually_exclusive` — pins existing `ValueError`.
- `test_event_decay_scale_zero_raises` — pins new `ValueError` (was silent NaN via `exp(-0/0)`).
- `test_event_duration_zero_raises` — pins new `ValueError`.
- `test_vectorized_event_accumulation_matches_loop` — 3 seeds × 3 durations parametrize; `assert_array_equal` byte-for-byte vs an inlined pre-vectorization loop reference. Includes near-end events (boundary clip) and overlapping events (`np.add.at` accumulation).

**Phase 2/3 — source (`src/gwtransport/examples.py`, `generate_example_deposition_timeseries`):**
- Raise `ValueError` on `event_decay_scale <= 0`, `event_duration <= 0`, and any `event_dates` entry outside `[dates[0], dates[-1]]`. Replaces three silent failure modes.
- **Vectorise** the per-event Python loop:
  ```python
  starts = dates.get_indexer(event_dates_index, method=\"nearest\")
  cols = np.arange(event_duration)
  flat_indices = starts[:, None] + cols[None, :]
  valid = flat_indices < n_dates
  decay_block = np.broadcast_to(event_magnitude * np.exp(-cols / event_decay_scale), flat_indices.shape)
  event = np.zeros(n_dates)
  np.add.at(event, flat_indices[valid], decay_block[valid])
  ```
  Preserves the loop's per-event boundary clipping (via `valid` mask) and overlap accumulation (via `np.add.at`).

## Test plan

- `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src -n auto` → 1204 passed, 8 skipped, 1 xfailed (unrelated P1.8 fronttracking), 20 warnings.
- `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/examples -k \"deposition or example\" -n auto` → 15 passed, 1 skipped, 1 xfailed.
- `ruff format . && ruff check --fix .` → clean.
- Test-reviewer mutation-verified boundary-clip-strip and accumulation-replacement both fail the vectorisation pinning test. Code-optimizer verified equivalence over 4 date-sets × 4 durations × 2 decay scales.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.