### PR TITLE
PR #223 review follow-up: strict spin-up guard, diffusion consolidation, guard-test docstrings

### DIFF
--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -775,13 +775,18 @@ def spinup_duration(
     # this matches V*R/Q.
     flow_arr = np.asarray(flow)
     flow_tedges_days = tedges_to_days(flow_tedges)
-    # Plateaus in flow_cum from Q = 0 bins make V → t inversion multi-valued; bump duplicates
-    # by the smallest representable amount so np.interp resolves consistently at plateau levels.
-    flow_cum = cumulative_flow_volume(flow_arr, np.diff(flow_tedges_days), strictly_monotone=True)
+    dt_days = np.diff(flow_tedges_days)
     target_cum = retardation_factor * float(aquifer_pore_volume)
-    if not flow_cum[-1] >= target_cum:
+    # Feasibility guard on the *un-bumped* cumulative total: the request is infeasible iff
+    # R*V_pore exceeds the true total infiltrated volume. (The monotone bump below would
+    # otherwise lift a trailing Q=0 plateau above target_cum and admit an infeasible request.)
+    flow_cum_raw = cumulative_flow_volume(flow_arr, dt_days)
+    if not flow_cum_raw[-1] >= target_cum:
         msg = "Residence time at the first time step is NaN. This indicates that the aquifer is not fully informed: flow timeseries too short."
         raise ValueError(msg)
+    # Plateaus in flow_cum from Q = 0 bins make V → t inversion multi-valued; bump duplicates
+    # by the smallest representable amount so np.interp resolves consistently at plateau levels.
+    flow_cum = cumulative_flow_volume(flow_arr, dt_days, strictly_monotone=True)
     rt_value = float(linear_interpolate(x_ref=flow_cum, y_ref=flow_tedges_days, x_query=target_cum))
     if np.isnan(rt_value):
         msg = "Residence time at the first time step is NaN. This indicates that the aquifer is not fully informed: flow timeseries too short."

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -108,7 +108,7 @@ from gwtransport._validation import (
     _validate_tedges_parity,
 )
 from gwtransport.residence_time import residence_time
-from gwtransport.utils import solve_inverse_transport
+from gwtransport.utils import cumulative_flow_volume, solve_inverse_transport
 
 # Numerical tolerance for coefficient sum to determine valid output bins
 EPSILON_COEFF_SUM = 1e-10
@@ -121,7 +121,7 @@ def _cfrac_mean_volume(
     *,
     step_widths: npt.NDArray[np.float64],
     cumulative_volume_at_cout_tedges: npt.NDArray[np.float64],
-    cumulative_volume_at_cin_tedges: npt.NDArray[np.float64],
+    cumulative_volume_at_cin_tedges: npt.NDArray[np.floating],
     tedges_days: npt.NDArray[np.floating],
     molecular_diffusivity: float,
     longitudinal_dispersivity: float,
@@ -518,8 +518,7 @@ def _infiltration_to_extraction_coeff_matrix(
         ])
 
     # Compute the cumulative flow at tedges
-    infiltration_volume = flow * dt_to_days(tedges)  # m3
-    cumulative_volume_at_cin_tedges = np.concatenate(([0], np.cumsum(infiltration_volume)))
+    cumulative_volume_at_cin_tedges = cumulative_flow_volume(flow, dt_to_days(tedges))  # m3
 
     # Compute the cumulative flow at cout_tedges
     cumulative_volume_at_cout_tedges = np.interp(cout_tedges, tedges, cumulative_volume_at_cin_tedges).astype(float)

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -1418,11 +1418,21 @@ def test_tedges_to_days_ref_kwarg_shifts_origin():
     np.testing.assert_array_equal(tedges_to_days(tedges), tedges_to_days(tedges, ref=tedges[0]))
 
 
-def test_tedges_to_days_dtype_contract_snapshot():
-    """The four pre-change spellings must all equal the helper bit-for-bit.
+def test_tedges_to_days_cross_array_ref_aligns_origins():
+    """A second edge array converted with ``ref=A[0]`` shares A's origin (the cin/cout pairing)."""
+    a = pd.DatetimeIndex(["2020-01-01", "2020-01-03"])
+    b = pd.DatetimeIndex(["2020-01-05", "2020-01-09"])
+    # b measured against a's origin: 4 and 8 days after a[0].
+    np.testing.assert_array_equal(tedges_to_days(b, ref=a[0]), np.array([4.0, 8.0]))
 
-    Locks the object-dtype-on-old-pandas contract #185 cites: ``.values``,
-    ``.to_numpy(dtype=float)``, ``.astype(float)``, ``.values.astype(float)``.
+
+def test_tedges_to_days_dtype_contract_snapshot():
+    """The five pre-change spellings must all equal the helper bit-for-bit.
+
+    A divisor/origin regression in the helper diverges from these independent spellings (a
+    days=1 -> days=2 swap is caught). The float64 cast in the helper is a no-op on modern
+    pandas but is a forward guard for the minimum-deps CI leg, where the timedelta quotient
+    could surface as object dtype (#185).
     """
     tedges = pd.DatetimeIndex(["2019-06-01", "2019-06-02", "2019-06-05", "2019-07-01"])
     ref = tedges[0]
@@ -1440,13 +1450,13 @@ def test_tedges_to_days_dtype_contract_snapshot():
 
 
 def test_tedges_to_days_timezone_invariance():
-    """tz-naive, UTC, and non-UTC edges must give bit-identical day arrays.
+    """tz-naive, UTC, and non-UTC edges give bit-identical day arrays on a no-DST span.
 
-    The package emits UTC-aware indices, so tz invariance is a real user path;
-    a ``tz_localize(None)`` slip inside the conversion would diverge here. The
-    span stays within a single DST regime (November, after the EU autumn
-    transition) so the local offset is constant and elapsed days are tz-label
-    independent.
+    The helper measures *absolute elapsed* days (instant differences over Timedelta), so it is
+    origin-relative but NOT wall-clock/tz-invariant across a DST boundary. This guard locks the
+    narrower realistic property: for a span with no DST transition (November) the local offset is
+    constant, so tz-naive, UTC, and the package's UTC-aware indices give identical elapsed days.
+    (It does not catch a ``tz_localize(None)`` slip, which preserves the elapsed-day spacing.)
     """
     naive = pd.DatetimeIndex(["2020-11-02", "2020-11-03", "2020-11-06", "2020-12-01"])
     utc = naive.tz_localize("UTC")


### PR DESCRIPTION
## Summary

Follow-up to the merged #223 (#185/#186 consolidation), which was merged before its optimizer + test-reviewer lenses finished. This lands their findings:

- **deposition.spinup_duration:** guard feasibility against the **un-bumped** cumulative total, restoring strict bit-identity at the raise boundary. In #223 the monotone bump runs before the guard, so a trailing Q=0 plateau could lift the total above `target_cum` and admit an otherwise-infeasible request (a ~3-ulp knife-edge, but a divergence from the pre-refactor behaviour).
- **diffusion:** consolidate the last inline cumulative-flow-volume site via `cumulative_flow_volume` (the one consolidation flagged as missed + safe), and widen `_cfrac_mean_volume`'s cumulative param to `npt.NDArray[np.floating]` to match the helper's return type.
- **test_utils:** add a cross-array `ref`-alignment guard; correct the tz-invariance docstring (the helper measures *absolute elapsed* days — origin-relative but not tz-invariant across DST) and the dtype-snapshot docstring (the float64 cast is a forward guard for the minimum-deps CI leg, not a no-op).

## Test plan

- `pytest` deposition spin-up + test_utils helper guards (tedges/dt/cumulative_flow_volume/cross-array-ref/dtype/tz) + a diffusion forward (`:521`) test — all green on current main.
- `ruff` + `ty` clean. Behaviour-preserving: the diffusion consolidation is bit-identical; the spin-up change only affects the previously-divergent unreachable knife-edge (now matches pre-refactor).

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.