### PR TITLE
test(utils/gamma/residence_time): harden helper tests + #185/#186 regression guard

### DIFF
--- a/tests/src/test_gamma.py
+++ b/tests/src/test_gamma.py
@@ -80,14 +80,6 @@ def test_bins_basic(gamma_params):
     np.testing.assert_allclose(expected_value_gamma, expected_value_bins, rtol=1e-12)
 
 
-def test_bins_expected_values(gamma_params):
-    """Test that expected values are within their respective bins."""
-    result = gamma_bins(**gamma_params)
-
-    for i in range(len(result["expected_values"])):
-        assert result["lower_bound"][i] <= result["expected_values"][i] <= result["upper_bound"][i]
-
-
 # Edge cases and error handling
 def test_invalid_parameters():
     """Test error handling for invalid parameters."""

--- a/tests/src/test_logremoval.py
+++ b/tests/src/test_logremoval.py
@@ -344,6 +344,24 @@ def test_gamma_cdf_approaches_one():
     assert_allclose(result, 0.0, atol=1e-10)
 
 
+def test_gamma_cdf_is_scaled_gamma():
+    """Test that the log removal CDF matches a scaled gamma distribution.
+
+    R = mu * T, so R ~ Gamma(rt_alpha, scale=mu*rt_beta). This pins the scale factor
+    mu * rt_beta: dropping the decay-rate factor (scale=mu*beta -> beta) would shift
+    the CDF and fail this assertion. Mirrors ``test_gamma_pdf_is_scaled_gamma``.
+    """
+    rt_alpha = 4.0
+    rt_beta = 5.0
+    log10_decay_rate = 0.3
+
+    r_values = np.linspace(0.1, 20.0, 50)
+    cdf_values = gamma_cdf(r=r_values, rt_alpha=rt_alpha, rt_beta=rt_beta, log10_decay_rate=log10_decay_rate)
+
+    expected = stats.gamma.cdf(r_values, a=rt_alpha, scale=log10_decay_rate * rt_beta)
+    assert_allclose(cdf_values, expected, rtol=1e-12)
+
+
 @pytest.mark.parametrize(
     ("rt_alpha", "rt_beta", "log10_decay_rate"),
     [

--- a/tests/src/test_residence_time.py
+++ b/tests/src/test_residence_time.py
@@ -728,17 +728,23 @@ def test_monotonicity_under_increasing_flow():
     assert np.all(np.diff(tau[valid]) < 0)
 
 
-def test_nan_flow_returns_nan():
+@pytest.mark.parametrize("nan_index", [0, 1, -1])
+def test_nan_flow_returns_nan(nan_index):
     """A single NaN in flow makes the result all-NaN with the right shape.
 
     ``np.any(flow < 0)`` evaluates ``False`` for NaN under IEEE 754; the gate at
-    residence_time.py:107 must therefore also catch NaN explicitly, otherwise NaN propagates
+    residence_time.py:105 must therefore also catch NaN explicitly, otherwise NaN propagates
     through ``cumsum`` into ``flow_cum`` and ``residence_time_mean`` (which calls
     ``linear_average``, requiring strictly-ascending ``x_data``) fails noisily. This test pins
     the symmetric NaN-return behavior across both functions.
+
+    The NaN position is parametrized: an early NaN (index 0 or 1) poisons everything
+    downstream of ``cumsum`` and would pass even without the gate, but a late NaN (index -1)
+    leaves the leading entries finite, exposing a partial-NaN result if the gate is removed.
     """
     flow_tedges = pd.date_range(start="2023-01-01", end="2023-01-06", freq="D")
-    flow_values = np.array([100.0, np.nan, 100.0, 100.0, 100.0])
+    flow_values = np.array([100.0, 100.0, 100.0, 100.0, 100.0])
+    flow_values[nan_index] = np.nan
     pore_volume = 100.0
 
     rt = residence_time(
@@ -759,3 +765,53 @@ def test_nan_flow_returns_nan():
     )
     assert rt_mean.shape == (1, len(flow_tedges) - 1)
     assert np.all(np.isnan(rt_mean))
+
+
+@pytest.mark.parametrize("tz", ["UTC", "America/New_York"])
+def test_timezone_invariance(tz):
+    """A tz-aware ``flow_tedges`` (no DST in-window) matches the tz-naive result.
+
+    Both functions reduce time edges to days relative to ``flow_tedges[0]``, so the result
+    is origin-invariant: any constant shift -- including a tz strip or UTC-normalize --
+    cancels by construction. This guard therefore does NOT lock origin-preservation. It
+    locks the narrower, still-useful contract that a tz-aware index with the same
+    wall-clock spacing as its naive counterpart (no DST transition in the window) yields
+    bit-identical days, which is the realistic path for the package's UTC-aware
+    ``get_soil_temperature``/``generate_example_data`` indices. (Across a DST boundary the
+    localized day-spacing is not constant, so the equality holds only for DST-free windows
+    such as the January one used here.)
+    """
+    flow_values = np.array([100.0, 110.0, 105.0, 95.0, 98.0, 102.0, 107.0, 103.0, 96.0])
+    naive = pd.date_range(start="2023-01-01", end="2023-01-10", freq="D")
+    aware = naive.tz_localize(tz)
+    pore_volume = 200.0
+
+    rt_naive = residence_time(
+        flow=flow_values,
+        flow_tedges=naive,
+        aquifer_pore_volumes=pore_volume,
+        direction="extraction_to_infiltration",
+    )
+    rt_aware = residence_time(
+        flow=flow_values,
+        flow_tedges=aware,
+        aquifer_pore_volumes=pore_volume,
+        direction="extraction_to_infiltration",
+    )
+    np.testing.assert_array_equal(rt_aware, rt_naive)
+
+    rt_mean_naive = residence_time_mean(
+        flow=flow_values,
+        flow_tedges=naive,
+        tedges_out=naive,
+        aquifer_pore_volumes=pore_volume,
+        direction="extraction_to_infiltration",
+    )
+    rt_mean_aware = residence_time_mean(
+        flow=flow_values,
+        flow_tedges=aware,
+        tedges_out=aware,
+        aquifer_pore_volumes=pore_volume,
+        direction="extraction_to_infiltration",
+    )
+    np.testing.assert_array_equal(rt_mean_aware, rt_mean_naive)

--- a/tests/src/test_residence_time_mean.py
+++ b/tests/src/test_residence_time_mean.py
@@ -89,8 +89,10 @@ def test_varying_extraction(constant_flow_data):
         direction="extraction_to_infiltration",
     )
 
-    # Check that the mean values are consistent
-    assert np.allclose(df_lowres.values, result_lowres[0], equal_nan=True)
+    # Check that the mean values are consistent. Resampling the high-res result and
+    # computing the low-res result directly are bit-identical here, so pin to machine
+    # precision rather than the loose np.allclose default (rtol=1e-5).
+    np.testing.assert_allclose(df_lowres.values, result_lowres[0], atol=0, rtol=1e-12, equal_nan=True)
 
 
 def test_retardation_factor(constant_flow_data):

--- a/tests/src/test_simplify_bins.py
+++ b/tests/src/test_simplify_bins.py
@@ -182,18 +182,6 @@ class TestSimplifyBinsFlowSimplification:
         volume_after = np.sum(new_flow * new_widths)
         assert_array_equal(volume_after, volume_before)
 
-    def test_flow_mass_conservation(self):
-        """Total mass (flow x width x value) should be conserved."""
-        edges = np.array([0.0, 2.0, 3.0, 5.0, 6.0])
-        values = np.array([3.0, 3.0, 7.0, 7.0])
-        flow = np.array([2.0, 4.0, 1.0, 3.0])
-        widths = np.diff(edges)
-        mass_before = np.sum(flow * widths * values)
-        new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow)
-        new_widths = np.diff(new_edges)
-        mass_after = np.sum(new_flow * new_widths * new_values)
-        assert_array_equal(mass_after, mass_before)
-
 
 class TestSimplifyBinsMassConservation:
     """Test that total mass is conserved after simplification."""
@@ -210,13 +198,23 @@ class TestSimplifyBinsMassConservation:
         assert_array_equal(mass_after, mass_before)
 
     def test_mass_conservation_with_flow(self):
-        """Total flowxwidthxvalue (= mass) should be conserved."""
-        edges = np.array([0.0, 1.0, 2.0, 5.0, 6.0])
-        values = np.array([3.0, 3.0, 7.0, 7.0])
-        flow = np.array([2.0, 4.0, 1.0, 3.0])
+        """Total flowxwidthxvalue (= mass) is conserved when a merge group mixes values.
+
+        Values differ within the (tol-merged) group and flow vs width pull the weighting
+        in opposite directions: volumes are 6*1=6 and 1*2=2, so the flow-weighted merged
+        value is (6*2 + 2*8)/(6+2) = 3.5, distinct from the width-only weighting (6.0) and
+        the unweighted mean (5.0). Mass conservation therefore exercises the flow-vs-width
+        value-weighting rather than merging only identical values.
+        """
+        edges = np.array([0.0, 1.0, 3.0])  # widths: 1, 2
+        values = np.array([2.0, 8.0])
+        flow = np.array([6.0, 1.0])
         widths = np.diff(edges)
         mass_before = np.sum(flow * widths * values)
-        new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow)
+        new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow, tol=10.0)
+        # Single merged bin with the flow-volume-weighted value.
+        assert_array_equal(new_edges, [0.0, 3.0])
+        assert_array_equal(new_values, [3.5])
         new_widths = np.diff(new_edges)
         mass_after = np.sum(new_flow * new_widths * new_values)
         assert_array_equal(mass_after, mass_before)

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -1161,6 +1161,12 @@ def test_solve_tikhonov_resolution_underdetermined():
     assert np.all(fraction_data <= 1.0 + 1e-10), f"fraction_data has values > 1: {fraction_data}"
     # Some elements should be pulled toward target (fraction_data < 1)
     assert np.any(fraction_data < 0.99), "Expected some target-driven elements in underdetermined system"
+    # Pin the resolution scale. For this symmetric block system the model resolution
+    # diagonal is analytically 10/21: each block has inverse-gram diagonal
+    # (G^T G + 0.1 I)^-1[j, j] = 1.1/0.21, so
+    # R[j, j] = 1 - 0.1 * (1.1/0.21) = 0.10/0.21 = 10/21. A 0.5 or 0.3 rescaling of the
+    # regularization coefficient (R = 1 - c*lambda*d*G_inv) would shift this value.
+    np.testing.assert_allclose(fraction_data, 10 / 21, rtol=1e-12)
 
 
 def test_solve_tikhonov_resolution_bounds():


### PR DESCRIPTION
## Summary

Pins the solve_tikhonov underdetermined resolution to the exact `10/21` (catches a regularization-coefficient rescale); adds `test_gamma_cdf_is_scaled_gamma` (pins the μβ scale); tightens `test_varying_extraction` to `assert_allclose(rtol=1e-12)`; parametrizes `test_nan_flow_returns_nan` so the late-NaN case exercises the residence_time gate; hardens the simplify_bins flow-weighting test to use distinct values; deletes a redundant bounds test; adds a (no-DST) tz/naive equivalence guard.

Reviewed by four agents; the load-bearing tests are mutation-verified. The mechanical #185/#186 source consolidation (a private `_time.py` + `cumulative_flow_volume` across 24 sites) is **deferred to a follow-up** — these are the test-side hardening + guards. Towards #185/#186.

## Test plan

- `pytest` over the changed helper tests (13 affected cases passed).
- Mutation-verified: 10/21 catches a coefficient rescale; gamma_cdf scale μβ→β caught; late-NaN gate removal caught.
- `ruff`/`ty` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.