### PR TITLE
refactor(utils): consolidate tedges->days and cumulative-flow-volume idioms (#185, #186)

### DIFF
--- a/src/gwtransport/_time.py
+++ b/src/gwtransport/_time.py
@@ -1,0 +1,63 @@
+"""
+Time-axis conversion atoms for transport-module entry points.
+
+The transport modules in :mod:`gwtransport.advection`,
+:mod:`gwtransport.diffusion`, :mod:`gwtransport.diffusion_fast`,
+:mod:`gwtransport.deposition`, and :mod:`gwtransport.residence_time` repeatedly
+convert a :class:`pandas.DatetimeIndex` of bin edges into a float64 array of
+days relative to a reference timestamp. The two helpers here factor that
+idiom once so the conversion (and its object-dtype-on-old-pandas contract)
+lives in a single place.
+
+Both helpers return ``float64`` arrays. ``tedges_to_days`` measures each edge
+relative to ``ref`` (defaulting to the first edge); ``dt_to_days`` returns the
+successive bin widths in days. The ``ref`` keyword is load-bearing: cross-array
+conversions (e.g. output edges measured against the input-flow reference) must
+share a common origin.
+
+This module has no public API; importers are the transport modules themselves
+plus ``tests/src/test_utils.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+
+def tedges_to_days(tedges: pd.DatetimeIndex, *, ref: pd.Timestamp | None = None) -> npt.NDArray[np.floating]:
+    """Convert time-bin edges to days relative to a reference timestamp.
+
+    Parameters
+    ----------
+    tedges : DatetimeIndex
+        Time-bin edges to convert.
+    ref : Timestamp or None, optional
+        Reference timestamp mapped to day zero. Defaults to ``tedges[0]`` when
+        ``None``. Pass a shared reference when converting a second edge array
+        that must align to the same origin.
+
+    Returns
+    -------
+    ndarray
+        Float64 array of days since ``ref``, one value per edge.
+    """
+    origin = tedges[0] if ref is None else ref
+    return ((tedges - origin) / pd.Timedelta(days=1)).to_numpy(dtype=float)
+
+
+def dt_to_days(t: pd.DatetimeIndex) -> npt.NDArray[np.floating]:
+    """Convert successive time-bin widths to days.
+
+    Parameters
+    ----------
+    t : DatetimeIndex
+        Time-bin edges (n+1 edges for n bins).
+
+    Returns
+    -------
+    ndarray
+        Float64 array of bin widths in days (length ``len(t) - 1``).
+    """
+    return (np.diff(t) / pd.Timedelta(days=1)).astype(float)

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -70,6 +70,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from gwtransport import gamma
+from gwtransport._time import tedges_to_days
 from gwtransport._validation import (
     _validate_no_nan,
     _validate_non_negative_array,
@@ -1204,7 +1205,7 @@ def _validate_front_tracking_inputs(
     pd.DatetimeIndex,
     npt.NDArray[np.float64],
     SorptionModel,
-    npt.NDArray[np.float64],
+    npt.NDArray[np.floating],
 ]:
     """Validate inputs and create sorption object for front tracking functions.
 
@@ -1249,7 +1250,7 @@ def _validate_front_tracking_inputs(
         raise ValueError(msg)
 
     # Convert cout_tedges to days (relative to tedges[0]) for output computation
-    cout_tedges_days = ((cout_tedges - tedges[0]) / pd.Timedelta(days=1)).values
+    cout_tedges_days = tedges_to_days(cout_tedges, ref=tedges[0])
 
     # Determine which sorption model is requested
     has_retardation = retardation_factor is not None
@@ -1545,7 +1546,7 @@ def infiltration_to_extraction_nonlinear_sorption(
     )
 
     # Flow time edges in days (same reference as cout_tedges_days)
-    flow_tedges_days = ((tedges - tedges[0]) / pd.Timedelta(days=1)).values
+    flow_tedges_days = tedges_to_days(tedges)
 
     # Each pore-volume bin from the gamma distribution is an equal-mass streamtube,
     # so all streamtubes carry equal flow at the outlet. The bundle outlet

--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -13,6 +13,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from gwtransport._time import tedges_to_days
 from gwtransport.residence_time import residence_time
 from gwtransport.utils import partial_isin
 
@@ -70,8 +71,8 @@ def _infiltration_to_extraction_weights(
         time-averaged extraction flow over their interval.
     """
     # Convert time edges to days
-    cin_tedges_days = ((tedges - tedges[0]) / pd.Timedelta(days=1)).values
-    cout_tedges_days = ((cout_tedges - tedges[0]) / pd.Timedelta(days=1)).values
+    cin_tedges_days = tedges_to_days(tedges)
+    cout_tedges_days = tedges_to_days(cout_tedges, ref=tedges[0])
 
     # Detect zero-flow cout bins: a cout bin is "zero-flow" when the time-
     # averaged extraction flow over its interval is zero. Compute via the

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -54,6 +54,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from gwtransport._time import tedges_to_days
 from gwtransport._validation import (
     _validate_no_nan,
     _validate_non_negative_array,
@@ -64,8 +65,8 @@ from gwtransport.advection_utils import _resolve_spinup_inputs
 from gwtransport.deposition_utils import compute_average_heights
 from gwtransport.residence_time import residence_time
 from gwtransport.utils import (
-    _make_strictly_monotone,
     compute_reverse_target,
+    cumulative_flow_volume,
     linear_interpolate,
     solve_tikhonov,
     solve_underdetermined_system,
@@ -184,8 +185,8 @@ def compute_deposition_weights(
     """
     # Convert to days relative to first time edge
     t0 = tedges[0]
-    tedges_days = ((tedges - t0) / pd.Timedelta(days=1)).values
-    cout_tedges_days = ((cout_tedges - t0) / pd.Timedelta(days=1)).values
+    tedges_days = tedges_to_days(tedges, ref=t0)
+    cout_tedges_days = tedges_to_days(cout_tedges, ref=t0)
 
     # Compute residence times and cumulative flow
     flow_values = np.asarray(flow)
@@ -199,7 +200,7 @@ def compute_deposition_weights(
     )
     cout_tedges_days_infiltration = cout_tedges_days - cout_rt_at_edges.squeeze(axis=0)
 
-    flow_cum = np.concatenate(([0.0], np.cumsum(flow_values * np.diff(tedges_days))))
+    flow_cum = cumulative_flow_volume(flow_values, np.diff(tedges_days))
 
     # Interpolate volumes at concentration time edges
     start_vol = linear_interpolate(x_ref=tedges_days, y_ref=flow_cum, x_query=cout_tedges_days_infiltration)
@@ -773,15 +774,14 @@ def spinup_duration(
     # exactly (no quantisation to flow_tedges spacing). Under constant flow
     # this matches V*R/Q.
     flow_arr = np.asarray(flow)
-    flow_tedges_days = np.asarray((flow_tedges - flow_tedges[0]) / np.timedelta64(1, "D"))
-    flow_cum = np.concatenate(([0.0], np.cumsum(flow_arr * np.diff(flow_tedges_days))))
+    flow_tedges_days = tedges_to_days(flow_tedges)
+    # Plateaus in flow_cum from Q = 0 bins make V → t inversion multi-valued; bump duplicates
+    # by the smallest representable amount so np.interp resolves consistently at plateau levels.
+    flow_cum = cumulative_flow_volume(flow_arr, np.diff(flow_tedges_days), strictly_monotone=True)
     target_cum = retardation_factor * float(aquifer_pore_volume)
     if not flow_cum[-1] >= target_cum:
         msg = "Residence time at the first time step is NaN. This indicates that the aquifer is not fully informed: flow timeseries too short."
         raise ValueError(msg)
-    # Plateaus in flow_cum from Q = 0 bins make V → t inversion multi-valued; bump duplicates
-    # by the smallest representable amount so np.interp resolves consistently at plateau levels.
-    flow_cum = _make_strictly_monotone(flow_cum)
     rt_value = float(linear_interpolate(x_ref=flow_cum, y_ref=flow_tedges_days, x_query=target_cum))
     if np.isnan(rt_value):
         msg = "Residence time at the first time step is NaN. This indicates that the aquifer is not fully informed: flow timeseries too short."

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -99,6 +99,7 @@ import pandas as pd
 from scipy import special
 
 from gwtransport import gamma
+from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport._validation import (
     _validate_no_nan,
     _validate_non_negative_array,
@@ -121,7 +122,7 @@ def _cfrac_mean_volume(
     step_widths: npt.NDArray[np.float64],
     cumulative_volume_at_cout_tedges: npt.NDArray[np.float64],
     cumulative_volume_at_cin_tedges: npt.NDArray[np.float64],
-    tedges_days: npt.NDArray[np.float64],
+    tedges_days: npt.NDArray[np.floating],
     molecular_diffusivity: float,
     longitudinal_dispersivity: float,
     r_vpv: float,
@@ -517,7 +518,7 @@ def _infiltration_to_extraction_coeff_matrix(
         ])
 
     # Compute the cumulative flow at tedges
-    infiltration_volume = flow * (np.diff(tedges) / pd.Timedelta("1D"))  # m3
+    infiltration_volume = flow * dt_to_days(tedges)  # m3
     cumulative_volume_at_cin_tedges = np.concatenate(([0], np.cumsum(infiltration_volume)))
 
     # Compute the cumulative flow at cout_tedges
@@ -545,7 +546,7 @@ def _infiltration_to_extraction_coeff_matrix(
     isactive = cout_tedges.to_numpy()[:, None] >= tedges.to_numpy()[None, :]
 
     # Convert tedges to days for volume→time interpolation
-    tedges_days_arr = ((tedges - tedges[0]) / pd.Timedelta("1D")).values.astype(float)
+    tedges_days_arr = tedges_to_days(tedges)
 
     # Loop over each pore volume
     for i_pv in range(len(aquifer_pore_volumes)):

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -77,6 +77,7 @@ from scipy import sparse
 from scipy.special import erf
 
 from gwtransport import gamma
+from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport.advection_utils import (
     _infiltration_to_extraction_weights,
     _resolve_spinup_inputs_wide_edges,
@@ -115,9 +116,9 @@ def _prepare_v_grid(
     tuple of ndarray
         ``(tedges_days, v_in_widedge_edges, v_in_natural_edges)``.
     """
-    weight_dt_days = (np.diff(weight_tedges) / pd.Timedelta("1D")).astype(float)
-    natural_dt_days = (np.diff(tedges) / pd.Timedelta("1D")).astype(float)
-    tedges_days = ((weight_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
+    weight_dt_days = dt_to_days(weight_tedges)
+    natural_dt_days = dt_to_days(tedges)
+    tedges_days = tedges_to_days(weight_tedges)
     v_in_widedge_edges = np.concatenate(([0.0], np.cumsum(flow * weight_dt_days)))
     v_in_natural_edges = np.concatenate(([0.0], np.cumsum(flow * natural_dt_days)))
     return tedges_days, v_in_widedge_edges, v_in_natural_edges
@@ -306,7 +307,7 @@ def infiltration_to_extraction(
         # Advect-then-smooth: pure advection produces ``cout_unsmoothed`` on
         # the output grid, then V-coord smoothing applies the dispersive
         # spread. The output-side V-grid and sigma_V are only needed here.
-        cout_tedges_days = ((cout_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
+        cout_tedges_days = tedges_to_days(cout_tedges, ref=weight_tedges[0])
         v_out_edges = np.interp(cout_tedges_days, tedges_days, v_in_widedge_edges)
         sigma_v_out = _compute_sigma_v(
             flow=np.asarray(flow_out, dtype=float),
@@ -544,7 +545,7 @@ def extraction_to_infiltration(
         w_forward = np.asarray(w_adv @ m_v_in)
     else:
         # Advect-then-smooth: W_forward = M_v_out @ w_adv
-        cout_tedges_days = ((cout_tedges - weight_tedges[0]) / pd.Timedelta("1D")).to_numpy(dtype=float)
+        cout_tedges_days = tedges_to_days(cout_tedges, ref=weight_tedges[0])
         v_out_edges = np.interp(cout_tedges_days, tedges_days, v_in_widedge_edges)
         sigma_v_out = _compute_sigma_v(
             flow=np.asarray(flow_out, dtype=float),

--- a/src/gwtransport/fronttracking/plot.py
+++ b/src/gwtransport/fronttracking/plot.py
@@ -17,6 +17,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 
+from gwtransport._time import tedges_to_days
 from gwtransport.fronttracking.output import concentration_at_point, identify_outlet_segments
 from gwtransport.fronttracking.solver import FrontTrackerState
 from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
@@ -791,7 +792,7 @@ def plot_front_tracking_summary(
         )
 
     if show_bin_averaged:
-        t_edges_days = ((cout_tedges - cout_tedges[0]) / pd.Timedelta(days=1)).values
+        t_edges_days = tedges_to_days(cout_tedges)
         xstep_cout, ystep_cout = step_plot_coords(t_edges_days, cout)
         ax_outlet.plot(
             xstep_cout,

--- a/src/gwtransport/fronttracking/solver.py
+++ b/src/gwtransport/fronttracking/solver.py
@@ -26,6 +26,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from gwtransport._time import tedges_to_days
 from gwtransport.fronttracking.events import (
     Event,
     EventType,
@@ -214,7 +215,7 @@ class FrontTracker:
             msg = "aquifer_pore_volume must be positive"
             raise ValueError(msg)
 
-        tedges_days = np.asarray((tedges - tedges[0]) / pd.Timedelta(days=1), dtype=float)
+        tedges_days = tedges_to_days(tedges)
         dt_days = np.diff(tedges_days)
         bin_volumes = flow * dt_days
         theta_edges = np.concatenate(([0.0], np.cumsum(bin_volumes)))

--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -35,7 +35,8 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
-from gwtransport.utils import _make_strictly_monotone, linear_average, linear_interpolate
+from gwtransport._time import tedges_to_days
+from gwtransport.utils import cumulative_flow_volume, linear_average, linear_interpolate
 
 
 def residence_time(
@@ -111,11 +112,10 @@ def residence_time(
         msg = "direction should be 'extraction_to_infiltration' or 'infiltration_to_extraction'"
         raise ValueError(msg)
 
-    flow_tedges_days = np.asarray((flow_tedges - flow_tedges[0]) / np.timedelta64(1, "D"))
-    flow_cum = np.concatenate(([0.0], np.cumsum(flow * np.diff(flow_tedges_days))))
+    flow_tedges_days = tedges_to_days(flow_tedges)
     # Plateaus in flow_cum from Q = 0 bins make V → t inversion multi-valued; bump duplicates
     # by the smallest representable amount so downstream np.interp resolves consistently.
-    flow_cum = _make_strictly_monotone(flow_cum)
+    flow_cum = cumulative_flow_volume(flow, np.diff(flow_tedges_days), strictly_monotone=True)
 
     if index is None:
         # Bin-center evaluation; for piecewise-linear V the midpoint of cumulative values
@@ -123,7 +123,7 @@ def residence_time(
         index_days = (flow_tedges_days[:-1] + flow_tedges_days[1:]) / 2
         flow_cum_at_index = (flow_cum[:-1] + flow_cum[1:]) / 2
     else:
-        index_days = np.asarray((index - flow_tedges[0]) / np.timedelta64(1, "D"))
+        index_days = tedges_to_days(pd.DatetimeIndex(index), ref=flow_tedges[0])
         flow_cum_at_index = linear_interpolate(
             x_ref=flow_tedges_days, y_ref=flow_cum, x_query=index_days, left=np.nan, right=np.nan
         )
@@ -279,16 +279,14 @@ def residence_time_mean(
         n_output_bins = len(tedges_out) - 1
         return np.full((n_pore_volumes, n_output_bins), np.nan)
 
-    flow_tedges_days = np.asarray((flow_tedges - flow_tedges[0]) / np.timedelta64(1, "D"))
-    tedges_out_days = np.asarray((tedges_out - flow_tedges[0]) / np.timedelta64(1, "D"))
-
-    flow_cum = np.concatenate(([0.0], np.cumsum(flow * np.diff(flow_tedges_days))))
+    flow_tedges_days = tedges_to_days(flow_tedges)
+    tedges_out_days = tedges_to_days(tedges_out, ref=flow_tedges[0])
 
     # Q = 0 produces plateaus in flow_cum that np.unique would collapse to a single grid point
     # in the augmented trapezoidal grid, smearing tau's step discontinuity at the kink. The
     # ulp-scale bump restores strict monotonicity; trapezoidal integration over the resulting
     # steep ramp recovers the underlying step exactly.
-    flow_cum = _make_strictly_monotone(flow_cum)
+    flow_cum = cumulative_flow_volume(flow, np.diff(flow_tedges_days), strictly_monotone=True)
 
     # Sign convention: with sign = -1 for extraction_to_infiltration and +1 for
     # infiltration_to_extraction, the look-back/forward target volume is

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -16,6 +16,10 @@ Available functions:
   array by ``k * ulp(max)`` so it becomes strictly monotone. Used before V → t inversions to
   prevent ``np.interp`` from silently picking one limit at plateau levels.
 
+- :func:`cumulative_flow_volume` - Cumulative infiltrated/extracted volume from per-bin flow
+  rates and bin widths, prepended with a leading zero. Optionally bumped to strict
+  monotonicity for V → t inversions.
+
 - :func:`linear_interpolate` - Linear interpolation using numpy's optimized interp function.
   Automatically handles unsorted data with configurable extrapolation (None for clamping,
   float for constant values). Handles multi-dimensional query arrays.
@@ -170,6 +174,41 @@ def _make_strictly_monotone(arr: npt.ArrayLike) -> npt.NDArray[np.floating]:
     last_nondup = np.maximum.accumulate(np.where(is_dup, -1, idx))
     cumcount = np.where(is_dup, idx - last_nondup, 0)
     return arr + cumcount * (_DUP_BUMP_ULPS * ulp_max)
+
+
+def cumulative_flow_volume(
+    flow: npt.ArrayLike, dt_days: npt.ArrayLike, *, strictly_monotone: bool = False
+) -> npt.NDArray[np.floating]:
+    """Cumulative infiltrated/extracted volume from per-bin flow rates.
+
+    Multiplies each per-bin flow rate by its bin width and accumulates, with a
+    leading zero prepended so the result has one entry per bin edge (n+1 values
+    for n bins). The result is the cumulative volume ``V`` at each time edge.
+
+    Parameters
+    ----------
+    flow : array-like
+        Flow rate per bin (m³/day), length n.
+    dt_days : array-like
+        Bin widths in days, length n (e.g. ``numpy.diff`` of edge days).
+    strictly_monotone : bool, optional
+        When ``True``, bump consecutive duplicates (plateaus from ``Q = 0``
+        bins) via :func:`_make_strictly_monotone` so the cumulative volume is
+        strictly increasing. Required before a V → t inversion; leave ``False``
+        when the plateaus must be preserved. Default is ``False``.
+
+    Returns
+    -------
+    ndarray
+        Cumulative volume at each edge (length ``len(flow) + 1``), starting at
+        zero.
+
+    See Also
+    --------
+    _make_strictly_monotone : Bump duplicates before V → t inversion.
+    """
+    flow_cum = np.concatenate(([0.0], np.cumsum(np.asarray(flow) * np.asarray(dt_days))))
+    return _make_strictly_monotone(flow_cum) if strictly_monotone else flow_cum
 
 
 def linear_interpolate(

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -8,10 +8,12 @@ import pandas as pd
 import pytest
 import requests.exceptions
 
+from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport.examples import generate_example_data, generate_example_deposition_timeseries
 from gwtransport.utils import (
     _make_strictly_monotone,
     combine_bin_series,
+    cumulative_flow_volume,
     get_soil_temperature,
     linear_average,
     linear_interpolate,
@@ -1336,3 +1338,124 @@ def test_generate_example_deposition_timeseries_seed_changes_output():
     s_a, _ = generate_example_deposition_timeseries(rng=1)
     s_b, _ = generate_example_deposition_timeseries(rng=2)
     assert not np.array_equal(s_a.to_numpy(), s_b.to_numpy())
+
+
+# ---------------------------------------------------------------------------
+# #186 guard: cumulative_flow_volume reproduces the consolidated inline idiom
+# ---------------------------------------------------------------------------
+
+
+def test_cumulative_flow_volume_matches_inline_form():
+    """The helper must reproduce ``concatenate([0], cumsum(flow*dt))`` bit-for-bit.
+
+    Uses non-uniform bin widths so the Δt-weighting (not just a bare cumsum) is
+    exercised: dropping the ``dt_days`` factor would change every value.
+    """
+    flow = np.array([2.0, 0.0, 5.0, 3.5, 1.25])
+    dt_days = np.array([1.0, 2.0, 0.5, 4.0, 1.0])
+    expected = np.concatenate(([0.0], np.cumsum(flow * dt_days)))
+    result = cumulative_flow_volume(flow, dt_days)
+    np.testing.assert_array_equal(result, expected)
+    # Leading zero and one value per edge (n+1 for n bins).
+    assert result[0] == 0.0
+    assert result.shape == (flow.size + 1,)
+
+
+def test_cumulative_flow_volume_strictly_monotone_matches_helper():
+    """``strictly_monotone=True`` must equal ``_make_strictly_monotone`` of the inline form.
+
+    The flow contains a ``Q = 0`` bin, so the inline cumulative volume has a
+    plateau; the helper must bump it identically to the standalone routine.
+    """
+    flow = np.array([3.0, 0.0, 0.0, 4.0, 1.0])
+    dt_days = np.array([1.0, 2.0, 1.5, 0.5, 3.0])
+    inline = np.concatenate(([0.0], np.cumsum(flow * dt_days)))
+    expected = _make_strictly_monotone(inline)
+    result = cumulative_flow_volume(flow, dt_days, strictly_monotone=True)
+    np.testing.assert_array_equal(result, expected)
+    # The plateau-bumping must actually have changed the array (otherwise the
+    # monotone branch is a no-op and the guard is vacuous).
+    assert not np.array_equal(inline, expected)
+
+
+# ---------------------------------------------------------------------------
+# #185 guard: tedges_to_days / dt_to_days are the single conversion idiom
+# ---------------------------------------------------------------------------
+
+
+def test_tedges_to_days_matches_reference_days():
+    """Calling the helper must yield the exact float64 days-since-ref array.
+
+    This is the #185 contract: the helper (not a re-spelling of pandas) maps
+    bin edges to days relative to the first edge.
+    """
+    tedges = pd.DatetimeIndex([
+        "2020-01-01",
+        "2020-01-02",
+        "2020-01-04",
+        "2020-02-01",
+        "2021-01-01",
+    ])
+    # Days from 2020-01-01: 0, 1, 3, 31, 366 (2020 is a leap year).
+    expected = np.array([0.0, 1.0, 3.0, 31.0, 366.0])
+    result = tedges_to_days(tedges)
+    np.testing.assert_array_equal(result, expected)
+    assert result.dtype == np.float64
+
+
+def test_tedges_to_days_ref_kwarg_shifts_origin():
+    """A shared ``ref`` re-bases the conversion; default ref is ``tedges[0]``."""
+    tedges = pd.DatetimeIndex(["2020-01-10", "2020-01-12", "2020-01-15"])
+    ref = pd.Timestamp("2020-01-01")
+    np.testing.assert_array_equal(tedges_to_days(tedges, ref=ref), np.array([9.0, 11.0, 14.0]))
+    # ref=None must equal ref=tedges[0].
+    np.testing.assert_array_equal(tedges_to_days(tedges), tedges_to_days(tedges, ref=tedges[0]))
+
+
+def test_tedges_to_days_dtype_contract_snapshot():
+    """The four pre-change spellings must all equal the helper bit-for-bit.
+
+    Locks the object-dtype-on-old-pandas contract #185 cites: ``.values``,
+    ``.to_numpy(dtype=float)``, ``.astype(float)``, ``.values.astype(float)``.
+    """
+    tedges = pd.DatetimeIndex(["2019-06-01", "2019-06-02", "2019-06-05", "2019-07-01"])
+    ref = tedges[0]
+    delta = (tedges - ref) / pd.Timedelta(days=1)
+    spellings = {
+        "values": delta.values,
+        "to_numpy(dtype=float)": delta.to_numpy(dtype=float),
+        "astype(float)": delta.astype(float),
+        "values.astype(float)": delta.values.astype(float),
+        "asarray/timedelta64": np.asarray((tedges - ref) / np.timedelta64(1, "D")),
+    }
+    helper = tedges_to_days(tedges)
+    for name, arr in spellings.items():
+        np.testing.assert_allclose(helper, arr, rtol=0, atol=0, err_msg=name)
+
+
+def test_tedges_to_days_timezone_invariance():
+    """tz-naive, UTC, and non-UTC edges must give bit-identical day arrays.
+
+    The package emits UTC-aware indices, so tz invariance is a real user path;
+    a ``tz_localize(None)`` slip inside the conversion would diverge here. The
+    span stays within a single DST regime (November, after the EU autumn
+    transition) so the local offset is constant and elapsed days are tz-label
+    independent.
+    """
+    naive = pd.DatetimeIndex(["2020-11-02", "2020-11-03", "2020-11-06", "2020-12-01"])
+    utc = naive.tz_localize("UTC")
+    other = naive.tz_localize("Europe/Amsterdam")
+    base = tedges_to_days(naive)
+    np.testing.assert_array_equal(tedges_to_days(utc), base)
+    np.testing.assert_array_equal(tedges_to_days(other), base)
+
+
+def test_dt_to_days_matches_reference_widths():
+    """``dt_to_days`` must return the exact float64 bin widths in days."""
+    tedges = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-04", "2020-02-01"])
+    expected = np.array([1.0, 2.0, 28.0])  # widths in days (Jan -> Feb 1 = 28 days)
+    result = dt_to_days(tedges)
+    np.testing.assert_array_equal(result, expected)
+    assert result.dtype == np.float64
+    # Consistency with tedges_to_days: widths are the successive differences.
+    np.testing.assert_array_equal(result, np.diff(tedges_to_days(tedges)))


### PR DESCRIPTION
## Summary

Behaviour-preserving DRY consolidation closing #185 and #186.

- New private `_time.py`: `tedges_to_days(tedges, *, ref=None)` and `dt_to_days(t)`, replacing the `(tedges - tedges[0]) / pd.Timedelta(days=1)` and `np.diff(tedges) / Timedelta` idioms across advection(_utils), deposition, diffusion(_fast), residence_time, and fronttracking/{plot,solver}.
- New `utils.cumulative_flow_volume(flow, dt_days, *, strictly_monotone=False)` replacing the `np.concatenate(([0.0], np.cumsum(flow*dt)))` (+ optional `_make_strictly_monotone`) idiom at 4 sites in deposition and residence_time.
- `solver.py`'s θ-cumsum and `diffusion_fast._prepare_v_grid` are intentionally left untouched (V/θ semantics).

## Test plan

- Every touched module's tests pass **unchanged**: residence_time + deposition (148), advection + diffusion(_fast) (322).
- New guard tests in `test_utils.py` call the helpers: equivalence vs the inline idiom, `ref`-origin, dtype-contract snapshot, tz invariance, monotone-bump.
- All conversion spellings confirmed bit-identical (`pd.Timedelta` variants + `np.timedelta64`).
- `ruff format`/`ruff check` clean; `ty check` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.