### PR TITLE
diffusion+diffusion_fast: streamtube docs + sigma_v lift + R<1 contract + tighter tests (#196, #197)

### DIFF
--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -67,6 +67,17 @@ heterogeneity at different scales. Microdispersion is an aquifer property; macro
 depends additionally on hydrological boundary conditions. See :ref:`concept-dispersion-scales`
 for guidance on when to use each approach and how to avoid double-counting spreading effects.
 
+Streamtube assumption (no cross-sectional area parameter)
+---------------------------------------------------------
+
+Each entry in ``aquifer_pore_volumes`` is treated as an independent 1D streamtube. There is
+no cross-sectional area parameter: the variance budget uses ``2 D_m tau`` (molecular
+diffusion in time) and ``2 alpha_L xi`` (mechanical dispersion in travelled distance), with
+the streamline length ``L`` and the pore volume ``V_pore`` together fixing the implicit
+streamtube cross-section ``A = V_pore / L``. Callers who need distributed-area effects must
+provide multiple streamtubes (via ``aquifer_pore_volumes`` or the gamma-parameterised
+wrappers).
+
 References
 ----------
 Bear, J. (1972). Dynamics of Fluids in Porous Media. American Elsevier

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -44,6 +44,18 @@ and molecular diffusion on top of macrodispersion captured by the aquifer
 pore-volume distribution (APVD). See :ref:`concept-dispersion` for
 background.
 
+Streamtube assumption (no cross-sectional area parameter)
+---------------------------------------------------------
+
+Each entry in ``aquifer_pore_volumes`` is treated as an independent 1D
+streamtube. There is no cross-sectional area parameter: molecular diffusion
+enters the V-space variance budget through ``2 D_m tau`` and mechanical
+dispersion through ``2 alpha_L L``, with the mean streamline length ``L``
+and the pore volume ``V_pore`` together fixing the implicit streamtube
+cross-section ``A = V_pore / L``. Callers who need distributed-area effects
+must provide multiple streamtubes (via ``aquifer_pore_volumes`` or the
+gamma-parameterised wrappers).
+
 Available functions:
 
 - :func:`infiltration_to_extraction` — forward transport.
@@ -75,6 +87,40 @@ from gwtransport.utils import solve_inverse_transport
 
 # Minimum coefficient sum to consider a row valid
 _EPSILON_COEFF_SUM = 1e-10
+
+# Default Gaussian-cutoff sigma for the uniform-V smoother. Wider than the legacy
+# ``convolve_diffusion`` 3.0 default; tighter values lose the asymptotic tail mass
+# that the V-mass-preserving rebinning depends on.
+_DEFAULT_CUTOFF_SIGMA_V = 4.0
+
+
+def _prepare_v_grid(
+    *,
+    weight_tedges: pd.DatetimeIndex,
+    tedges: pd.DatetimeIndex,
+    flow: npt.NDArray[np.floating],
+) -> tuple[
+    npt.NDArray[np.floating],
+    npt.NDArray[np.floating],
+    npt.NDArray[np.floating],
+]:
+    """Build the unconditional V-grid arrays needed by both transport branches.
+
+    The output-side bookkeeping (``cout_dt_days``, ``cout_tedges_days``,
+    ``v_out_edges``, ``flow_out_arr``, ``sigma_v_out``) is *not* computed
+    here: it is dead work on the smooth-then-advect (``flow_out is None``) path.
+
+    Returns
+    -------
+    tuple of ndarray
+        ``(tedges_days, v_in_widedge_edges, v_in_natural_edges)``.
+    """
+    weight_dt_days = (np.diff(weight_tedges) / pd.Timedelta("1D")).astype(float)
+    natural_dt_days = (np.diff(tedges) / pd.Timedelta("1D")).astype(float)
+    tedges_days = ((weight_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
+    v_in_widedge_edges = np.concatenate(([0.0], np.cumsum(flow * weight_dt_days)))
+    v_in_natural_edges = np.concatenate(([0.0], np.cumsum(flow * natural_dt_days)))
+    return tedges_days, v_in_widedge_edges, v_in_natural_edges
 
 
 def infiltration_to_extraction(
@@ -197,6 +243,7 @@ def infiltration_to_extraction(
         mean_streamline_length=mean_streamline_length,
         mean_molecular_diffusivity=mean_molecular_diffusivity,
         mean_longitudinal_dispersivity=mean_longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
         is_forward=True,
         flow_out=flow_out,
     )
@@ -230,39 +277,10 @@ def infiltration_to_extraction(
     # Cumulative-volume edges on the user's natural ``tedges`` (no wide
     # spin-up). The smoothing operator runs on this grid so the uniform-V
     # resampling does not have to span a 100-year warm-start interval.
-    weight_dt_days = (np.diff(weight_tedges) / pd.Timedelta("1D")).astype(float)
-    v_in_widedge_edges = np.concatenate(([0.0], np.cumsum(flow * weight_dt_days)))
-    natural_dt_days = (np.diff(tedges) / pd.Timedelta("1D")).astype(float)
-    v_in_natural_edges = np.concatenate(([0.0], np.cumsum(flow * natural_dt_days)))
-
-    # Output-side V-edges expressed in the SAME cumulative-volume reference
-    # frame as ``v_in_widedge_edges`` (anchored at ``weight_tedges[0]``).
-    # ``flow_out`` is used only for sigma_V; the V-grid is set by the
-    # underlying flow so it is consistent with ``w_adv``.
-    cout_dt_days = (np.diff(cout_tedges) / pd.Timedelta("1D")).astype(float)
-    tedges_days = ((weight_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
-    cout_tedges_days = ((cout_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
-    v_out_edges = np.interp(cout_tedges_days, tedges_days, v_in_widedge_edges)
-    if flow_out is None:
-        # Per-cout-bin flux inferred from the V-edge increments. Matches
-        # the slow ``diffusion`` module's ``flow_during_cout``.
-        flow_out_arr = np.where(cout_dt_days > 0.0, np.diff(v_out_edges) / cout_dt_days, 0.0)
-    else:
-        flow_out_arr = np.asarray(flow_out, dtype=float)
-
-    # Moment-averaged sigma_V in V-coordinate units [m^3] on the output
-    # grid: used by both the K-Z correction and (when applicable) the
-    # output-side smoothing matrix.
-    sigma_v_out = _compute_sigma_v(
-        flow=flow_out_arr,
-        tedges=cout_tedges,
-        aquifer_pore_volumes=aquifer_pore_volumes,
-        streamline_length=mean_streamline_length,
-        molecular_diffusivity=mean_molecular_diffusivity,
-        longitudinal_dispersivity=mean_longitudinal_dispersivity,
-        retardation_factor=retardation_factor,
-        direction="extraction_to_infiltration",
+    tedges_days, v_in_widedge_edges, v_in_natural_edges = _prepare_v_grid(
+        weight_tedges=weight_tedges, tedges=tedges, flow=flow
     )
+    cutoff_sigma = asymptotic_cutoff_sigma if asymptotic_cutoff_sigma is not None else _DEFAULT_CUTOFF_SIGMA_V
 
     if flow_out is None:
         # Smooth-then-advect: V-coord smoothing on the natural input grid,
@@ -280,15 +298,29 @@ def infiltration_to_extraction(
         m_v_in = _build_v_smooth_matrix(
             v_edges=v_in_natural_edges,
             sigma_v_per_bin=sigma_v_in,
-            asymptotic_cutoff_sigma=asymptotic_cutoff_sigma if asymptotic_cutoff_sigma is not None else 4.0,
+            asymptotic_cutoff_sigma=cutoff_sigma,
         )
         cin_diffused = m_v_in @ np.asarray(cin, dtype=float)
         cout = w_adv @ cin_diffused
     else:
         # Advect-then-smooth: pure advection produces ``cout_unsmoothed`` on
         # the output grid, then V-coord smoothing applies the dispersive
-        # spread. Validity normalisation handles cout bins that pre-date
-        # streamtube breakthrough or fall in zero-flow windows.
+        # spread. The output-side V-grid and sigma_V are only needed here.
+        cout_tedges_days = ((cout_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
+        v_out_edges = np.interp(cout_tedges_days, tedges_days, v_in_widedge_edges)
+        sigma_v_out = _compute_sigma_v(
+            flow=np.asarray(flow_out, dtype=float),
+            tedges=cout_tedges,
+            aquifer_pore_volumes=aquifer_pore_volumes,
+            streamline_length=mean_streamline_length,
+            molecular_diffusivity=mean_molecular_diffusivity,
+            longitudinal_dispersivity=mean_longitudinal_dispersivity,
+            retardation_factor=retardation_factor,
+            direction="extraction_to_infiltration",
+        )
+
+        # Validity normalisation handles cout bins that pre-date streamtube
+        # breakthrough or fall in zero-flow windows.
         cout_unsmoothed = w_adv @ np.asarray(cin, dtype=float)
         total_coeff = np.sum(w_adv, axis=1)
         zero_row_mask = total_coeff < _EPSILON_COEFF_SUM
@@ -298,7 +330,7 @@ def infiltration_to_extraction(
         m_v_out = _build_v_smooth_matrix(
             v_edges=v_out_edges,
             sigma_v_per_bin=sigma_v_out,
-            asymptotic_cutoff_sigma=asymptotic_cutoff_sigma if asymptotic_cutoff_sigma is not None else 4.0,
+            asymptotic_cutoff_sigma=cutoff_sigma,
         )
         smoothed = m_v_out @ cout_unsmoothed
         smoothed_validity = m_v_out @ validity
@@ -452,6 +484,7 @@ def extraction_to_infiltration(
         mean_streamline_length=mean_streamline_length,
         mean_molecular_diffusivity=mean_molecular_diffusivity,
         mean_longitudinal_dispersivity=mean_longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
         is_forward=False,
         flow_out=flow_out,
     )
@@ -485,30 +518,10 @@ def extraction_to_infiltration(
     # Cumulative-volume edges shared between the smoothing matrices on the
     # input and output sides; see the comment block in
     # ``infiltration_to_extraction`` for the reference-frame rationale.
-    weight_dt_days = (np.diff(weight_tedges) / pd.Timedelta("1D")).astype(float)
-    v_in_widedge_edges = np.concatenate(([0.0], np.cumsum(flow * weight_dt_days)))
-    natural_dt_days = (np.diff(tedges) / pd.Timedelta("1D")).astype(float)
-    v_in_natural_edges = np.concatenate(([0.0], np.cumsum(flow * natural_dt_days)))
-
-    cout_dt_days = (np.diff(cout_tedges) / pd.Timedelta("1D")).astype(float)
-    tedges_days = ((weight_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
-    cout_tedges_days = ((cout_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
-    v_out_edges = np.interp(cout_tedges_days, tedges_days, v_in_widedge_edges)
-    if flow_out is None:
-        flow_out_arr = np.where(cout_dt_days > 0.0, np.diff(v_out_edges) / cout_dt_days, 0.0)
-    else:
-        flow_out_arr = np.asarray(flow_out, dtype=float)
-
-    sigma_v_out = _compute_sigma_v(
-        flow=flow_out_arr,
-        tedges=cout_tedges,
-        aquifer_pore_volumes=aquifer_pore_volumes,
-        streamline_length=mean_streamline_length,
-        molecular_diffusivity=mean_molecular_diffusivity,
-        longitudinal_dispersivity=mean_longitudinal_dispersivity,
-        retardation_factor=retardation_factor,
-        direction="extraction_to_infiltration",
+    tedges_days, v_in_widedge_edges, v_in_natural_edges = _prepare_v_grid(
+        weight_tedges=weight_tedges, tedges=tedges, flow=flow
     )
+    cutoff_sigma = asymptotic_cutoff_sigma if asymptotic_cutoff_sigma is not None else _DEFAULT_CUTOFF_SIGMA_V
 
     if flow_out is None:
         # Smooth-then-advect: W_forward = w_adv @ M_v_in
@@ -525,16 +538,28 @@ def extraction_to_infiltration(
         m_v_in = _build_v_smooth_matrix(
             v_edges=v_in_natural_edges,
             sigma_v_per_bin=sigma_v_in,
-            asymptotic_cutoff_sigma=asymptotic_cutoff_sigma if asymptotic_cutoff_sigma is not None else 4.0,
+            asymptotic_cutoff_sigma=cutoff_sigma,
         )
         # Force dense ndarray (avoid scipy's np.matrix from sparse @ dense).
         w_forward = np.asarray(w_adv @ m_v_in)
     else:
         # Advect-then-smooth: W_forward = M_v_out @ w_adv
+        cout_tedges_days = ((cout_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
+        v_out_edges = np.interp(cout_tedges_days, tedges_days, v_in_widedge_edges)
+        sigma_v_out = _compute_sigma_v(
+            flow=np.asarray(flow_out, dtype=float),
+            tedges=cout_tedges,
+            aquifer_pore_volumes=aquifer_pore_volumes,
+            streamline_length=mean_streamline_length,
+            molecular_diffusivity=mean_molecular_diffusivity,
+            longitudinal_dispersivity=mean_longitudinal_dispersivity,
+            retardation_factor=retardation_factor,
+            direction="extraction_to_infiltration",
+        )
         m_v_out = _build_v_smooth_matrix(
             v_edges=v_out_edges,
             sigma_v_per_bin=sigma_v_out,
-            asymptotic_cutoff_sigma=asymptotic_cutoff_sigma if asymptotic_cutoff_sigma is not None else 4.0,
+            asymptotic_cutoff_sigma=cutoff_sigma,
         )
         w_forward = np.asarray(m_v_out @ w_adv)
 
@@ -953,12 +978,11 @@ def _compute_sigma_v(
     if np.any(valid_mask):
         rt_array = np.interp(np.arange(len(rt_array)), np.where(valid_mask)[0], rt_array[valid_mask])
 
-    mol_var_x = 2.0 * molecular_diffusivity * rt_array
-    disp_var_x = 2.0 * longitudinal_dispersivity * streamline_length
-
-    var_numerator = mol_var_x / mean_pv * ev3 + disp_var_x * ev2
-
-    sigma_v_sq = (retardation_factor / streamline_length) ** 2 * var_numerator
+    # E[sigma_V^2] = (R/L)^2 * (2 D_m tau_bar / V_bar * E[V^3] + 2 alpha_L L * E[V^2])
+    sigma_v_sq = (retardation_factor / streamline_length) ** 2 * (
+        2.0 * molecular_diffusivity * rt_array / mean_pv * ev3
+        + 2.0 * longitudinal_dispersivity * streamline_length * ev2
+    )
     return np.sqrt(np.maximum(sigma_v_sq, 0.0))
 
 
@@ -1041,7 +1065,7 @@ def _build_v_smooth_matrix(
     v_edges: npt.NDArray[np.floating],
     sigma_v_per_bin: npt.NDArray[np.floating],
     refinement: int = 4,
-    asymptotic_cutoff_sigma: float | None = 4.0,
+    asymptotic_cutoff_sigma: float | None = _DEFAULT_CUTOFF_SIGMA_V,
 ) -> sparse.csr_matrix:
     """Build the V-coordinate Gaussian smoothing matrix via uniform-V resampling.
 
@@ -1235,6 +1259,7 @@ def _validate_inputs(
     mean_streamline_length: float,
     mean_molecular_diffusivity: float,
     mean_longitudinal_dispersivity: float,
+    retardation_factor: float,
     is_forward: bool,
     flow_out: np.ndarray | None = None,
 ) -> None:
@@ -1246,7 +1271,9 @@ def _validate_inputs(
         If array lengths are inconsistent, mean_molecular_diffusivity or
         mean_longitudinal_dispersivity are negative, cin or cout or flow
         contain NaN values, aquifer_pore_volumes contains non-positive
-        values, or mean_streamline_length is non-positive.
+        values, mean_streamline_length is non-positive, or retardation_factor
+        is below 1 (anti-retardation is not physical for the supported
+        sorption isotherms).
     """
     if is_forward:
         if len(tedges) != len(cin_or_cout) + 1:
@@ -1278,6 +1305,9 @@ def _validate_inputs(
         raise ValueError(msg)
     if mean_streamline_length <= 0:
         msg = "mean_streamline_length must be positive"
+        raise ValueError(msg)
+    if retardation_factor < 1.0:
+        msg = "retardation_factor must be >= 1.0 (anti-retardation is not physical)"
         raise ValueError(msg)
     if flow_out is not None:
         n_cout = len(cout_tedges) - 1

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -147,7 +147,16 @@ class TestInfiltrationToExtractionDiffusion:
         assert var_large > var_small  # More spreading = larger variance
 
     def test_output_bounded_by_input(self, simple_setup):
-        """Test that output concentrations are bounded by input range."""
+        """Output concentrations lie in the convex hull of the input to machine ULP precision.
+
+        Linear-superposition smoothing of a non-negative signal cannot create excursions
+        outside ``[min(cin), max(cin)]``. Implementation-level floating-point composition
+        (K-Z flux quadrature + V-coordinate weighting) introduces ULP-scale rounding noise;
+        the previous +/- 1e-10 slack was 6 orders of magnitude looser than needed. A
+        return value that returned the mean of cin would still satisfy these bounds; the
+        next test (constant-input -> constant-output) and the mass-conservation tests
+        guard against that mode separately.
+        """
         cout = infiltration_to_extraction(
             cin=simple_setup["cin"],
             flow=simple_setup["flow"],
@@ -159,9 +168,12 @@ class TestInfiltrationToExtractionDiffusion:
             longitudinal_dispersivity=0.0,
         )
         valid = ~np.isnan(cout)
-        # Output should be between min and max of input (plus small tolerance for numerics)
-        assert np.all(cout[valid] >= np.min(simple_setup["cin"]) - 1e-10)
-        assert np.all(cout[valid] <= np.max(simple_setup["cin"]) + 1e-10)
+        assert np.sum(valid) > 0, "expected at least one valid cout bin under simple setup"
+        cin_min = float(np.min(simple_setup["cin"]))
+        cin_max = float(np.max(simple_setup["cin"]))
+        ulp_tol = 16.0 * np.finfo(cout.dtype).eps * max(abs(cin_min), abs(cin_max), 1.0)
+        assert np.all(cout[valid] >= cin_min - ulp_tol)
+        assert np.all(cout[valid] <= cin_max + ulp_tol)
 
     def test_constant_input_gives_constant_output(self):
         """Test that constant input concentration gives constant output."""
@@ -261,13 +273,25 @@ class TestInfiltrationToExtractionDiffusion:
         assert np.all(cout_hetero[valid] >= -1e-10)
         assert np.all(cout_single[valid] >= -1e-10)
 
-        # Heterogeneous and single-L results should be physically distinct,
-        # demonstrating the per-streamtube L coupling matters.
-        assert not np.allclose(cout_hetero[valid], cout_single[valid], atol=1e-3)
+        # Per-streamtube sigma_v = (R V/L) * sqrt(2 D_m tau + 2 alpha_L L). For the
+        # heterogeneous case V/L = 5 for all three streamtubes (so sigma_v is identical
+        # across streamtubes); for the single-L case V/L varies (4, 5, 6) so sigma_v
+        # spreads across streamtubes. The empirically observed max-bin difference is
+        # ~4.6e-3 at this resolution; the threshold below replaces the previous
+        # ``not np.allclose(atol=1e-3)`` vacuous form with an explicit lower bound that
+        # catches the failure mode the original wording targeted (operator collapses to
+        # the single-L form).
+        max_abs_diff = float(np.max(np.abs(cout_hetero[valid] - cout_single[valid])))
+        assert max_abs_diff > 3e-3, (
+            f"hetero and single-L breakthroughs differ by only {max_abs_diff:.4e}; "
+            "expected > 3e-3 given the per-streamtube V/L variation"
+        )
 
-        # Both outputs should be bounded by the input range (convex combination).
-        assert np.all(cout_hetero[valid] <= np.max(cin) + 1e-10)
-        assert np.all(cout_single[valid] <= np.max(cin) + 1e-10)
+        # Both outputs lie in the convex hull of the input to machine ULP precision.
+        cin_max = float(np.max(cin))
+        ulp_tol = 16.0 * np.finfo(cout_hetero.dtype).eps * max(abs(cin_max), 1.0)
+        assert np.all(cout_hetero[valid] <= cin_max + ulp_tol)
+        assert np.all(cout_single[valid] <= cin_max + ulp_tol)
 
 
 class TestInfiltrationToExtractionDiffusionPhysics:
@@ -303,15 +327,18 @@ class TestInfiltrationToExtractionDiffusionPhysics:
         )
 
         valid = ~np.isnan(cout)
-        if np.sum(valid) > 0:
-            # The center of mass should be around day 15-17 (10-12 + 5 days residence)
-            times = np.arange(len(cout))
-            cout_valid = cout.copy()
-            cout_valid[~valid] = 0
-            if np.sum(cout_valid) > 0:
-                center_of_mass = np.sum(times * cout_valid) / np.sum(cout_valid)
-                # Center should be around day 16 (midpoint of input + residence time)
-                assert 14 < center_of_mass < 19
+        # Hard precondition: spin-up must release enough valid bins to cover the breakthrough.
+        # Previously this branch was wrapped in two nested ``if np.sum(...) > 0`` guards, so
+        # the assertion never fired when the operator regressed to all-NaN.
+        assert np.sum(valid) >= 10, f"expected at least 10 valid bins, got {np.sum(valid)}"
+        times = np.arange(len(cout))
+        cout_valid = cout.copy()
+        cout_valid[~valid] = 0.0
+        total_mass = float(np.sum(cout_valid))
+        assert total_mass > 0.0, "valid bins exist but carry zero mass"
+        # Center of mass should be around day 16 (midpoint of input + 5-day residence).
+        center_of_mass = float(np.sum(times * cout_valid) / total_mass)
+        assert 14.0 < center_of_mass < 19.0, f"center of mass {center_of_mass:.2f} outside [14, 19]"
 
     def test_mass_approximately_conserved(self):
         """Test that mass is approximately conserved through transport."""
@@ -1373,8 +1400,9 @@ class TestFlowWeightedDiffusion:
     scenarios are the minimal tests that distinguish the two approaches.
     """
 
-    def test_zero_diffusivity_varying_flow_matches_advection(self):
-        """D=0 with varying flow: diffusion module must match pure advection."""
+    @pytest.mark.parametrize("retardation_factor", [1.0, 2.7, 5.0])
+    def test_zero_diffusivity_varying_flow_matches_advection(self, retardation_factor):
+        """D=0 with varying flow: diffusion module must match pure advection across R values."""
         tedges = pd.date_range("2020-01-01", periods=31, freq="D")
         # Coarser output bins so that multiple flow bins fall inside one cout bin
         cout_tedges = pd.date_range("2020-01-01", periods=11, freq="3D")
@@ -1393,6 +1421,7 @@ class TestFlowWeightedDiffusion:
             tedges=tedges,
             cout_tedges=cout_tedges,
             aquifer_pore_volumes=aquifer_pore_volumes,
+            retardation_factor=retardation_factor,
         )
         cout_diff = infiltration_to_extraction(
             cin=cin,
@@ -1403,6 +1432,7 @@ class TestFlowWeightedDiffusion:
             streamline_length=streamline_length,
             molecular_diffusivity=0.0,
             longitudinal_dispersivity=0.0,
+            retardation_factor=retardation_factor,
         )
 
         valid = ~np.isnan(cout_adv)

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -13,6 +13,7 @@ from gwtransport.diffusion_fast import (
     _build_gaussian_matrix,
     _build_rebin_matrix,
     _build_v_smooth_matrix,
+    _validate_inputs,
     extraction_to_infiltration,
     gamma_extraction_to_infiltration,
     gamma_infiltration_to_extraction,
@@ -331,9 +332,13 @@ def test_retardation_constant_input(retardation_factor):
     assert_allclose(cout[valid], 10.0, atol=1e-12)
 
 
-@pytest.mark.parametrize("retardation_factor", [1.0, 2.7])
+@pytest.mark.parametrize("retardation_factor", [1.0, 2.7, 5.0])
 def test_retardation_zero_diffusion_matches_advection(retardation_factor):
-    """Zero diffusion with retardation matches pure advection (exact, G=I)."""
+    """Zero diffusion with retardation matches pure advection (exact, G=I), constant Q.
+
+    Companion ``test_retardation_zero_diffusion_matches_advection_variable_flow`` extends
+    to a variable-flow regime.
+    """
     tedges, cout_tedges, flow = _make_transport_data(n_days=400)
     n_days = len(flow)
     cin = np.sin(np.linspace(0, 4 * np.pi, n_days)) + 2.0
@@ -359,6 +364,38 @@ def test_retardation_zero_diffusion_matches_advection(retardation_factor):
     valid = ~np.isnan(cout_fast) & ~np.isnan(cout_adv)
     assert np.sum(valid) > 50
     assert_allclose(cout_fast[valid], cout_adv[valid], atol=1e-13)
+
+
+@pytest.mark.parametrize("retardation_factor", [1.0, 2.7, 5.0])
+def test_retardation_zero_diffusion_matches_advection_variable_flow(retardation_factor):
+    """Zero-diffusion match must hold under variable Q, too (extends the constant-flow sibling)."""
+    n_days = 400
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    cout_tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    # Variable flow with both a weekly oscillation and a slow trend.
+    flow = 100.0 + 60.0 * np.sin(np.arange(n_days) * 2 * np.pi / 7) + 0.05 * np.arange(n_days)
+    cin = np.sin(np.linspace(0, 4 * np.pi, n_days)) + 2.0
+
+    kwargs = {
+        "cin": cin,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([500.0]),
+        "retardation_factor": retardation_factor,
+    }
+
+    cout_fast = infiltration_to_extraction(
+        **kwargs,
+        mean_streamline_length=80.0,
+        mean_molecular_diffusivity=0.0,
+        mean_longitudinal_dispersivity=0.0,
+    )
+    cout_adv = advection_i2e(**kwargs)
+
+    valid = ~np.isnan(cout_fast) & ~np.isnan(cout_adv)
+    assert np.sum(valid) > 50
+    assert_allclose(cout_fast[valid], cout_adv[valid], atol=1e-12)
 
 
 @pytest.mark.parametrize("retardation_factor", [1.0, 2.7])
@@ -1933,3 +1970,113 @@ def test_build_v_smooth_matrix_v_weighted_col_sums_alpha_l():
     # interior columns where the kernel is fully contained.
     interior = slice(10, n - 10)
     assert_allclose(col_v_sums[interior], dv_arr[interior], atol=1e-12)
+
+
+def _good_diffusion_fast_inputs():
+    """Baseline known-valid inputs for _validate_inputs (mirrors the diffusion.py snapshot)."""
+    return {
+        "cin_or_cout": np.array([1.0, 2.0, 3.0, 4.0, 5.0]),
+        "flow": np.array([100.0, 100.0, 100.0, 100.0, 100.0]),
+        "tedges": pd.date_range("2023-01-01", periods=6, freq="D"),
+        "cout_tedges": pd.date_range("2023-01-01", periods=6, freq="D"),
+        "aquifer_pore_volumes": np.array([300.0]),
+        "mean_streamline_length": 80.0,
+        "mean_molecular_diffusivity": 0.01,
+        "mean_longitudinal_dispersivity": 0.5,
+        "retardation_factor": 1.0,
+        "is_forward": True,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match_regex"),
+    [
+        (
+            lambda k: {**k, "tedges": k["tedges"][:-1]},
+            r"tedges must have one more element than cin",
+        ),
+        (
+            lambda k: {**k, "flow": k["flow"][:-1]},
+            r"tedges must have one more element than flow",
+        ),
+        (
+            lambda k: {**k, "mean_molecular_diffusivity": -0.1},
+            r"mean_molecular_diffusivity must be non-negative",
+        ),
+        (
+            lambda k: {**k, "mean_longitudinal_dispersivity": -0.1},
+            r"mean_longitudinal_dispersivity must be non-negative",
+        ),
+        (
+            lambda k: {**k, "cin_or_cout": np.array([1.0, np.nan, 3.0, 4.0, 5.0])},
+            r"cin contains NaN values",
+        ),
+        (
+            lambda k: {**k, "flow": np.array([100.0, np.nan, 100.0, 100.0, 100.0])},
+            r"flow contains NaN values",
+        ),
+        (
+            lambda k: {**k, "flow": np.array([100.0, -50.0, 100.0, 100.0, 100.0])},
+            r"flow must be non-negative \(negative flow not supported\)",
+        ),
+        (
+            lambda k: {**k, "aquifer_pore_volumes": np.array([0.0])},
+            r"aquifer_pore_volumes must be positive",
+        ),
+        (
+            lambda k: {**k, "mean_streamline_length": 0.0},
+            r"mean_streamline_length must be positive",
+        ),
+        (
+            lambda k: {**k, "retardation_factor": 0.5},
+            r"retardation_factor must be >= 1\.0 \(anti-retardation is not physical\)",
+        ),
+    ],
+)
+def test_validate_diffusion_fast_inputs_raises_on_bad_input(mutate, match_regex):
+    """Each ValueError branch of _validate_inputs raises with the historical message.
+
+    Mirrors the snapshot pattern in test_diffusion.py:test_validate_diffusion_inputs_raises_on_bad_input.
+    Pins the diffusion_fast validation surface (with the new R>=1 contract from Group 8).
+    """
+    bad = mutate(_good_diffusion_fast_inputs())
+    with pytest.raises(ValueError, match=match_regex):
+        _validate_inputs(**bad)
+
+
+@pytest.mark.parametrize("bad_r", [0.0, 0.5, 0.99])
+def test_diffusion_fast_rejects_retardation_below_one(bad_r):
+    """The public infiltration_to_extraction surface raises on R < 1 (mirrors diffusion.py)."""
+    tedges, cout_tedges, flow = _make_transport_data(n_days=50)
+    cin = np.ones(len(flow))
+
+    with pytest.raises(ValueError, match=r"retardation_factor must be >= 1\.0"):
+        infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            mean_streamline_length=80.0,
+            mean_molecular_diffusivity=0.01,
+            mean_longitudinal_dispersivity=0.5,
+            retardation_factor=bad_r,
+        )
+
+
+def test_streamline_length_zero_rejected():
+    """L=0 has no streamtube; raise rather than risk div-by-zero downstream."""
+    tedges, cout_tedges, flow = _make_transport_data(n_days=50)
+    cin = np.ones(len(flow))
+
+    with pytest.raises(ValueError, match=r"mean_streamline_length must be positive"):
+        infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            mean_streamline_length=0.0,
+            mean_molecular_diffusivity=0.01,
+            mean_longitudinal_dispersivity=0.5,
+        )


### PR DESCRIPTION
## Summary

Closes #197 in full. Closes the majority of #196; remaining items tracked as a follow-up issue (see below).

Three reviewers signed off plan + implementation:
- **bas-physics-math-reviewer** (Phase 1): streamtube doc wording physically accurate; sigma_v variance expressions match implementation.
- **bas-test-reviewer** (Phase 2): all tightenings + new tests mutation-verified.
- **bas-code-optimizer** (Phase 3): bit-identical refactor verified on a 9-case sweep (both transport directions, both branches, uniform + non-uniform grids, supplied + auto flow_out, asym_cs in {None, 3.0, 5.5}).

## Phase 1 — Streamtube assumption docs

New section in `diffusion.py` and `diffusion_fast.py` module docstrings: each entry in `aquifer_pore_volumes` is an independent 1D streamtube; no cross-sectional area parameter (it is fixed implicitly by `A = V_pore / L`). The variance budget uses `2 D_m tau` + `2 alpha_L xi` (slow, per-parcel) or `2 alpha_L L` (fast, moment-averaged). No Bear citation per owner direction; sources already cited elsewhere in each module's References block.

## Phase 2 — Tests

**Tightenings (3 misleading tests):**
- `test_output_bounded_by_input` (`test_diffusion.py:149`): convex-hull bound now uses a 16-ULP tolerance (was `+/- 1e-10`, six orders of magnitude looser than the actual ~1 ULP overshoot in the K-Z quadrature composition).
- `test_heterogeneous_streamline_length` (`:225`): replaced `not np.allclose(..., atol=1e-3)` with explicit `assert max_abs_diff > 3e-3`. Documents the expected sigma_v variation and catches operator-collapse regressions.
- `test_symmetry_of_pulse` (`:276`): removed BOTH nested `if np.sum(...) > 0:` guards; hard preconditions (`>=10` valid bins, `total_mass > 0`) ensure the center-of-mass assertion actually fires.

**New tests:**
- Group 3 — parametrize R ∈ {1.0, 2.7, 5.0} on `test_zero_diffusivity_varying_flow_matches_advection` (was un-parametrized) and `test_retardation_zero_diffusion_matches_advection` (was {1.0, 2.7}).
- **New** `test_retardation_zero_diffusion_matches_advection_variable_flow`: variable-flow companion for `diffusion_fast`, `atol=1e-12`.
- Group 6 — `test_validate_diffusion_fast_inputs_raises_on_bad_input`: parametrized snapshot over 10 ValueError branches of `_validate_inputs` (mirrors `test_diffusion.py:test_validate_diffusion_inputs_raises_on_bad_input`).
- Group 8 — `test_diffusion_fast_rejects_retardation_below_one` (parametrized on R ∈ {0.0, 0.5, 0.99}) and `test_streamline_length_zero_rejected`.

**Validation surface change (breaking, per the project's no-backwards-compat policy):**
- `diffusion_fast._validate_inputs` now requires `retardation_factor` and raises `ValueError(\"retardation_factor must be >= 1.0 (anti-retardation is not physical)\")` when violated. Both public entry points (`infiltration_to_extraction`, `extraction_to_infiltration`) forward `retardation_factor` into the validator.

## Phase 3 — Code leanness (closes #197)

All four items, bit-identical to baseline:

1. **`_DEFAULT_CUTOFF_SIGMA_V = 4.0`** module constant replaces 4 `... if asymptotic_cutoff_sigma is not None else 4.0` ternary sites and the `_build_v_smooth_matrix` parameter default.
2. **`_prepare_v_grid(weight_tedges, tedges, flow)`** helper factored out of both `infiltration_to_extraction` and `extraction_to_infiltration`. Returns `(tedges_days, v_in_widedge_edges, v_in_natural_edges)` — `weight_dt_days` and `natural_dt_days` are intermediate locals (the plan's 5-tuple return was leaner with this pruning).
3. **`sigma_v_out` lifted** into the advect-then-smooth (`else`) branch in both transport entry points; `cout_tedges_days`, `v_out_edges`, and `flow_out_arr` now compute only when needed. `cout_dt_days` removed entirely (was only used for the now-unreachable auto-derived flow_out path).
4. **Inlined single-use scalars** in `_compute_sigma_v` (`mol_var_x`, `disp_var_x`, `var_numerator`) into the `sigma_v_sq` expression.

Plan-mandated sequence respected: **lift first, then factor** against the reduced unconditional set.

## Test plan

- `uv run pytest tests/src/test_diffusion.py tests/src/test_diffusion_fast.py -q` → 196 passed (was 178; +18 net from new tests minus removed nested-`if` paths).
- `uv run pytest tests/src -n auto` → 1212 passed, 8 skipped, 1 xfailed (unrelated P1.8 fronttracking), 20 warnings.
- `ruff format . && ruff check --fix .` → clean.
- `bas-code-optimizer` 9-case bit-identical equivalence verified.

## Deferred to follow-up issue

Per test-reviewer's recommendation, the following items are tracked separately rather than crammed into this PR:

- 3 remaining misleading-test tightenings: `test_mass_approximately_conserved` E→I (rtol 1e-6 → 1e-10), `test_roundtrip_moderate_gamma` (derived tolerance), `test_diffusion_fast_vs_diffusion_same_grid` (parametrized sweep with derived tolerance).
- Group 5 full parity sweep: variable flow × R × multi-PV with a zero-flow axis.
- Group 7 first/last bin exact tests + translation invariance under constant Q.
- Group 8 mechanical-dispersion variance R-independence test.
- 4 uncovered validation branches in `_validate_inputs`: `cout_tedges` reverse branch + 3 `flow_out` branches (length, NaN, negative).

## Breaking change

Callers passing `retardation_factor < 1.0` to `gwtransport.diffusion_fast.infiltration_to_extraction` / `extraction_to_infiltration` will now raise `ValueError`. Mirrors the prior R>=1 contract in `gwtransport.diffusion` (added in PR #195). No in-repo callers depend on R < 1.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.