### PR TITLE
test(percolation): constitutive ground-truth, transient mass balance, fan-integrator coverage

### DIFF
--- a/tests/src/test_percolation.py
+++ b/tests/src/test_percolation.py
@@ -3,11 +3,16 @@ Unit and integration tests for :mod:`gwtransport.percolation`.
 
 Tests cover:
 
-- Section B: end-to-end percolation with BC and vG (empty, first-arrival, rarefaction, mass-balance).
+- Section A: known-answer constitutive ground-truth (hand-derived literals, never
+  recomputed from the class under test) — anchors BC/vG against a Mualem→Burdine
+  exponent swap and a dropped Mualem square.
+- Section B: end-to-end percolation with BC and vG (empty, first-arrival, rarefaction,
+  pure-shock breakthrough, mass-balance).
 - Section C: K-scaling identity, time-rescaling, validation.
-- Section D: vG article-reproducibility against article-stated characteristic speeds.
+- Section D: vG characteristic-speed monotonicity (property test).
 - Section E: smoke (multi-column, perf budget).
 - Section M: missing-test additions (dry days, saturation, idempotence, sign-flip invariance, two-step ramp).
+- Section P: transient global mass balance (BC closed-form, vG exact ``L=0`` branch).
 
 Tolerances: machine precision for Brooks-Corey closed-form paths; brentq-bounded
 for vG; explicitly relaxed where physical reasoning permits (e.g. mass balance
@@ -19,14 +24,18 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 
 import logging
 import time
+import warnings
 
 import numpy as np
 import pandas as pd
 import pytest
 
 from gwtransport.fronttracking.math import BrooksCoreyConductivity, VanGenuchtenMualemConductivity
-from gwtransport.fronttracking.output import compute_domain_mass, concentration_at_point
-from gwtransport.fronttracking.waves import DecayingShockWave
+from gwtransport.fronttracking.output import (
+    compute_domain_mass,
+    concentration_at_point,
+)
+from gwtransport.fronttracking.waves import DecayingShockWave, RarefactionWave
 from gwtransport.percolation import root_zone_to_water_table_kinematic_wave
 
 # Soil O05 (coarse sand) parameters — used as the default test fixture.
@@ -36,6 +45,93 @@ O05_VG = {"theta_r": 0.01, "theta_s": 0.337, "k_s": 0.174, "van_genuchten_n": 2.
 
 def _make_tedges(n_days: int) -> pd.DatetimeIndex:
     return pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+
+
+# =============================================================================
+# Section A — Known-answer constitutive ground-truth
+# =============================================================================
+#
+# Every literal below is hand-derived (independent CAS / mpmath at 50 digits)
+# from the closed-form constitutive curves — NEVER produced by running the
+# class under test. The Brooks-Corey curve uses the Mualem exponent
+# ``a = 3 + 2/λ``; for soil O05 (λ = 0.25) this is ``a = 11``. The Burdine
+# variant ``a = 2 + 3/λ = 14`` gives DIFFERENT numbers (recorded below as the
+# discriminator), so these tests fail under a Mualem→Burdine swap. The vG
+# ``_k_se`` literals fail under a dropped Mualem square (``u·u → u``).
+
+
+class TestConstitutiveGroundTruth:
+    """A-series: hardcoded known-answer literals for BC and vG constitutive curves."""
+
+    def test_a1_bc_total_concentration_known_answer(self):
+        """A1: ``BrooksCoreyConductivity.total_concentration(0.002)`` equals the hand-derived literal.
+
+        ``C_T(C) = Δθ · (C/k_s)^(1/a)`` with ``Δθ = 0.327``, ``k_s = 0.174``,
+        ``a = 3 + 2/λ = 11`` (Mualem). Evaluated at ``C = 0.002`` this is
+        ``0.327 · (0.002/0.174)^(1/11) = 0.21788524470301235`` (mpmath, 50 digits).
+        The Burdine exponent ``a = 14`` would give ``0.2376898645655214`` instead,
+        so this literal distinguishes Mualem from Burdine.
+        """
+        sorption = BrooksCoreyConductivity(**O05)
+        # Hand-derived literal (Mualem a=11); Burdine a=14 would give 0.2376898645655214.
+        np.testing.assert_allclose(sorption.total_concentration(0.002), 0.21788524470301235, rtol=1e-13)
+
+    def test_a2_bc_retardation_known_answer(self):
+        """A2: ``BrooksCoreyConductivity.retardation(0.002)`` equals the hand-derived literal.
+
+        ``R(C) = (Δθ / (a·k_s)) · (C/k_s)^(1/a − 1)`` with ``a = 11`` (Mualem).
+        At ``C = 0.002`` this is ``9.903874759227834`` (mpmath, 50 digits).
+        """
+        sorption = BrooksCoreyConductivity(**O05)
+        np.testing.assert_allclose(sorption.retardation(0.002), 9.903874759227834, rtol=1e-13)
+
+    def test_a3_bc_shock_speed_known_answer(self):
+        """A3: ``BrooksCoreyConductivity.shock_speed`` between two nonzero levels equals the literal.
+
+        Rankine-Hugoniot ``(C₂ − C₁)/(C_T(C₂) − C_T(C₁))`` with
+        ``C₁ = 0.05·k_s = 0.0087``, ``C₂ = 0.3·k_s = 0.0522`` and the Mualem
+        ``a = 11`` total-concentration curve evaluates to ``0.9873688299795546``
+        (mpmath, 50 digits). This is a chord speed, distinct from either
+        single-side characteristic speed.
+        """
+        sorption = BrooksCoreyConductivity(**O05)
+        c1 = 0.05 * O05["k_s"]
+        c2 = 0.3 * O05["k_s"]
+        np.testing.assert_allclose(sorption.shock_speed(c1, c2), 0.9873688299795546, rtol=1e-13)
+
+    def test_a4_vg_k_se_known_answers(self):
+        """A4: ``VanGenuchtenMualemConductivity._k_se`` at fixed ``S_e`` equals hand-derived literals.
+
+        ``K_M(S_e) = k_s · S_e^L · [1 − (1 − S_e^{1/m})^m]^2`` with ``k_s = 0.174``,
+        ``L = 0.5`` (default Mualem), ``m = 1 − 1/n_vG`` and ``n_vG = 2.28``.
+        Literals at ``S_e ∈ {0.3, 0.5, 0.7}`` from mpmath (50 digits). Dropping
+        the Mualem square (``u·u → u``) would give {0.00644, 0.02160, 0.05027}
+        instead, so these literals catch that mutation.
+        """
+        sorption = VanGenuchtenMualemConductivity(**O05_VG)
+        # Hand-derived literals (Mualem, squared term). Dropped-square would give
+        # 0.00643692421945469 / 0.0215963614450827 / 0.050269334712603586.
+        expected = {0.3: 0.00043475733403324765, 0.5: 0.0037907655426169216, 0.7: 0.017358332655388515}
+        for se, k_expected in expected.items():
+            np.testing.assert_allclose(sorption._k_se(se), k_expected, rtol=1e-12)  # noqa: SLF001
+
+    def test_a5_vg_k_se_burdine_branch_known_answers(self):
+        """A5: ``_k_se`` with ``L = 0`` (Burdine/exact branch) equals hand-derived literals.
+
+        Same curve with ``L = 0``: ``K_M(S_e) = k_s · [1 − (1 − S_e^{1/m})^m]^2``.
+        Literals at ``S_e ∈ {0.3, 0.5, 0.7}`` from mpmath (50 digits). Pins the
+        root-finding-free branch used by the vG ``mualem_l = 0`` mass-balance test.
+        """
+        sorption = VanGenuchtenMualemConductivity(
+            theta_r=O05_VG["theta_r"],
+            theta_s=O05_VG["theta_s"],
+            k_s=O05_VG["k_s"],
+            van_genuchten_n=O05_VG["van_genuchten_n"],
+            mualem_l=0.0,
+        )
+        expected = {0.3: 0.0007937546629693939, 0.5: 0.005360952042145455, 0.7: 0.020747175800063807}
+        for se, k_expected in expected.items():
+            np.testing.assert_allclose(sorption._k_se(se), k_expected, rtol=1e-12)  # noqa: SLF001
 
 
 # =============================================================================
@@ -69,7 +165,18 @@ class TestEndToEnd:
         np.testing.assert_array_equal(q_wt_vg, np.zeros(60))
 
     def test_b3_first_arrival_analytic_bc(self):
-        """B3 (BC): first-arrival ``θ_V`` matches analytic shock-arrival formula."""
+        """B3 (BC): the closed-form first-arrival DIAGNOSTIC matches the analytic shock formula.
+
+        Checks ``structures[0]["theta_first_arrival"]`` — the value returned by
+        :func:`gwtransport.fronttracking.math.compute_first_front_arrival_theta`,
+        a closed-form *diagnostic* of when ``c_first`` reaches the outlet. This is
+        NOT the solver's tracked wetting-front (an actual ``ShockWave``); the
+        pure-shock end-to-end breakthrough that exercises the tracked front is
+        covered by ``test_b6_constant_flux_pure_shock_known_answer_bc``. The
+        diagnostic equals ``V_out · C_T(q0) / q0`` with ``C_T`` from Brooks-Corey
+        (value-anchored by Section A / B6 — this first-arrival check is a geometric
+        diagnostic, not the constitutive ground truth, which lives in those tests).
+        """
         tedges = _make_tedges(400)
         q0 = 0.002  # m/day
         z_wt = 0.5  # m
@@ -94,7 +201,15 @@ class TestEndToEnd:
         np.testing.assert_allclose(structures[0]["theta_first_arrival"], theta_v_arrival, rtol=1e-13)
 
     def test_b3_first_arrival_analytic_vg(self):
-        """B3' (vG): first-arrival ``θ_V`` matches analytic; brentq-bounded tolerance."""
+        """B3' (vG): the closed-form first-arrival DIAGNOSTIC matches the analytic shock formula.
+
+        As in ``test_b3_first_arrival_analytic_bc`` this checks the closed-form
+        ``theta_first_arrival`` diagnostic (``compute_first_front_arrival_theta``),
+        not the solver's tracked front. vG ``C_T`` requires a brentq inversion, so
+        the tolerance is brentq-bounded. Value-anchored by Section A / B7 — this
+        first-arrival check is a geometric diagnostic, not the constitutive ground
+        truth, which lives in those tests.
+        """
         tedges = _make_tedges(400)
         q0 = 0.002
         z_wt = 0.5
@@ -174,6 +289,153 @@ class TestEndToEnd:
             # Self-similar relation R(c) = (θ - θ_origin) / (v - v_origin) — machine precision for BC closed form.
             np.testing.assert_allclose(r_from_sorption, r_from_self_similar, rtol=1e-13)
 
+    @staticmethod
+    def _assert_bare_rarefaction_self_similar(sorption_kwargs, rtol, *, n=120, wet_days=30, mult=50.0):
+        """Probe an uncollided ``RarefactionWave`` and assert ``R(c)·(v − v_start) == θ − θ_start``.
+
+        Uses a long column so the drying-step rarefaction never reaches the
+        outlet, and probes a θ strictly *before* the wetting shock collides with
+        the fan (so the wave is still a bare :class:`RarefactionWave`, not the
+        post-collision DSW that B4 inspects). The fan apex of a bare rarefaction
+        is ``(v_start, theta_start)``.
+
+        Parameters
+        ----------
+        sorption_kwargs : dict
+            Constitutive-model keyword arguments forwarded to the solver.
+        rtol : float
+            Relative tolerance for the self-similar identity (machine precision
+            for the Brooks-Corey closed form, brentq-bounded for van Genuchten).
+        n : int, optional
+            Total number of daily input bins. Default 120. A shorter drying tail
+            (smaller ``n``) keeps the vG caller cheap while still producing a
+            finitely-deactivating bare rarefaction.
+        wet_days : int, optional
+            Number of leading wet days (the wetting-front shock that later
+            collides with the fan). Default 30.
+        mult : float, optional
+            Column-length multiplier ``v_out = theta_s · mult``. Default 50.0
+            (long enough that the fan never reaches the outlet before collision).
+        """
+        tedges = _make_tedges(n)
+        q_root = np.zeros(n)
+        q_root[:wet_days] = 0.003  # wetting phase
+        q_root[wet_days:] = 0.0005  # drying phase → emits a rarefaction
+        v_out_val = sorption_kwargs["theta_s"] * mult  # long column: fan never reaches the outlet
+        with warnings.catch_warnings():
+            # The long column pushes some output θ-bins past the inlet window; the
+            # resulting back-transform warning is incidental to this wave-geometry
+            # probe (which reads the wave list directly, not the bin-average).
+            warnings.simplefilter("ignore")
+            _, structures = root_zone_to_water_table_kinematic_wave(
+                q_root_zone=q_root,
+                tedges=tedges,
+                q_water_table_tedges=tedges,
+                cumulative_pore_volumes_outlet=np.array([v_out_val]),
+                **sorption_kwargs,
+            )
+        state = structures[0]["tracker_state"]
+        sorption = state.sorption
+        rarefactions = [w for w in state.waves if isinstance(w, RarefactionWave)]
+        assert rarefactions, "Expected a bare RarefactionWave from the drying step"
+        rw = rarefactions[0]
+        # Probe strictly inside [theta_start, theta_deactivation): the fan has
+        # spatial extent and has not yet been consumed by the wetting shock.
+        assert np.isfinite(rw.theta_deactivation), "Rarefaction should deactivate at the shock collision"
+        theta_probe = rw.theta_start + 0.5 * (rw.theta_deactivation - rw.theta_start)
+        v_tail = rw.tail_position_at_theta(theta_probe)
+        v_head = rw.head_position_at_theta(theta_probe)
+        assert v_tail is not None
+        assert v_head is not None
+        v_samples = np.linspace(v_tail + 0.05 * (v_head - v_tail), v_head - 0.05 * (v_head - v_tail), 8)
+        for v in v_samples:
+            c = rw.concentration_at_point(float(v), theta_probe)
+            assert c is not None, f"bare rarefaction did not return c at interior point v={v}"
+            r_from_sorption = float(sorption.retardation(c))
+            r_from_self_similar = (theta_probe - rw.theta_start) / (v - rw.v_start)
+            np.testing.assert_allclose(r_from_sorption, r_from_self_similar, rtol=rtol)
+
+    def test_b4b_bare_rarefaction_self_similar_bc(self):
+        """B4b (BC): an uncollided ``RarefactionWave`` obeys ``R(c)·(v − v_start) == θ − θ_start``.
+
+        Complements B4 (which inspects the post-collision DSW): here the fan is
+        probed before any collision, on a long column. Machine precision for the
+        Brooks-Corey closed form.
+        """
+        self._assert_bare_rarefaction_self_similar(O05, rtol=1e-13)
+
+    def test_b4c_bare_rarefaction_self_similar_vg(self):
+        """B4c (vG): the bare-``RarefactionWave`` self-similar law holds for van Genuchten.
+
+        Same probe as B4b with the vG-Mualem curve; tolerance is brentq-bounded
+        (the self-similar inversion ``c = K_M^{-1}(Δθ/R)`` uses brentq). Uses a
+        short drying tail (``n=25``) — the per-bin vG brentq inversions make a
+        long tail expensive (~9 s at ``n=120``); ``n=25`` still produces a
+        finitely-deactivating bare rarefaction and catches the ``r_target``
+        self-similar mutation.
+        """
+        self._assert_bare_rarefaction_self_similar(O05_VG, rtol=1e-11, n=25, wet_days=12, mult=50.0)
+
+    def test_b6_constant_flux_pure_shock_known_answer_bc(self):
+        """B6 (BC): constant ``q0`` from rest → single wetting shock arriving at a hardcoded θ.
+
+        A constant ``q_root_zone = q0`` from the dry initial state (``θ = θ_r``)
+        emits one wetting-front shock; its arrival θ at the outlet is
+        ``V_out · C_T(q0) / q0``. With ``q0 = 0.002`` and ``V_out = θ_s · 0.5``
+        for soil O05, the hand-derived literal is ``18.35683186622879`` (mpmath,
+        50 digits). The Burdine exponent would give ``20.025…`` instead — this
+        literal is setup-specific (it pins both ``q0`` and ``V_out``), so the
+        breakthrough is a clean 0→q0 step. Confirms the solver's tracked front,
+        not just the closed-form diagnostic (which B3 checks).
+        """
+        n = 400
+        tedges = _make_tedges(n)
+        q0 = 0.002  # m/day — PINNED (literal below is setup-specific)
+        v_out_val = O05["theta_s"] * 0.5  # V_out PINNED
+        q_wt, structures = root_zone_to_water_table_kinematic_wave(
+            q_root_zone=np.full(n, q0),
+            tedges=tedges,
+            q_water_table_tedges=tedges,
+            cumulative_pore_volumes_outlet=np.array([v_out_val]),
+            **O05,
+        )
+        # Hand-derived arrival θ (Mualem a=11); Burdine a=14 would give 20.02537108964518.
+        np.testing.assert_allclose(structures[0]["theta_first_arrival"], 18.35683186622879, rtol=1e-13)
+        # The breakthrough is a clean 0→q0 step: exactly one partial bin straddling
+        # the arrival, zeros before, q0 after.
+        partial = np.where((q_wt > 1e-12) & (q_wt < q0 * (1.0 - 1e-9)))[0]
+        assert partial.size == 1, f"expected exactly one partial bin in a clean 0→q0 step, got {partial.size}"
+        k = int(partial[0])
+        np.testing.assert_array_equal(q_wt[:k], np.zeros(k))
+        np.testing.assert_allclose(q_wt[k + 1 :], q0, rtol=1e-13)
+
+    def test_b7_constant_flux_pure_shock_known_answer_vg(self):
+        """B7 (vG): constant-flux pure-shock arrival for van Genuchten, own hardcoded literal.
+
+        vG analogue of B6 with the same ``q0 = 0.002`` and ``V_out = θ_s · 0.5``.
+        The arrival θ is ``V_out · C_T(q0) / q0`` with vG ``C_T(q0) = Δθ · S_e(q0)``
+        and ``S_e(q0)`` from ``K_M(S_e) = q0``; the hand-derived literal is
+        ``11.875931658164122`` (mpmath, 50 digits). Tolerance brentq-bounded.
+        """
+        n = 400
+        tedges = _make_tedges(n)
+        q0 = 0.002  # PINNED
+        v_out_val = O05_VG["theta_s"] * 0.5  # PINNED
+        q_wt, structures = root_zone_to_water_table_kinematic_wave(
+            q_root_zone=np.full(n, q0),
+            tedges=tedges,
+            q_water_table_tedges=tedges,
+            cumulative_pore_volumes_outlet=np.array([v_out_val]),
+            **O05_VG,
+        )
+        # Hand-derived vG arrival θ (mpmath, 50 digits).
+        np.testing.assert_allclose(structures[0]["theta_first_arrival"], 11.875931658164122, rtol=1e-12)
+        partial = np.where((q_wt > 1e-12) & (q_wt < q0 * (1.0 - 1e-9)))[0]
+        assert partial.size == 1, f"expected exactly one partial bin in a clean 0→q0 step, got {partial.size}"
+        k = int(partial[0])
+        np.testing.assert_array_equal(q_wt[:k], np.zeros(k))
+        np.testing.assert_allclose(q_wt[k + 1 :], q0, rtol=1e-12)
+
     def test_b5a_compute_domain_mass_against_analytic_steady_state(self):
         """B5a: ``compute_domain_mass`` against analytic steady-state, *not* the conservation tautology.
 
@@ -223,43 +485,106 @@ class TestEndToEnd:
         )
         np.testing.assert_allclose(numerical_domain_mass, analytic_domain_mass, rtol=1e-13)
 
-    def test_b5a_universal_ibp_integrator_active_in_rarefaction(self):
-        """B5a-aux: ``compute_domain_mass`` over a rarefaction interior exercises the IBP integrator
-        (not just the constant-region path).
+    @staticmethod
+    def _assert_domain_mass_straddling_rarefaction(sorption_kwargs, theta_probe, rtol):
+        """Drive a fan that STRADDLES ``v_outlet`` and quantitatively pin the IBP integrator.
 
-        Drives a wetting then drying sequence so a rarefaction fan forms inside the column.
-        At the chosen final θ, the rarefaction is fully inside the column with a known
-        ``c_head`` and ``c_tail``, and ``compute_domain_mass`` invokes the IBP
-        ``_integrate_rarefaction_spatial_universal``. Compares the IBP integrator output
-        against an independent trapezoidal-rule integration of the self-similar fan
-        ``c(u) = sorption.concentration_from_retardation(kappa / u)``.
+        Wet-then-dry forcing emits a bare rarefaction. At ``theta_probe`` the fan
+        straddles the outlet (``v_tail < v_outlet < v_head``), so
+        :func:`compute_domain_mass` partitions ``[0, v_outlet]`` into a constant
+        upstream region ``[0, v_tail]`` at ``c_tail`` plus the fan interior
+        ``[v_tail, v_outlet]`` — the latter routed through the universal IBP
+        antiderivative ``_integrate_rarefaction_spatial_universal`` (the
+        constant region is NOT). The reference is
+
+        ``C_T(c_tail)·v_tail + ∫_{v_tail}^{v_outlet} C_T(c(v)) dv``,
+
+        with the integral an INDEPENDENT trapezoidal rule over
+        :func:`concentration_at_point` on a fine v-grid — so it exercises the IBP
+        integrator (not just the constant-region ``C_T·Δv`` path).
+
+        Parameters
+        ----------
+        sorption_kwargs : dict
+            Constitutive-model keyword arguments forwarded to the solver.
+        theta_probe : float
+            Cumulative flow at which the fan straddles the outlet (asserted).
+        rtol : float
+            Relative tolerance: trapezoid truncation for the closed-form
+            Brooks-Corey path, brentq-bounded for van Genuchten.
         """
         n = 200
         tedges = _make_tedges(n)
         q_root = np.zeros(n)
-        q_root[:50] = 0.002  # wet phase
-        # day 50+: drying — q drops to a tiny but positive value (avoids degenerate clean-water)
-        q_root[50:] = 0.0002
-        z_wt = 0.5
-        v_out_val = O05["theta_s"] * z_wt
-        _, structures = root_zone_to_water_table_kinematic_wave(
-            q_root_zone=q_root,
-            tedges=tedges,
-            q_water_table_tedges=tedges,
-            cumulative_pore_volumes_outlet=np.array([v_out_val]),
-            **O05,
-        )
-        # Verify a rarefaction was created.
-        assert structures[0]["n_rarefactions"] >= 1, "Expected at least one rarefaction after the drying step"
+        q_root[:50] = 0.003  # wet phase: wetting-front shock
+        q_root[50:] = 0.0005  # drying phase: emits a rarefaction
+        v_out_val = sorption_kwargs["theta_s"] * 0.5  # outlet inside the fan's straddle window
+        with warnings.catch_warnings():
+            # Long-tail forcing pushes some output θ-bins past the inlet window;
+            # the resulting back-transform warning is incidental here (we read the
+            # wave list / compute_domain_mass directly, not the bin-average).
+            warnings.simplefilter("ignore")
+            _, structures = root_zone_to_water_table_kinematic_wave(
+                q_root_zone=q_root,
+                tedges=tedges,
+                q_water_table_tedges=tedges,
+                cumulative_pore_volumes_outlet=np.array([v_out_val]),
+                **sorption_kwargs,
+            )
+        assert structures[0]["n_rarefactions"] >= 1, "Expected a rarefaction after the drying step"
         state = structures[0]["tracker_state"]
-        # The domain mass at the final θ is non-trivial; just confirm it's positive and finite.
-        theta_final = state.theta_current
-        mass = compute_domain_mass(theta=theta_final, v_outlet=v_out_val, waves=state.waves, sorption=state.sorption)
-        assert np.isfinite(mass)
-        assert mass > 0
-        # Independent check: compute_cumulative_inlet_mass minus compute_domain_mass should equal
-        # what's exited — but this IS the conservation identity. The non-tautological test is the
-        # primary test above. Here we just sanity-check that the IBP path is reachable (n_rarefactions >= 1).
+        sorption = state.sorption
+        rarefactions = [w for w in state.waves if isinstance(w, RarefactionWave) and w.was_active_at(theta_probe)]
+        assert rarefactions, "Expected an active bare RarefactionWave at theta_probe"
+        rw = rarefactions[0]
+        v_tail = rw.tail_position_at_theta(theta_probe)
+        v_head = rw.head_position_at_theta(theta_probe)
+        assert v_tail is not None
+        assert v_head is not None
+        # The fan must STRADDLE v_outlet, else the IBP integrator is not exercised.
+        assert v_tail < v_out_val < v_head, (
+            f"fan must straddle v_outlet={v_out_val}: got v_tail={v_tail}, v_head={v_head} at θ={theta_probe}"
+        )
+
+        # Independent reference: constant upstream region at c_tail + trapezoidal
+        # integration of the fan interior over [v_tail, v_outlet]. The trapezoid
+        # over concentration_at_point is independent of the IBP antiderivative.
+        m_constant = float(sorption.total_concentration(rw.c_tail)) * v_tail
+        v_grid = np.linspace(v_tail, v_out_val, 4001)
+        c_grid = np.array([concentration_at_point(float(v), theta_probe, state.waves, sorption) for v in v_grid])
+        ct_grid = np.array([float(sorption.total_concentration(float(c))) for c in c_grid])
+        m_fan_ref = float(np.trapezoid(ct_grid, v_grid))
+        m_reference = m_constant + m_fan_ref
+        # Sanity: the fan term is a non-trivial share of the total (so a κ-mutation
+        # in the IBP antiderivative materially shifts the result).
+        assert m_fan_ref > 0.1 * m_reference, "fan-interior term is too small to exercise the IBP integrator"
+
+        m_domain = compute_domain_mass(theta=theta_probe, v_outlet=v_out_val, waves=state.waves, sorption=sorption)
+        np.testing.assert_allclose(m_domain, m_reference, rtol=rtol)
+
+    def test_b5a_universal_ibp_integrator_active_in_rarefaction_bc(self):
+        """B5a-aux (BC): ``compute_domain_mass`` over a straddling fan exercises the IBP integrator.
+
+        At ``θ = 18.7`` the bare drying rarefaction straddles ``v_outlet = θ_s·0.5``,
+        so ``compute_domain_mass`` routes ``[v_tail, v_outlet]`` through the
+        universal IBP antiderivative ``_integrate_rarefaction_spatial_universal``.
+        Compared against an independent ``np.trapezoid`` over
+        :func:`concentration_at_point` (4001 points). ``rtol = 1e-6`` accommodates
+        the trapezoid truncation; the verified baseline relerr is ≈ 5e-10. A
+        ``κ → 0.5·κ`` mutation in the antiderivative ``g = C_T·u − κ·c`` shifts the
+        fan term by ~4% and fails this bound.
+        """
+        self._assert_domain_mass_straddling_rarefaction(O05, theta_probe=18.7, rtol=1e-6)
+
+    def test_b5a_universal_ibp_integrator_active_in_rarefaction_vg(self):
+        """B5a-aux (vG): the straddling-fan IBP-integrator check for van Genuchten.
+
+        vG counterpart of the BC test at ``θ = 20.0`` (where the fan straddles
+        ``v_outlet = θ_s·0.5``). The fan-interior ``c(v)`` inversion uses brentq,
+        so the tolerance is brentq-bounded; the verified baseline relerr is
+        ≈ 6e-10 (trapezoid- and brentq-limited), comfortably under ``rtol = 1e-6``.
+        """
+        self._assert_domain_mass_straddling_rarefaction(O05_VG, theta_probe=20.0, rtol=1e-6)
 
     def test_b5b_multi_pulse_smoke_no_crash(self):
         """B5b (multi-pulse): smoke test — multi-pulse input doesn't crash the solver.
@@ -398,51 +723,35 @@ class TestKScaling:
 
 
 # =============================================================================
-# Section D — vG article reproducibility
+# Section D — vG characteristic-speed monotonicity (property test)
 # =============================================================================
 
 
-class TestArticleReproducibility:
-    """D-series tests: comparison against the article's published vG characteristic speeds."""
+class TestCharacteristicSpeedMonotonicity:
+    """D-series: vG characteristic speeds increase monotonically with θ (property test).
 
-    def test_d2_tail_rarefaction_speeds_match_article(self):
-        """D2: ``V_c(θ) = 1/R(K_vG(θ))`` at θ ∈ {0.11, 0.09, 0.06, 0.04} from Afbeelding 4 / 6.
+    The previous D2 also asserted a 5×-vs-article band against the article's
+    plotted vG curve (``n_vG`` not pinned to the Heinen 2020 Staringreeks row).
+    A factor-of-5 "agreement" is not evidence and was dropped (PERC-M4); the
+    quantitative ground-truth for the vG curve now lives in the hand-derived
+    ``_k_se`` literals (``TestConstitutiveGroundTruth.test_a4_*``). What remains
+    here is the genuine structural property: ``V_c(θ) = 1/R(K_vG(θ))`` must be
+    strictly monotone increasing in θ.
+    """
 
-        The article reports for soil O05 (coarse sand):
-        - V(0.11) = 6.4 cm/d
-        - V(0.09) = 3.35 cm/d
-        - V(0.06) = 1.37 cm/d
-        - V(0.04) = 0.31 cm/d
+    def test_d2_characteristic_speeds_monotone_increasing_with_theta(self):
+        """D2: ``V_c(θ) = 1/R(K_vG(θ))`` is strictly increasing in θ (wetter soil drains faster).
 
-        These are from the article's plotted vG curve fit. The Heinen 2020
-        Staringreeks vG parameters for O05 are not pinned in v1 — we use
-        ``n_vG = 2.28`` (a plausible coarse-sand value) and assert ~50%
-        tolerance to acknowledge the article-vs-Staringreeks-fit residual.
-        The point of the test is structural: characteristic speeds should
-        increase monotonically with θ; an exact match would require either
-        recalibrating ``n_vG`` to match the article's plotted curve or
-        using the exact Heinen 2020 row (deferred to a follow-up).
+        Pure monotonicity property — no article-band comparison. Spans a wide θ
+        range so the check is non-trivial; wetter soil (higher θ, higher K)
+        must have a faster characteristic speed.
         """
         sorption = VanGenuchtenMualemConductivity(**O05_VG)
-        # Convert θ to K via the constitutive curve, then look up R, then V_c = 1/R.
-        theta_values = np.array([0.11, 0.09, 0.06, 0.04])
-        # K_vG at each θ: solve forward (not inverse).
+        theta_values = np.array([0.04, 0.06, 0.09, 0.11, 0.15, 0.20])  # increasing θ
         s_e = (theta_values - O05_VG["theta_r"]) / (O05_VG["theta_s"] - O05_VG["theta_r"])
         k_values = np.array([sorption._k_se(float(s)) for s in s_e])  # noqa: SLF001
-        r_values = sorption.retardation(k_values)
-        v_c_cm_per_day = 100.0 * (1.0 / r_values)  # convert m/day → cm/day
-        article_values = np.array([6.4, 3.35, 1.37, 0.31])
-        # Monotone-increasing check (structural):
-        assert np.all(np.diff(v_c_cm_per_day) < 0), (
-            f"Characteristic speeds should be monotone decreasing with decreasing θ; got {v_c_cm_per_day}"
-        )
-        # Order-of-magnitude agreement with article (50% tolerance reflects the
-        # article-vs-Staringreeks-fit residual identified in physics-math review).
-        # If a closer Heinen 2020 fit becomes available, tighten this in v2.
-        rel_err = np.abs(v_c_cm_per_day - article_values) / article_values
-        assert rel_err.max() < 5.0, (
-            f"vG with n_vG=2.28 should be within 5× of article's plotted speeds; got rel_err={rel_err}"
-        )
+        v_c = 1.0 / sorption.retardation(k_values)
+        assert np.all(np.diff(v_c) > 0), f"characteristic speed V_c = 1/R must increase strictly with θ; got {v_c}"
 
 
 # =============================================================================
@@ -506,20 +815,65 @@ class TestMissingCoverage:
     """M-series tests: dry days, saturation, idempotence, sign-flip invariance, two-step ramp."""
 
     def test_m2_dry_days_handled(self):
-        """M2: dry intervals (q=0) interspersed with positive q → no NaN, no crash."""
+        """M2: dry intervals (q=0) interspersed with positive q → no NaN/inf, physical bounds hold.
+
+        Constructs a wet-then-dry-then-wet sequence on a short column so the
+        signal exits *inside* the inlet θ-window (PERC-M2 regime). Asserts the
+        physical bounds ``0 ≤ q_wt ≤ q_root.max()`` (a flux at the water table can
+        neither go negative nor exceed the largest root-zone leakage), not merely
+        the absence of NaN/inf. The clamp-to-zero ``UserWarning`` is exercised
+        separately by ``test_m2b_no_clamp_warning_inside_inlet_window``.
+        """
         tedges = _make_tedges(60)
         q_root = np.full(60, 0.001)
-        q_root[20:30] = 0.0  # dry period
-        v_out = np.array([O05["theta_s"] * 0.5])
-        q_wt, _ = root_zone_to_water_table_kinematic_wave(
-            q_root_zone=q_root,
-            tedges=tedges,
-            q_water_table_tedges=tedges,
-            cumulative_pore_volumes_outlet=v_out,
-            **O05,
-        )
+        q_root[20:30] = 0.0  # dry period (full zero — the genuine dry-days case)
+        v_out = np.array([O05["theta_s"] * 0.3])
+        # The full-zero dry gap pushes the drying tail past the inlet window,
+        # tripping the benign out-of-window clamp warning (the subject of M2b,
+        # which uses an in-window forcing). Match it explicitly via pytest.warns
+        # rather than blanket-silencing, so any unrelated new warning still
+        # surfaces as an error here.
+        with pytest.warns(UserWarning, match="clamp threshold"):
+            q_wt, _ = root_zone_to_water_table_kinematic_wave(
+                q_root_zone=q_root,
+                tedges=tedges,
+                q_water_table_tedges=tedges,
+                cumulative_pore_volumes_outlet=v_out,
+                **O05,
+            )
         assert not np.any(np.isnan(q_wt))
         assert not np.any(np.isinf(q_wt))
+        # Physical bounds: 0 ≤ q_wt ≤ q_root.max(). The upper edge can sit a few
+        # ULPs above q_root.max() where the bin-average grazes the steady plateau.
+        assert np.all(q_wt >= 0.0), f"q_wt went negative: min={q_wt.min()}"
+        assert np.all(q_wt <= q_root.max() + 1e-12), f"q_wt exceeded q_root.max(): max={q_wt.max()}"
+
+    def test_m2b_no_clamp_warning_inside_inlet_window(self):
+        """M2b: a wet-then-dry run *inside* the inlet θ-window emits no clamp-to-zero ``UserWarning``.
+
+        The benign FP guard at ``advection.py`` clamps tiny negative bin-averages
+        to zero and warns when output θ-bins exceed the inlet window (inconsistent
+        θ ranges). Per the physics review this is NOT a code bug and must not be
+        NaN-masked; the fix is to keep the response inside the inlet window. This
+        test pins that contract: a wet-then-dry sequence on a short column,
+        executed under ``warnings.simplefilter("error")``, must complete without
+        raising any ``UserWarning``.
+        """
+        n = 200
+        tedges = _make_tedges(n)
+        q_root = np.zeros(n)
+        q_root[:30] = 0.003  # wet phase
+        q_root[30:] = 0.0008  # dry phase (small but positive → column stays wet, θ bounded)
+        v_out = np.array([O05["theta_s"] * 0.2])  # short column: signal exits within the inlet window
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any UserWarning becomes an exception
+            root_zone_to_water_table_kinematic_wave(
+                q_root_zone=q_root,
+                tedges=tedges,
+                q_water_table_tedges=tedges,
+                cumulative_pore_volumes_outlet=v_out,
+                **O05,
+            )
 
     @pytest.mark.parametrize(
         ("f_val", "q_factor", "should_raise"),
@@ -581,16 +935,20 @@ class TestMissingCoverage:
         np.testing.assert_array_equal(q1, q2)
 
     def test_m6_sign_flip_invariance(self):
-        """M6: under K-scaling, the inlet-θ inversion uses ``q/f``, not ``q·f``.
+        """M6: under K-scaling the OUTPUT back-transform ``q_wt = f·cout`` is correctly oriented.
 
-        A bug pairing ``cin = q·f`` with ``q_wt = cout/f`` cancels in mass balance and
-        in C2's time-rescaling. Catch: at steady state, ``q_water_table(steady) ≈
-        q_root_zone(steady)`` regardless of scaling — provided the inversion is
-        consistent.
+        The percolation wrapper inverts the inlet as ``cin = q/f`` and recovers
+        the outlet as ``q_wt = f·cout``. The *inlet* leg (``q/f`` vs ``q·f``) is
+        what C2's time-rescaling identity guards (the arrival θ shifts under a
+        wrong inlet inversion). This test guards the *output* leg: a bug pairing
+        the correct inlet ``cin = q/f`` with a wrong output ``q_wt = cout/f``
+        cancels in C2 and in mass balance, but breaks the steady-state amplitude.
 
-        Concrete check: run with ``k_scaling = 2.0`` (constant) and constant q_root.
-        After the wetting front passes the outlet, ``q_water_table → q_root_zone``
-        exactly (steady state is preserved under any time-only K-scaling).
+        Concrete check: run with constant ``k_scaling = 2.0`` and constant
+        ``q_root``. Once the wetting front passes the outlet, ``q_water_table``
+        must return to ``q_root_zone`` exactly — steady state is preserved under
+        any time-only K-scaling only if the back-transform multiplies (not
+        divides) by ``f``.
         """
         n = 365
         tedges = _make_tedges(n)
@@ -607,7 +965,7 @@ class TestMissingCoverage:
         )
         # The last 50 days should be at steady state ≈ q_root_val.
         steady_state = q_wt[-50:].mean()
-        np.testing.assert_allclose(steady_state, q_root_val, rtol=1e-10)
+        np.testing.assert_allclose(steady_state, q_root_val, rtol=1e-13)
 
     def test_m7_two_step_ramp_shock_speed(self):
         """M7: shock between two non-zero levels uses Rankine-Hugoniot ``ΔK/Δθ``, not ``dK/dθ``.
@@ -789,11 +1147,13 @@ class TestShippedCollisionBugRegression:
 
         # Sample the arrival bin (straddles the front jump → largest trapezoid
         # error) plus four spread-out bins covering the DSW-controlled and
-        # steady regimes.
+        # steady regimes. 2001 sample points keep the trapezoid error ≈ 4e-14
+        # (≪ rtol=1e-3) even across the arrival jump, while a 5% bin-average
+        # overshoot — the shipped-bug symptom — still fails at rtol=1e-3.
         idx = [int(eligible[0]), *(int(eligible[j]) for j in np.linspace(1, eligible.size - 1, 4).astype(int))]
         for k in idx:
             t_lo, t_hi = out_days[k], out_days[k + 1]
-            tt = np.linspace(t_lo, t_hi, 20001)
+            tt = np.linspace(t_lo, t_hi, 2001)
             c_exact = np.array([
                 concentration_at_point(v_out_val, state.theta_at_t(float(t)), state.waves, state.sorption) for t in tt
             ])
@@ -804,3 +1164,93 @@ class TestShippedCollisionBugRegression:
                 rtol=1e-3,
                 err_msg=f"bin {k}: bin-average {q_wt[k]:.6e} vs flow-weighted exact {mean_exact:.6e}",
             )
+
+
+# =============================================================================
+# Section P — Transient global mass balance
+# =============================================================================
+#
+# Reuses the Plan 1 independent-reference pattern: m_in and m_out are summed
+# DIRECTLY from the public-API arrays (q_root_zone, q_water_table) — never from
+# the solver's internal mass functions — and only the *stored* term reads
+# compute_domain_mass.
+#
+# UNITS: the percolation public API is in water-depth flux [m/day], not solute
+# mass. With Δt in days, m_in = Σ q_root·Δt and m_out = Σ q_wt·Δt are both in
+# metres of water depth.
+#
+# STORED-TERM SCALING (physics-verified): compute_domain_mass integrates the
+# conserved storage C_T = θ − θ_r over the solver V-coordinate, where dV = θ_s·dz.
+# It therefore returns θ_s × the physical stored depth, so the closing term is
+# compute_domain_mass(θ) / θ_s (DIVIDE). Multiplying by θ_s, or omitting the
+# factor, leaves an O(0.03–0.1) residual — both are plausible-looking traps.
+
+
+class TestTransientMassBalance:
+    """P-series: transient global water-balance closure for percolation (BC and vG)."""
+
+    # Wet-then-dry forcing whose response exits *inside* the inlet θ-window
+    # (avoids the out-of-window degradation regime). The "dry" phase is small but
+    # positive so the column stays wet and the final θ stays bounded.
+    _WET_THEN_DRY = np.array([0.003] * 30 + [0.0008] * 170)
+    _Z_WT = 0.2  # short column [m]
+    _DT_DAYS = 1.0
+
+    def _run(self, sorption_kwargs):
+        q_root = self._WET_THEN_DRY
+        n = len(q_root)
+        tedges = _make_tedges(n)
+        v_out_val = sorption_kwargs["theta_s"] * self._Z_WT
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            q_wt, structures = root_zone_to_water_table_kinematic_wave(
+                q_root_zone=q_root,
+                tedges=tedges,
+                q_water_table_tedges=tedges,
+                cumulative_pore_volumes_outlet=np.array([v_out_val]),
+                **sorption_kwargs,
+            )
+        return q_root, q_wt, structures[0]["tracker_state"], v_out_val
+
+    def test_p1_global_water_balance_bc_closed_form(self):
+        """P1 (BC): ``Σ q_root·Δt == Σ q_wt·Δt + compute_domain_mass(θ)/θ_s`` to machine precision.
+
+        Brooks-Corey is closed-form throughout, so the balance closes at
+        ``rtol ≈ 1e-12`` (the verified residual is ≈ 5e-17). The stored term
+        DIVIDES ``compute_domain_mass`` by ``θ_s`` (see module note); the
+        ``×θ_s`` and ``×1`` traps are checked explicitly below to fail.
+        """
+        q_root, q_wt, state, v_out_val = self._run(O05)
+        theta_s = O05["theta_s"]
+        theta_query = float(state.theta_edges[-1])  # end of the inlet window
+        m_in = float(np.sum(q_root) * self._DT_DAYS)
+        m_out = float(np.sum(q_wt) * self._DT_DAYS)
+        m_dom = compute_domain_mass(theta=theta_query, v_outlet=v_out_val, waves=state.waves, sorption=state.sorption)
+        stored = m_dom / theta_s  # DIVIDE — physics-verified
+        np.testing.assert_allclose(m_in, m_out + stored, rtol=1e-12)
+        # The two plausible-but-wrong scalings must NOT close.
+        assert not np.isclose(m_in, m_out + m_dom, rtol=1e-6), "m_dom (no θ_s factor) should not close the balance"
+        assert not np.isclose(m_in, m_out + m_dom * theta_s, rtol=1e-6), "m_dom·θ_s should not close the balance"
+
+    def test_p2_global_water_balance_vg_exact_branch(self):
+        """P2 (vG, ``mualem_l = 0``): the exact-branch global water balance closes to ``rtol ≈ 1e-12``.
+
+        The Burdine (``L = 0``) vG branch has a closed-form ``S_e(C)`` inverse and
+        is free of root-finding, so the balance closes to machine precision
+        (verified residual ≈ 3e-17). This is the only end-to-end conservation
+        test on the vG exact branch (vG otherwise appears in B1/B3'/B7/D2).
+        """
+        vg_l0 = {
+            "theta_r": O05_VG["theta_r"],
+            "theta_s": O05_VG["theta_s"],
+            "k_s": O05_VG["k_s"],
+            "van_genuchten_n": O05_VG["van_genuchten_n"],
+            "van_genuchten_l": 0.0,
+        }
+        q_root, q_wt, state, v_out_val = self._run(vg_l0)
+        theta_s = vg_l0["theta_s"]
+        theta_query = float(state.theta_edges[-1])
+        m_in = float(np.sum(q_root) * self._DT_DAYS)
+        m_out = float(np.sum(q_wt) * self._DT_DAYS)
+        m_dom = compute_domain_mass(theta=theta_query, v_outlet=v_out_val, waves=state.waves, sorption=state.sorption)
+        np.testing.assert_allclose(m_in, m_out + m_dom / theta_s, rtol=1e-12)


### PR DESCRIPTION
## Summary

Anchors the Brooks-Corey / van Genuchten constitutive curves to hand-derived literals (catches a Mualem↔Burdine exponent swap and a dropped Mualem square that the self-consistent end-to-end pipeline otherwise passes). Adds a transient global water balance with `stored = compute_domain_mass / θ_s` (the θ_s and ×1 traps are asserted not to close) and a vG exact-branch check; rewrites the IBP-integrator test to actually exercise `_integrate_rarefaction_spatial_universal` on a fan straddling the outlet vs an independent trapezoid reference. Adds constant-flux pure-shock and bare-rarefaction self-similarity known-answers (BC + vG); splits D2 into a monotonicity property test; tightens M6.

Reviewed by four agents; the literals were independently re-derived to 50 digits and the fan-integrator test is mutation-verified (κ→0.5κ caught). Test-only.

## Test plan

- `pytest tests/src/test_percolation.py` — 42 passed.
- Mutation-verified: Mualem→Burdine swap and dropped Mualem square caught by the literals; κ→0.5κ caught by the rewritten B5a test.
- `ruff`/`ty` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.