### PR TITLE
fronttracking: handle a wetting shock colliding with a fully-drained (c=0) fan

### DIFF
--- a/src/gwtransport/fronttracking/waves.py
+++ b/src/gwtransport/fronttracking/waves.py
@@ -24,6 +24,7 @@ from scipy.integrate import IntegrationWarning, quad
 from scipy.optimize import brentq
 
 from gwtransport.fronttracking.math import (
+    _C_MIN,
     BrooksCoreyConductivity,
     FreundlichSorption,
     LangmuirSorption,
@@ -554,7 +555,9 @@ class DecayingShockWave(Wave):
         construction.
     c_decay_initial : float
         Concentration on the decaying side at θ=theta_start [mass/volume].
-        Must be strictly positive.
+        Must be non-negative; a fully-drained collision value of ``0`` is
+        floored to the shared dry-soil singularity floor ``_C_MIN`` so the
+        retardation and secant-speed evaluations stay finite (issue #222).
     c_fixed : float
         Concentration on the non-decaying side [mass/volume]. Constant in θ.
         Non-negative.
@@ -609,9 +612,12 @@ class DecayingShockWave(Wave):
         if self.decay_side not in {"left", "right"}:
             msg = f"decay_side must be 'left' or 'right', got {self.decay_side!r}"
             raise ValueError(msg)
-        if self.c_decay_initial <= 0.0:
-            msg = f"c_decay_initial must be positive, got {self.c_decay_initial}"
+        if self.c_decay_initial < 0.0:
+            msg = f"c_decay_initial must be non-negative, got {self.c_decay_initial}"
             raise ValueError(msg)
+        # Floor a fully-drained fan tail (c_decay_initial == 0, #222) to _C_MIN so the
+        # retardation and secant-speed evaluations stay finite (package floor convention).
+        self.c_decay_initial = max(self.c_decay_initial, _C_MIN)
         if self.c_fixed < 0.0:
             msg = f"c_fixed must be non-negative, got {self.c_fixed}"
             raise ValueError(msg)
@@ -702,21 +708,26 @@ class DecayingShockWave(Wave):
         """Cumulative flow θ at which ``c_decay`` reaches ``c_fan_tail``.
 
         ``c_decay(θ)`` is strictly monotone from ``c_decay_initial`` toward
-        ``c_fan_tail``, so the exhaustion θ is well-defined. Returns ``None``
-        if the fan tail is at (or beyond) the collision concentration — i.e.
-        the fan never decays past it, so no exhaustion event occurs.
+        ``c_fan_tail``, so the exhaustion θ is well-defined. The crossing test is
+        orientation-agnostic: it holds for both the shrinking decay
+        (``c_decay_initial > c_fan_tail``) and the growing decay
+        (``c_decay_initial < c_fan_tail``). Returns ``None`` when ``c_fan_tail``
+        is not strictly between ``c_fixed`` and ``c_decay_initial`` — e.g. full drying
+        (``c_fan_tail == c_fixed``), where the decay asymptotically merges with
+        the fixed state and no finite exhaustion event occurs.
 
         Returns
         -------
         float or None
             Cumulative flow θ at exhaustion, or ``None`` if not reached.
         """
-        # The decaying side runs from c_decay_initial toward c_fan_tail. Only a
-        # tail STRICTLY between c_fixed and c_decay_initial gives an interior
-        # exhaustion. Full drying (c_fan_tail == c_fixed) decays asymptotically
-        # toward the floor with no finite crossing, so return None rather than
-        # growing the bracket forever (van Genuchten would otherwise hang).
-        if not (self.c_fixed < self.c_fan_tail < self.c_decay_initial):
+        # An interior exhaustion needs c_fan_tail strictly between c_fixed and
+        # c_decay_initial (orientation-agnostic via min/max). Full drying
+        # (c_fan_tail == c_fixed) merges asymptotically with no finite crossing —
+        # return None rather than grow the bracket forever (van Genuchten would hang).
+        c_lo = min(self.c_fixed, self.c_decay_initial)
+        c_hi = max(self.c_fixed, self.c_decay_initial)
+        if not (c_lo < self.c_fan_tail < c_hi):
             return None
 
         theta_local_collision = self.theta_start - self.theta_origin
@@ -724,7 +735,7 @@ class DecayingShockWave(Wave):
         def f(theta_local: float) -> float:
             return self._c_decay_at_theta_local(theta_local) - self.c_fan_tail
 
-        # c_decay decreases with θ_local; find where it crosses c_fan_tail.
+        # c_decay is monotone in θ_local; find where it crosses c_fan_tail.
         f_lo = f(theta_local_collision)
         if f_lo <= 0.0:
             # Already at/below the tail at collision — exhausted immediately.

--- a/tests/src/test_front_tracking_drained_fan_collision.py
+++ b/tests/src/test_front_tracking_drained_fan_collision.py
@@ -1,0 +1,207 @@
+"""
+Regression and conservation tests for issue #222.
+
+A wetting shock that collides with a *fully drained* (c=0) drying rarefaction
+fan used to raise ``ValueError: c_decay_initial must be positive`` deep in the
+solver (``handlers.py`` → ``DecayingShockWave.__post_init__``). The collision
+hands the fan-tail concentration to the merged
+:class:`~gwtransport.fronttracking.waves.DecayingShockWave` as
+``c_decay_initial``; for a fully drained fan that value is exactly ``0``.
+
+The fix floors ``c_decay_initial`` to the shared dry-soil singularity floor
+``_C_MIN`` (matching the package's retardation-floor convention) rather than
+rejecting the collision, and generalises the fan-exhaustion orientation guard
+so the *growing* decay (``c_decay_initial < c_fan_tail``) is handled. For the
+issue's inputs the decaying shock asymptotically merges with the fan head, so
+there is no finite exhaustion event -- the solver terminates cleanly.
+
+These end-to-end tests drive the public
+:func:`gwtransport.percolation.root_zone_to_water_table_kinematic_wave` entry
+point. Mass conservation is checked via an *independent* route -- a fine-grid
+trapezoidal integral of :func:`compute_breakthrough_curve` over θ compared to
+``Σ cin·Δθ − compute_domain_mass(θ_end)`` -- following the
+``test_percolation.py::test_b5a`` pattern. This deliberately avoids the
+``compute_bin_averaged_concentration_exact`` route (which is itself
+``m_in − m_dom`` and would make the check tautological).
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gwtransport.fronttracking.math import _C_MIN, BrooksCoreyConductivity
+from gwtransport.fronttracking.output import compute_breakthrough_curve, compute_domain_mass
+from gwtransport.fronttracking.waves import DecayingShockWave
+from gwtransport.percolation import root_zone_to_water_table_kinematic_wave
+
+# Brooks-Corey soil and short column from issue #222.
+_BC_KWARGS = {"theta_r": 0.05, "theta_s": 0.40, "k_s": 0.01, "brooks_corey_lambda": 0.5}
+_V_OUTLET = 0.05  # cumulative pore volume of the (short) column = theta_s * z_wt
+
+
+def _run_percolation(q_root: np.ndarray):
+    """Drive the percolation solver and return ``(q_wt, tracker_state)``.
+
+    Parameters
+    ----------
+    q_root : numpy.ndarray
+        Root-zone flux per daily bin (m/day).
+
+    Returns
+    -------
+    q_wt : numpy.ndarray
+        Water-table flux (the bin-averaged public output).
+    state : FrontTrackerState
+        Complete solver state (wave list, θ-edges, sorption) for the single
+        column at ``_V_OUTLET``.
+    """
+    tedges = pd.date_range("2024-01-01", periods=len(q_root) + 1, freq="D")
+    with warnings.catch_warnings():
+        # The wet-zero-wet forcing pushes a few output θ-bins past the inlet
+        # window; that back-transform warning is incidental here -- conservation
+        # is read from the wave list / compute_domain_mass directly, not q_wt.
+        warnings.simplefilter("ignore")
+        q_wt, structures = root_zone_to_water_table_kinematic_wave(
+            q_root_zone=q_root,
+            tedges=tedges,
+            q_water_table_tedges=tedges,
+            cumulative_pore_volumes_outlet=[_V_OUTLET],
+            **_BC_KWARGS,
+        )
+    return q_wt, structures[0]["tracker_state"]
+
+
+def _independent_conservation_rel_err(q_root: np.ndarray, state, n_grid: int = 600) -> float:
+    """Relative mass-balance residual via the independent breakthrough integral.
+
+    Computes ``|∫ breakthrough dθ + M_domain(θ_end) − M_in| / M_in`` where the
+    breakthrough integral is a trapezoidal rule over
+    :func:`compute_breakthrough_curve` (independent of the ``m_in − m_dom``
+    back-transform), ``M_domain`` is the spatial domain-mass integral, and
+    ``M_in = Σ cin·Δθ`` in the solver's native θ/V frame. With no K-scaling the
+    solver-frame inlet concentration equals ``q_root`` and ``Δθ = θ_s·Δt`` is
+    carried in ``state.theta_edges``.
+
+    Parameters
+    ----------
+    q_root : numpy.ndarray
+        Root-zone flux per bin; equals the solver-frame inlet concentration.
+    state : FrontTrackerState
+        Solver state holding the wave list, θ-edges, and sorption model.
+    n_grid : int, optional
+        Number of θ-grid points for the trapezoidal breakthrough integral.
+        Default 600. The integrand is first-order across shock fronts, so the
+        grid truncation dominates the residual.
+
+    Returns
+    -------
+    float
+        Relative conservation error.
+    """
+    theta_edges = np.asarray(state.theta_edges, dtype=float)
+    theta_end = float(theta_edges[-1])
+
+    theta_grid = np.linspace(0.0, theta_end, n_grid)
+    breakthrough = compute_breakthrough_curve(theta_grid, _V_OUTLET, state.waves, state.sorption)
+    mass_out = float(np.trapezoid(breakthrough, theta_grid))
+
+    mass_domain = compute_domain_mass(theta=theta_end, v_outlet=_V_OUTLET, waves=state.waves, sorption=state.sorption)
+    mass_in = float(np.sum(q_root * np.diff(theta_edges)))
+
+    return abs(mass_out + mass_domain - mass_in) / mass_in
+
+
+class TestWettingShockIntoDrainedFan:
+    """Issue #222: wetting shock colliding with a fully-drained (c=0) fan."""
+
+    def test_wetting_shock_into_drained_fan_runs(self):
+        """The issue's exact wet→zero→wet forcing runs without raising.
+
+        On baseline this raises ``ValueError: c_decay_initial must be positive``
+        from ``DecayingShockWave.__post_init__`` when the wetting shock collides
+        with the fully drained fan tail (c_decay_initial == 0). The floor fixes
+        it; this is the regression guard.
+        """
+        q_root = np.array([0.003] * 30 + [0.0] * 30 + [0.003] * 60)
+        q_wt, _ = _run_percolation(q_root)
+        # The solver completed and produced a finite, physically bounded output.
+        assert np.all(np.isfinite(q_wt))
+        assert np.nanmin(q_wt) >= 0.0
+        np.testing.assert_array_less(q_wt, 0.003 + 1e-9)
+
+    def test_wetting_shock_into_drained_fan_conserves_mass(self):
+        """Equal-level (#222 exact input) conserves mass to a first-order grid tolerance.
+
+        Independent breakthrough integral vs ``Σ cin·Δθ − M_domain``; NOT the
+        ``compute_bin_averaged_concentration_exact`` (``m_in − m_dom``) route.
+        """
+        q_root = np.array([0.003] * 30 + [0.0] * 30 + [0.003] * 60)
+        _, state = _run_percolation(q_root)
+        rel_err = _independent_conservation_rel_err(q_root, state)
+        # ~1.5e-3: first-order trapezoidal truncation across the breakthrough shock
+        # fronts plus the numerical DecayingShockWave (quad+brentq) floor. An
+        # independent RK4 reference confirms the underlying solution conserves to
+        # ~0.17%; refining the grid further is dominated by the numerical-DSW cost.
+        assert rel_err < 2e-3, f"mass not conserved: relative error {rel_err:.3e}"
+
+    def test_unequal_wetting_shock_into_drained_fan_runs_and_conserves(self):
+        """Unequal-wet variant (post-gap flux differs) runs and conserves mass.
+
+        ``[0.003]*30 + [0.0]*30 + [0.005]*60``: the trailing wet plateau is at a
+        different level from the leading one, so the collision orientation and
+        fan-exhaustion guard are exercised in the growing decay regime.
+        """
+        q_root = np.array([0.003] * 30 + [0.0] * 30 + [0.005] * 60)
+        q_wt, state = _run_percolation(q_root)
+        assert np.all(np.isfinite(q_wt))
+        assert np.nanmin(q_wt) >= 0.0
+        rel_err = _independent_conservation_rel_err(q_root, state)
+        assert rel_err < 1e-3, f"mass not conserved: relative error {rel_err:.3e}"
+
+
+@pytest.mark.parametrize(
+    "c_decay_initial",
+    [0.0, -1e-30],
+)
+def test_decaying_shock_wave_floors_zero_decay_initial(c_decay_initial):
+    """A drained collision value of ``0`` is floored to ``_C_MIN``, not rejected.
+
+    Directly constructs the wave that the collision handler builds for the
+    #222 case (Brooks-Corey, ``c_fixed > 0``, fully drained tail) and asserts
+    the floor leaves ``c_decay_initial`` finite and positive and routes through
+    the numerical DSW path (closed-form ``K`` stays NaN).
+    """
+    sorption = BrooksCoreyConductivity(**_BC_KWARGS)
+    if c_decay_initial < 0.0:
+        with pytest.raises(ValueError, match="c_decay_initial must be non-negative"):
+            DecayingShockWave(
+                theta_start=24.0,
+                v_start=0.01,
+                c_decay_initial=c_decay_initial,
+                c_fixed=0.003,
+                c_fan_tail=0.003,
+                decay_side="right",
+                v_origin=0.0,
+                theta_origin=12.0,
+                sorption=sorption,
+            )
+        return
+
+    dsw = DecayingShockWave(
+        theta_start=24.0,
+        v_start=0.01,
+        c_decay_initial=c_decay_initial,
+        c_fixed=0.003,
+        c_fan_tail=0.003,
+        decay_side="right",
+        v_origin=0.0,
+        theta_origin=12.0,
+        sorption=sorption,
+    )
+    assert dsw.c_decay_initial == _C_MIN
+    # c_fixed > 0 with Brooks-Corey routes to the numerical solver, not a closed form.
+    assert np.isnan(dsw.K)
+    # Full drying (c_fan_tail == c_fixed) merges asymptotically: no finite exhaustion.
+    assert dsw.theta_at_fan_exhaustion() is None

--- a/tests/src/test_front_tracking_waves.py
+++ b/tests/src/test_front_tracking_waves.py
@@ -550,7 +550,7 @@ class TestDecayingShockWave:
             DecayingShockWave(decay_side="middle", **common)
 
         with pytest.raises(ValueError, match="c_decay_initial"):
-            DecayingShockWave(**{**common, "decay_side": "left", "c_decay_initial": 0.0})
+            DecayingShockWave(**{**common, "decay_side": "left", "c_decay_initial": -1.0})
 
         with pytest.raises(ValueError, match="c_fixed"):
             DecayingShockWave(**{**common, "decay_side": "left", "c_fixed": -1.0})


### PR DESCRIPTION
## Summary

A wet→dry→wet forcing (e.g. `q_root = [0.003]*30 + [0.0]*30 + [0.003]*60` through the Brooks-Corey percolation solver) crashed with `ValueError: c_decay_initial must be positive`, deep in the solver, on an otherwise-valid input. A fully-drained rarefaction fan reaches clean water (c=0); when a later wetting shock collides with its tail, the merged `DecayingShockWave` is handed `c_decay_initial = 0`, which `__post_init__` rejected.

The fix follows the package's existing dry-soil convention: rather than rejecting `c_decay_initial = 0`, floor it to the shared `_C_MIN` — the same floor `retardation()` already applies for the Brooks-Corey / Freundlich-n>1 / van-Genuchten singularity — so the retardation and secant-speed evaluations stay finite. `theta_at_fan_exhaustion`'s orientation guard is generalized to a `min/max` bracket so the growing-decay orientation is handled; for the issue's equal-level case the decay asymptotically merges with the fan head (no finite exhaustion) and the solver terminates cleanly.

An independent RK4 reference (built during review) confirms this conserves mass to ~0.15% on the issue's input — versus ~7% loss for the naive "spawn a clean-water shock and drop the fan" alternative, which discards the fan's stored profile.

Closes #222.

## Test plan

- New `tests/src/test_front_tracking_drained_fan_collision.py`: the issue's exact input and an unequal-level variant both run without raising (both crash on baseline) and conserve mass via an *independent* breakthrough-curve integral — `|∫ breakthrough dθ + M_domain − Σ cin·Δθ|`, deliberately not the `m_in − m_dom` route — to first-order grid tolerance (~1.5e-3 equal / ~5e-4 unequal).
- `test_decaying_shock_wave_floors_zero_decay_initial` pins the floor (c=0 → `_C_MIN`, numerical DSW path) and the negative-rejection; the `__post_init__` rejection test is updated (0.0 → -1.0) since 0.0 now floors.
- `pytest tests/src/test_front_tracking_waves.py tests/src/test_front_tracking_drained_fan_collision.py` pass; `ruff` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
