### PR TITLE
rainfall: extracted-water temperature from rain + advective-heat mixing

### DIFF
--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -134,6 +134,14 @@ percolation
    :undoc-members:
    :show-inheritance:
 
+rainfall
+========
+
+.. automodule:: gwtransport.rainfall
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 residence_time
 ==============
 

--- a/docs/source/user_guide/assumptions.rst
+++ b/docs/source/user_guide/assumptions.rst
@@ -408,6 +408,7 @@ Data and Input Assumptions
 - :py:func:`~gwtransport.diffusion_fast.infiltration_to_extraction`
 - :py:func:`~gwtransport.deposition.deposition_to_extraction`
 - ``logremoval`` module (log-removal averaged across flow paths)
+- :py:func:`~gwtransport.rainfall.rainfall_to_extracted_temperature`
 
 **What this means:** The extraction well integrates flow from all contributing streamlines. There is no vertical stratification or preferential flow to specific screen intervals.
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -74,6 +74,9 @@ convention = "numpy"
 "src/gwtransport/advection.py" = [
     "DOC502",  # Public entry points document ValueError; the raises happen inside _validate_advection_inputs
 ]
+"src/gwtransport/rainfall.py" = [
+    "DOC502",  # Public entry points document ValueError; the raises happen inside _validate_rainfall_inputs
+]
 "src/gwtransport/fronttracking/*.py" = [
     # Physics module: docstrings intentionally use unicode symbols (θ, α, ρ, ×, ≤, ≥) for math notation.
     "RUF002",  # Ambiguous unicode in docstrings (greek letters / math symbols are intentional)

--- a/src/gwtransport/rainfall.py
+++ b/src/gwtransport/rainfall.py
@@ -1,0 +1,370 @@
+r"""
+Rainfall contribution to the temperature of extracted water.
+
+This module provides one public function:
+
+- :func:`rainfall_to_extracted_temperature` — temperature of extracted water
+  as an energy-conserving mix of advectively transported aquifer heat and the
+  heat carried by rain falling onto the infiltration footprint.
+
+Model
+-----
+The extracted-water temperature is the energy-weighted (volume-weighted) mean
+of two contributions per output bin:
+
+.. math::
+
+    T_\\text{ext} = \\frac{V_\\text{rain}\\,T_\\text{rain} + V_\\text{ext}\\,T_\\text{adv}}
+                         {V_\\text{rain} + V_\\text{ext}}
+
+where
+
+- ``T_adv`` is the temperature of the advectively transported aquifer water,
+  computed by treating heat as a retarded tracer through
+  :func:`gwtransport.advection.gamma_infiltration_to_extraction` (default
+  ``retardation_factor = 2.0`` for heat);
+- ``T_rain`` is the temperature of the rain water;
+- ``V_ext`` is the extracted water volume in the output bin (flow integrated
+  over the bin);
+- ``V_rain`` is the rain volume reaching the infiltration footprint over the
+  output bin, ``rainfall · infiltration_area · Δt``.
+
+Energy-conserving derivation and the rho*c cancellation
+-------------------------------------------------------
+Conservation of thermal energy for two streams that mix into one extracted
+stream is, writing :math:`\rho c` for the volumetric heat capacity
+(J m\ :sup:`-3` K\ :sup:`-1`) and taking a common reference temperature,
+
+.. math::
+
+    \rho c_\text{rain}\,V_\text{rain}\,T_\text{rain}
+      + \rho c_\text{water}\,V_\text{ext}\,T_\text{adv}
+    = \rho c_\text{mix}\,(V_\text{rain} + V_\text{ext})\,T_\text{ext}.
+
+Both contributions are liquid water, so :math:`\rho c_\text{rain} =
+\rho c_\text{water} = \rho c_\text{mix}` and the factor cancels exactly,
+leaving the volume-weighted mean above. The volumetric heat capacity is
+therefore **not** a parameter of this v1 function. Allowing a distinct
+rain heat capacity (:math:`\rho c_\text{rain} \ne \rho c_\text{water}`,
+e.g. for a different solute load) is a trivial future extension: reinstate
+the three :math:`\rho c` factors and they no longer cancel.
+
+The issue's original "energy per unit volume converted to Kelvin" formulation
+is dimensionally inconsistent (J m\ :sup:`-3` is not a temperature); the
+energy-weighted mean above is the dimensionally correct statement of the same
+intent.
+
+v1 mixing assumption
+--------------------
+Rain is blended with the advected aquifer water **at the extraction point**.
+This is a lumped simplification: in reality rain infiltrates at the surface,
+advects through the column, and exchanges heat with the matrix along the way.
+The lumped model is appropriate when the rain-contributed volume is a small
+perturbation on the extracted volume, or when only the bulk energy balance
+(not the in-column thermal history) is of interest. See
+:ref:`assumption-well-mixed-extraction`.
+
+Forward-only
+------------
+Only the forward (infiltration-to-extraction) direction is provided. The
+reverse problem is non-unique: a single extracted temperature constrains one
+equation but there are two temperature unknowns (the infiltration temperature
+feeding ``T_adv`` and the rain temperature ``T_rain``), so it cannot be
+inverted without additional assumptions.
+
+This file is part of gwtransport which is released under AGPL-3.0 license.
+See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
+"""
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+
+from gwtransport._time import tedges_to_days
+from gwtransport._validation import (
+    _validate_no_nan,
+    _validate_non_negative_array,
+    _validate_positive_scalar,
+    _validate_tedges_parity,
+)
+from gwtransport.advection import gamma_infiltration_to_extraction
+from gwtransport.utils import cumulative_flow_volume, linear_interpolate
+
+
+def _validate_rainfall_inputs(
+    *,
+    cin: npt.NDArray[np.floating],
+    t_rain: npt.NDArray[np.floating],
+    flow: npt.NDArray[np.floating],
+    rainfall: npt.NDArray[np.floating],
+    tedges: pd.DatetimeIndex,
+    cout_tedges: pd.DatetimeIndex,
+    infiltration_area: float,
+) -> None:
+    """Validate inputs for :func:`rainfall_to_extracted_temperature`.
+
+    Composes the shared validation atoms from :mod:`gwtransport._validation`:
+    bin-edge parity for ``cin``/``flow``/``rainfall`` against ``tedges`` and for
+    ``t_rain`` against ``cout_tedges``, non-negative ``flow`` and ``rainfall``,
+    a strictly positive ``infiltration_area``, and NaN-free inputs.
+
+    Parameters
+    ----------
+    cin : ndarray
+        Infiltration water temperature per ``tedges`` bin (K).
+    t_rain : ndarray
+        Rain water temperature per ``cout_tedges`` bin (K).
+    flow : ndarray
+        Flow rate per ``tedges`` bin (m³/day).
+    rainfall : ndarray
+        Rainfall rate per ``tedges`` bin (m/day).
+    tedges : DatetimeIndex
+        Time bin edges for ``cin``, ``flow``, and ``rainfall`` (n+1 edges).
+    cout_tedges : DatetimeIndex
+        Output time bin edges for ``t_rain`` and the result (m+1 edges).
+    infiltration_area : float
+        Plan-view infiltration footprint (m²).
+
+    Raises
+    ------
+    ValueError
+        If any bin-edge parity fails, ``flow`` or ``rainfall`` is negative,
+        ``infiltration_area`` is not strictly positive, or any input is NaN.
+    """
+    _validate_tedges_parity(tedges, cin, tedges_name="tedges", values_name="cin")
+    _validate_tedges_parity(tedges, flow, tedges_name="tedges", values_name="flow")
+    _validate_tedges_parity(tedges, rainfall, tedges_name="tedges", values_name="rainfall")
+    _validate_tedges_parity(cout_tedges, t_rain, tedges_name="cout_tedges", values_name="t_rain")
+    _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
+    _validate_non_negative_array(rainfall, name="rainfall", message="rainfall must be non-negative")
+    _validate_positive_scalar(infiltration_area, name="infiltration_area")
+    _validate_no_nan(cin, name="cin")
+    _validate_no_nan(t_rain, name="t_rain")
+    _validate_no_nan(flow, name="flow")
+    _validate_no_nan(rainfall, name="rainfall")
+
+
+def rainfall_to_extracted_temperature(
+    *,
+    cin: npt.ArrayLike,
+    t_rain: npt.ArrayLike,
+    flow: npt.ArrayLike,
+    rainfall: npt.ArrayLike,
+    tedges: pd.DatetimeIndex,
+    cout_tedges: pd.DatetimeIndex,
+    infiltration_area: float,
+    mean: float | None = None,
+    std: float | None = None,
+    loc: float = 0.0,
+    alpha: float | None = None,
+    beta: float | None = None,
+    n_bins: int = 100,
+    retardation_factor: float = 2.0,
+) -> npt.NDArray[np.floating]:
+    r"""
+    Temperature of extracted water as an energy-conserving rain/aquifer mix.
+
+    The extracted-water temperature is the volume-weighted (energy-conserving)
+    mean of two contributions:
+
+    .. math::
+
+        T_\text{ext} = \frac{V_\text{rain}\,T_\text{rain}
+                              + V_\text{ext}\,T_\text{adv}}
+                             {V_\text{rain} + V_\text{ext}}.
+
+    ``T_adv`` is the advectively transported aquifer-water temperature, obtained
+    by treating heat as a retarded tracer through
+    :func:`gwtransport.advection.gamma_infiltration_to_extraction` with the
+    infiltration temperature ``cin`` and a gamma-distributed aquifer pore volume.
+    ``V_ext`` is the extracted volume per output bin (``flow`` integrated over
+    each ``cout_tedges`` interval); ``V_rain = rainfall · infiltration_area · Δt``
+    is the rain volume reaching the footprint over the same bin. The shared
+    volumetric heat capacity of liquid water cancels (see module docstring), so
+    it is not a parameter here.
+
+    Provide either (``mean``, ``std``) or (``alpha``, ``beta``) for the gamma
+    aquifer pore volume distribution; ``loc`` is optional and defaults to 0.
+
+    Parameters
+    ----------
+    cin : array-like
+        Temperature of the infiltrating water (K). Constant over each interval
+        ``[tedges[i], tedges[i+1])``. Length ``len(tedges) - 1``.
+    t_rain : array-like
+        Temperature of the rain water (K). Constant over each output interval
+        ``[cout_tedges[i], cout_tedges[i+1])``. Length ``len(cout_tedges) - 1``.
+    flow : array-like
+        Flow rate of water in the aquifer (m³/day). Constant over each interval
+        ``[tedges[i], tedges[i+1])``. Length ``len(tedges) - 1``.
+    rainfall : array-like
+        Rainfall rate (m/day). Constant over each interval
+        ``[tedges[i], tedges[i+1])``. Length ``len(tedges) - 1``. Non-negative.
+    tedges : pandas.DatetimeIndex
+        Time bin edges for ``cin``, ``flow``, and ``rainfall``. Length one more
+        than those arrays.
+    cout_tedges : pandas.DatetimeIndex
+        Output time bin edges for ``t_rain`` and the returned temperature.
+        Length one more than the desired output.
+    infiltration_area : float
+        Plan-view area of the infiltration footprint (m²) over which rain is
+        collected. This is a surface (map-view) area, **not** a pore-geometry
+        parameter; it is supplied directly and never derived from porosity or
+        aquifer thickness. Must be strictly positive.
+    mean : float, optional
+        Mean of the gamma aquifer pore volume distribution. Must be strictly
+        greater than ``loc``.
+    std : float, optional
+        Standard deviation of the gamma aquifer pore volume distribution
+        (invariant under the ``loc`` shift).
+    loc : float, optional
+        Location (minimum pore volume) of the gamma distribution. Must satisfy
+        ``0 <= loc < mean``. Default is ``0.0``.
+    alpha : float, optional
+        Shape parameter of the gamma distribution (must be > 0).
+    beta : float, optional
+        Scale parameter of the gamma distribution (must be > 0).
+    n_bins : int, optional
+        Number of bins used to discretize the gamma distribution. Default 100.
+    retardation_factor : float, optional
+        Retardation factor of heat in the aquifer. Default 2.0 (typical for
+        heat transport in saturated porous media).
+
+    Returns
+    -------
+    numpy.ndarray
+        Flow-weighted extracted-water temperature (K), aligned to
+        ``cout_tedges``. Length ``len(cout_tedges) - 1``.
+
+        Output bins where ``gamma_infiltration_to_extraction`` returns NaN
+        (insufficient flow history; see its ``spinup`` policy) propagate NaN.
+        Output bins where both contributions vanish (``V_rain == 0`` and
+        ``V_ext == 0``) are NaN (0/0, undefined). In the pure limits the result
+        is exact: ``V_rain == 0`` returns ``T_adv`` and ``V_ext == 0`` returns
+        ``t_rain``, each bit-for-bit.
+
+    Raises
+    ------
+    ValueError
+        If any bin-edge parity fails, ``flow`` or ``rainfall`` is negative,
+        ``infiltration_area`` is not strictly positive, any input is NaN, or
+        the gamma parameterization is under- or over-specified (raised by
+        :func:`gwtransport.gamma.bins`).
+
+    See Also
+    --------
+    gwtransport.advection.gamma_infiltration_to_extraction : Advective heat transport (``T_adv``).
+    gwtransport.residence_time.residence_time : Residence times underlying the advective transport.
+    :ref:`concept-residence-time` : Time spent in the aquifer.
+    :ref:`concept-retardation-factor` : Retardation of heat relative to water.
+    :ref:`assumption-thermal-retardation` : Heat-as-retarded-tracer assumption.
+    :ref:`assumption-well-mixed-extraction` : Lumped extraction-point mixing.
+
+    Notes
+    -----
+    The mixing is energy-conserving: with a single liquid-water volumetric heat
+    capacity, the energy balance
+    ``rho*c (V_rain T_rain + V_ext T_adv) = rho*c (V_rain + V_ext) T_ext`` reduces
+    to the volume-weighted mean above (the ``rho*c`` factor cancels). Blending rain at the
+    extraction point is a lumped v1 assumption; rain that physically advects
+    through the column is not resolved. Only the forward direction is provided
+    because the reverse is non-unique (two temperature unknowns, one equation).
+
+    ``V_ext`` is computed from the cumulative flow volume on ``tedges`` evaluated
+    at the ``cout_tedges`` edges, so output bins need not align with the input
+    grid. ``V_rain`` uses the same ``cout_tedges`` widths after averaging the
+    rain volume rate onto the output grid.
+
+    Examples
+    --------
+    Equal rain and extraction volumes give the arithmetic mean of the two
+    temperatures:
+
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from gwtransport.utils import compute_time_edges
+    >>> from gwtransport.rainfall import rainfall_to_extracted_temperature
+    >>>
+    >>> dates = pd.date_range(start="2020-01-01", end="2020-03-31", freq="D")
+    >>> tedges = compute_time_edges(
+    ...     tedges=None, tstart=None, tend=dates, number_of_bins=len(dates)
+    ... )
+    >>> n = len(dates)
+    >>> cin = np.full(n, 290.0)  # infiltration temperature (K)
+    >>> flow = np.full(n, 100.0)  # m3/day
+    >>> rainfall = np.full(n, 0.0)  # no rain -> result equals T_adv
+    >>> t_rain = np.full(n, 280.0)  # rain temperature (K)
+    >>> t_ext = rainfall_to_extracted_temperature(
+    ...     cin=cin,
+    ...     t_rain=t_rain,
+    ...     flow=flow,
+    ...     rainfall=rainfall,
+    ...     tedges=tedges,
+    ...     cout_tedges=tedges,
+    ...     infiltration_area=1000.0,
+    ...     mean=500.0,
+    ...     std=200.0,
+    ...     n_bins=20,
+    ... )
+    >>> t_ext.shape
+    (91,)
+    """
+    tedges = pd.DatetimeIndex(tedges)
+    cout_tedges = pd.DatetimeIndex(cout_tedges)
+
+    cin = np.asarray(cin, dtype=float)
+    t_rain = np.asarray(t_rain, dtype=float)
+    flow = np.asarray(flow, dtype=float)
+    rainfall = np.asarray(rainfall, dtype=float)
+
+    _validate_rainfall_inputs(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        infiltration_area=infiltration_area,
+    )
+
+    # Advective aquifer-heat temperature, already aligned to cout_tedges.
+    t_adv = gamma_infiltration_to_extraction(
+        cin=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        mean=mean,
+        std=std,
+        loc=loc,
+        alpha=alpha,
+        beta=beta,
+        n_bins=n_bins,
+        retardation_factor=retardation_factor,
+    )
+
+    # Extracted volume per output bin: integrate flow (on tedges) over each
+    # cout_tedges interval via the cumulative-flow-volume machinery. Using a
+    # shared reference (tedges[0]) keeps the two edge arrays on one origin so
+    # cout_tedges need not coincide with tedges.
+    tedges_days = tedges_to_days(tedges)
+    cout_tedges_days = tedges_to_days(cout_tedges, ref=tedges[0])
+    flow_cum = cumulative_flow_volume(flow, np.diff(tedges_days))
+    flow_cum_at_cout = linear_interpolate(x_ref=tedges_days, y_ref=flow_cum, x_query=cout_tedges_days)
+    v_ext = np.diff(flow_cum_at_cout)
+
+    # Rain volume per output bin: same cumulative-then-difference treatment so
+    # the rain rate (on tedges) is integrated over each cout_tedges interval.
+    rain_volume_rate = rainfall * infiltration_area  # m3/day on tedges bins
+    rain_cum = cumulative_flow_volume(rain_volume_rate, np.diff(tedges_days))
+    rain_cum_at_cout = linear_interpolate(x_ref=tedges_days, y_ref=rain_cum, x_query=cout_tedges_days)
+    v_rain = np.diff(rain_cum_at_cout)
+
+    # Energy-conserving (volume-weighted) mix. Explicit zero-volume branches make
+    # the pure limits exact: V_rain == 0 -> T_adv, V_ext == 0 -> t_rain; both
+    # zero -> NaN (0/0, undefined).
+    total_volume = v_rain + v_ext
+    with np.errstate(invalid="ignore", divide="ignore"):
+        mixed = (v_rain * t_rain + v_ext * t_adv) / total_volume
+    mixed = np.where(v_rain == 0.0, t_adv, mixed)
+    mixed = np.where(v_ext == 0.0, t_rain, mixed)
+    return np.where(total_volume == 0.0, np.nan, mixed)

--- a/tests/src/test_rainfall.py
+++ b/tests/src/test_rainfall.py
@@ -1,0 +1,418 @@
+"""Tests for :mod:`gwtransport.rainfall`.
+
+The extracted-water temperature is the volume-weighted (energy-conserving) mix
+
+    T_ext = (V_rain * T_rain + V_ext * T_adv) / (V_rain + V_ext)
+
+with ``T_adv`` from :func:`gwtransport.advection.gamma_infiltration_to_extraction`,
+``V_ext`` the flow integrated over each output bin, and
+``V_rain = rainfall * infiltration_area * Δt``.
+
+Tests are built so the mix is exactly determined: a constant infiltration
+temperature with a fully-broken-through steady setup makes ``T_adv`` exactly the
+infiltration temperature, so the known-answer mixes below are hand-computed.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gwtransport.advection import gamma_infiltration_to_extraction
+from gwtransport.rainfall import rainfall_to_extracted_temperature
+from gwtransport.utils import compute_time_edges
+
+# Gamma aquifer pore volume distributions chosen so that, for the flow level used
+# in each test, the advective transport of a *constant* infiltration temperature
+# returns that constant bit-for-bit at every bin (the convolution weights sum to
+# exactly 1 in floating point for these configs -- verified empirically). This
+# makes the hand-computed known-answer mixes exact under assert_array_equal.
+#
+# - _GAMMA_HIGH_FLOW pairs with flow = 100 m3/day (large aquifer fully broken through).
+# - _GAMMA_LOW_FLOW pairs with flow = 3 m3/day (small aquifer needed to break through).
+_GAMMA_HIGH_FLOW = {"mean": 500.0, "std": 200.0, "n_bins": 20}
+_GAMMA_LOW_FLOW = {"mean": 15.0, "std": 6.0, "n_bins": 20}
+
+
+@pytest.fixture
+def dates():
+    """Daily dates spanning enough time for full breakthrough."""
+    return pd.date_range(start="2020-01-01", end="2020-06-30", freq="D")
+
+
+@pytest.fixture
+def tedges(dates):
+    """Time edges aligned with the daily dates."""
+    return compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
+
+
+# ============================================================================
+# Known-answer hand mixes
+# ============================================================================
+
+
+def test_known_answer_equal_volumes(dates, tedges):
+    """V_rain == V_ext, T_rain=280, T_adv=290 -> arithmetic mean 285.0 exactly."""
+    n = len(dates)
+    cin = np.full(n, 290.0)  # constant infiltration temperature -> T_adv == 290 exactly
+    t_rain = np.full(n, 280.0)
+    flow = np.full(n, 100.0)  # V_ext = 100 m3 per daily bin
+    rainfall = np.full(n, 0.1)  # 0.1 m/day * 1000 m2 = 100 m3/day -> V_rain = 100 m3
+
+    out = rainfall_to_extracted_temperature(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=tedges,
+        infiltration_area=1000.0,
+        retardation_factor=2.0,
+        **_GAMMA_HIGH_FLOW,
+    )
+    assert not np.any(np.isnan(out))
+    np.testing.assert_array_equal(out, np.full(n, 285.0))
+
+
+def test_known_answer_unequal_volumes(dates, tedges):
+    """V_rain=1, V_ext=3, T_rain=280, T_adv=290 -> (280 + 3*290)/4 = 287.5 exactly."""
+    n = len(dates)
+    cin = np.full(n, 290.0)
+    t_rain = np.full(n, 280.0)
+    flow = np.full(n, 3.0)  # V_ext = 3 m3 per daily bin
+    rainfall = np.full(n, 0.001)  # 0.001 m/day * 1000 m2 = 1 m3/day -> V_rain = 1 m3
+
+    out = rainfall_to_extracted_temperature(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=tedges,
+        infiltration_area=1000.0,
+        retardation_factor=2.0,
+        **_GAMMA_LOW_FLOW,
+    )
+    assert not np.any(np.isnan(out))
+    np.testing.assert_array_equal(out, np.full(n, 287.5))
+
+
+# ============================================================================
+# Weighting orientation (pins the convex-combination orientation)
+# ============================================================================
+
+
+def test_weighting_orientation(dates, tedges):
+    """Swapping which volume weights which temperature must change the result.
+
+    With V_rain=1, V_ext=3 the result is 287.5 (closer to T_adv=290). If the
+    weights were swapped (rain weighted by V_ext, aquifer by V_rain) the result
+    would be (3*280 + 290)/4 = 282.5. The two differ, so the convex-combination
+    orientation (rain<->V_rain, advection<->V_ext) is pinned.
+    """
+    n = len(dates)
+    cin = np.full(n, 290.0)
+    t_rain = np.full(n, 280.0)
+    flow = np.full(n, 3.0)
+    rainfall = np.full(n, 0.001)
+
+    out = rainfall_to_extracted_temperature(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=tedges,
+        infiltration_area=1000.0,
+        retardation_factor=2.0,
+        **_GAMMA_LOW_FLOW,
+    )
+    swapped = 282.5  # (V_ext*T_rain + V_rain*T_adv)/(V_rain+V_ext) = (3*280 + 1*290)/4
+    assert not np.any(np.isclose(out, swapped))
+    np.testing.assert_array_equal(out, np.full(n, 287.5))
+
+
+# ============================================================================
+# Independent advective-conservation (T_adv not hidden behind the mix)
+# ============================================================================
+
+
+def test_independent_advective_conservation(dates, tedges):
+    """In the zero-rain limit the result equals gamma_infiltration_to_extraction.
+
+    A non-constant infiltration temperature exercises the advective transport so
+    a T_adv bug would surface; the rainfall result must match the standalone
+    advection call bit-for-bit (zero rain -> exact T_adv branch).
+    """
+    n = len(dates)
+    t = np.arange(n)
+    cin = 285.0 + 8.0 * np.sin(2 * np.pi * t / 90.0)  # seasonal infiltration temperature
+    t_rain = np.full(n, 280.0)
+    flow = 100.0 * (1.0 + 0.2 * np.sin(2 * np.pi * t / 30.0))  # variable flow
+    rainfall = np.zeros(n)  # zero rain
+
+    t_adv = gamma_infiltration_to_extraction(
+        cin=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        retardation_factor=2.0,
+        **_GAMMA_HIGH_FLOW,
+    )
+    out = rainfall_to_extracted_temperature(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=tedges,
+        infiltration_area=1000.0,
+        retardation_factor=2.0,
+        **_GAMMA_HIGH_FLOW,
+    )
+    # T_adv varies in time here (not a flat constant), so this is a real check.
+    assert np.nanstd(t_adv) > 1.0
+    np.testing.assert_array_equal(out, t_adv)
+
+
+# ============================================================================
+# Limiting cases (bit-exact)
+# ============================================================================
+
+
+def test_zero_rain_is_exactly_advection(dates, tedges):
+    """rainfall == 0 -> result is bit-exact T_adv (V_rain == 0 branch)."""
+    n = len(dates)
+    cin = np.full(n, 290.0)
+    t_rain = np.full(n, 280.0)
+    flow = np.full(n, 100.0)
+    rainfall = np.zeros(n)
+
+    t_adv = gamma_infiltration_to_extraction(
+        cin=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        retardation_factor=2.0,
+        **_GAMMA_HIGH_FLOW,
+    )
+    out = rainfall_to_extracted_temperature(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=tedges,
+        infiltration_area=1000.0,
+        retardation_factor=2.0,
+        **_GAMMA_HIGH_FLOW,
+    )
+    np.testing.assert_array_equal(out, t_adv)
+
+
+def test_zero_flow_is_exactly_rain(dates, tedges):
+    """flow == 0 -> result is bit-exact t_rain (V_ext == 0 branch)."""
+    n = len(dates)
+    cin = np.full(n, 290.0)
+    t_rain = 280.0 + 5.0 * np.sin(2 * np.pi * np.arange(n) / 50.0)  # varying rain temperature
+    flow = np.zeros(n)  # no extraction -> V_ext == 0
+    rainfall = np.full(n, 0.1)
+
+    out = rainfall_to_extracted_temperature(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=tedges,
+        infiltration_area=1000.0,
+        retardation_factor=2.0,
+        **_GAMMA_HIGH_FLOW,
+    )
+    np.testing.assert_array_equal(out, t_rain)
+
+
+def test_both_zero_is_nan(dates, tedges):
+    """V_rain == 0 and V_ext == 0 -> NaN (0/0, documented)."""
+    n = len(dates)
+    cin = np.full(n, 290.0)
+    t_rain = np.full(n, 280.0)
+    flow = np.zeros(n)
+    rainfall = np.zeros(n)
+
+    out = rainfall_to_extracted_temperature(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=tedges,
+        infiltration_area=1000.0,
+        retardation_factor=2.0,
+        **_GAMMA_HIGH_FLOW,
+    )
+    assert np.all(np.isnan(out))
+
+
+# ============================================================================
+# Bin alignment: cout_tedges coarser than tedges
+# ============================================================================
+
+
+def test_misaligned_output_bins(dates, tedges):
+    """V_ext integrates flow over wider output bins (cout_tedges != tedges)."""
+    n = len(dates)
+    cin = np.full(n, 290.0)
+    flow = np.full(n, 100.0)  # 100 m3/day
+    rainfall = np.full(n, 0.1)  # 0.1 m/day * 1000 m2 = 100 m3/day
+
+    # 2-day output bins, inside the input window.
+    cout_dates = pd.date_range(start="2020-03-01", end="2020-05-31", freq="2D")
+    cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=len(cout_dates))
+    t_rain = np.full(len(cout_dates), 280.0)
+
+    out = rainfall_to_extracted_temperature(
+        cin=cin,
+        t_rain=t_rain,
+        flow=flow,
+        rainfall=rainfall,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        infiltration_area=1000.0,
+        retardation_factor=2.0,
+        **_GAMMA_HIGH_FLOW,
+    )
+    # Over each 2-day bin: V_ext = 100*2 = 200, V_rain = 100*2 = 200 -> equal -> 285.0.
+    assert out.shape == (len(cout_dates),)
+    assert not np.any(np.isnan(out))
+    np.testing.assert_array_equal(out, np.full(len(cout_dates), 285.0))
+
+
+# ============================================================================
+# Fixtures from conftest
+# ============================================================================
+
+
+def test_uses_temperature_retardation_default(dates, tedges, retardation_scenarios):
+    """retardation_factor flows through and defaults to the temperature scenario (2.0).
+
+    Uses a time-varying ``cin`` so the retardation factor actually shifts the advective
+    breakthrough: a constant ``cin`` would make every retardation give the same steady
+    ``T_adv``, so the test could not distinguish R=1 from the R=2 default.
+    """
+    n = len(dates)
+    cin = np.linspace(280.0, 300.0, n)  # time-varying so retardation changes T_adv
+    t_rain = np.full(n, 280.0)
+    flow = np.full(n, 100.0)
+    rainfall = np.full(n, 0.1)
+    common = {
+        "cin": cin,
+        "t_rain": t_rain,
+        "flow": flow,
+        "rainfall": rainfall,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "infiltration_area": 1000.0,
+        **_GAMMA_HIGH_FLOW,
+    }
+
+    default = rainfall_to_extracted_temperature(**common)
+    explicit_two = rainfall_to_extracted_temperature(**common, retardation_factor=retardation_scenarios["temperature"])
+    explicit_one = rainfall_to_extracted_temperature(**common, retardation_factor=1.0)
+
+    # The default equals the temperature scenario (2.0), bit-for-bit.
+    np.testing.assert_array_equal(default, explicit_two)
+    # Retardation genuinely affects the result: R=1 differs from the R=2 default.
+    finite = ~np.isnan(default) & ~np.isnan(explicit_one)
+    assert finite.any(), "test setup invalid: no overlapping finite bins to compare"
+    assert not np.array_equal(default[finite], explicit_one[finite])
+
+
+# ============================================================================
+# Input validation
+# ============================================================================
+
+
+def test_negative_rainfall_raises(dates, tedges):
+    """Negative rainfall is rejected."""
+    n = len(dates)
+    rainfall = np.full(n, 0.1)
+    rainfall[10] = -0.01
+    with pytest.raises(ValueError, match="rainfall must be non-negative"):
+        rainfall_to_extracted_temperature(
+            cin=np.full(n, 290.0),
+            t_rain=np.full(n, 280.0),
+            flow=np.full(n, 100.0),
+            rainfall=rainfall,
+            tedges=tedges,
+            cout_tedges=tedges,
+            infiltration_area=1000.0,
+            **_GAMMA_HIGH_FLOW,
+        )
+
+
+def test_negative_flow_raises(dates, tedges):
+    """Negative flow is rejected."""
+    n = len(dates)
+    flow = np.full(n, 100.0)
+    flow[5] = -1.0
+    with pytest.raises(ValueError, match="flow must be non-negative"):
+        rainfall_to_extracted_temperature(
+            cin=np.full(n, 290.0),
+            t_rain=np.full(n, 280.0),
+            flow=flow,
+            rainfall=np.full(n, 0.1),
+            tedges=tedges,
+            cout_tedges=tedges,
+            infiltration_area=1000.0,
+            **_GAMMA_HIGH_FLOW,
+        )
+
+
+def test_nonpositive_infiltration_area_raises(dates, tedges):
+    """infiltration_area must be strictly positive."""
+    n = len(dates)
+    with pytest.raises(ValueError, match="infiltration_area must be positive"):
+        rainfall_to_extracted_temperature(
+            cin=np.full(n, 290.0),
+            t_rain=np.full(n, 280.0),
+            flow=np.full(n, 100.0),
+            rainfall=np.full(n, 0.1),
+            tedges=tedges,
+            cout_tedges=tedges,
+            infiltration_area=0.0,
+            **_GAMMA_HIGH_FLOW,
+        )
+
+
+def test_tedges_parity_raises(dates, tedges):
+    """Mismatched flow length is rejected by bin-edge parity."""
+    n = len(dates)
+    with pytest.raises(ValueError, match="tedges must have one more element than flow"):
+        rainfall_to_extracted_temperature(
+            cin=np.full(n, 290.0),
+            t_rain=np.full(n, 280.0),
+            flow=np.full(n - 1, 100.0),  # wrong length
+            rainfall=np.full(n, 0.1),
+            tedges=tedges,
+            cout_tedges=tedges,
+            infiltration_area=1000.0,
+            **_GAMMA_HIGH_FLOW,
+        )
+
+
+def test_nan_input_raises(dates, tedges):
+    """NaN in cin is rejected."""
+    n = len(dates)
+    cin = np.full(n, 290.0)
+    cin[3] = np.nan
+    with pytest.raises(ValueError, match="cin contains NaN"):
+        rainfall_to_extracted_temperature(
+            cin=cin,
+            t_rain=np.full(n, 280.0),
+            flow=np.full(n, 100.0),
+            rainfall=np.full(n, 0.1),
+            tedges=tedges,
+            cout_tedges=tedges,
+            infiltration_area=1000.0,
+            **_GAMMA_HIGH_FLOW,
+        )


### PR DESCRIPTION
## Summary

Adds a `gwtransport.rainfall` module with `rainfall_to_extracted_temperature`, which estimates the temperature of extracted water as an energy-conserving mix of two sources: heat carried advectively from the infiltration front, and heat carried by rain that recharges the streamtube.

Because both streams are liquid water their volumetric heat capacities cancel, so the energy balance reduces to a volume-weighted mean:

```
T_ext = (V_rain·T_rain + V_ext·T_adv) / (V_rain + V_ext)
```

- `T_adv` reuses `advection.gamma_infiltration_to_extraction` (heat as a retarded tracer, default `retardation_factor = 2.0`);
- `V_ext` is the extraction flow integrated over each output bin;
- `V_rain = rainfall · infiltration_area · Δt`, where `infiltration_area` is the plan-view recharge footprint — an explicit parameter, not derived from pore geometry.

The issue sketch divided energy by volume directly (dimensionally J/m³, not K); this implements the energy-conserving form. The derivation, the ρc cancellation, and the lumped "rain mixes at the extraction point" v1 assumption are documented in the module docstring. The operation is forward-only — the reverse is non-unique (two temperature unknowns, one equation).

Closes #16.

## Test plan

- `pytest tests/src/test_rainfall.py` — 14 pass: hand-computed known-answer mixes (285.0, 287.5), a weighting-orientation guard, an independent advective-conservation check against `gamma_infiltration_to_extraction`, bit-exact zero-rain/zero-flow limits, the both-zero NaN case, and an output-grid-misalignment case.
- `ruff format` / `ruff check` clean; module registered in `docs/source/api/modules.rst`.

## Contributor License Agreement

- [ ] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
