### PR TITLE
pre-commit: strip volatile notebook execution timestamps (keep run counts and output)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -78,3 +78,39 @@ for src in sorted(src_dir.glob("*.md")):
 PY
 
 git add .github/agents/
+
+# Strip the volatile per-cell execution timestamps (metadata.execution -- the dates a cell
+# last ran) from staged example notebooks so they never appear in version control.
+# execution_count and cell outputs are intentionally kept: they record that the notebook ran
+# and what it produced, which the example tests verify.
+python3 - <<'PY'
+import json
+import pathlib
+import subprocess
+
+result = subprocess.run(
+    ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+    capture_output=True,
+    text=True,
+)
+staged = [p for p in result.stdout.splitlines() if p.startswith("examples/") and p.endswith(".ipynb")]
+
+for rel_path in staged:
+    nb_path = pathlib.Path(rel_path)
+    if not nb_path.exists():
+        continue
+    with nb_path.open(encoding="utf-8") as f:
+        nb = json.load(f)
+    changed = False
+    for cell in nb.get("cells", []):
+        if cell.get("cell_type") != "code":
+            continue
+        if "execution" in cell.get("metadata", {}):
+            del cell["metadata"]["execution"]
+            changed = True
+    if changed:
+        with nb_path.open("w", encoding="utf-8") as f:
+            json.dump(nb, f, indent=1, ensure_ascii=False)
+            f.write("\n")
+        subprocess.run(["git", "add", rel_path], check=True)
+PY

--- a/examples/01_Aquifer_Characterization_Temperature.ipynb
+++ b/examples/01_Aquifer_Characterization_Temperature.ipynb
@@ -67,14 +67,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "imports",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:08:15.969007Z",
-     "iopub.status.busy": "2026-05-10T21:08:15.968924Z",
-     "iopub.status.idle": "2026-05-10T21:08:17.039752Z",
-     "shell.execute_reply": "2026-05-10T21:08:17.038582Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -117,14 +110,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "generate_data",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:08:17.041824Z",
-     "iopub.status.busy": "2026-05-10T21:08:17.041604Z",
-     "iopub.status.idle": "2026-05-10T21:08:24.640308Z",
-     "shell.execute_reply": "2026-05-10T21:08:24.639763Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -177,14 +163,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "optimization_setup",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:08:24.641743Z",
-     "iopub.status.busy": "2026-05-10T21:08:24.641622Z",
-     "iopub.status.idle": "2026-05-10T21:08:24.646859Z",
-     "shell.execute_reply": "2026-05-10T21:08:24.646379Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -230,14 +209,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "objective_function",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:08:24.648053Z",
-     "iopub.status.busy": "2026-05-10T21:08:24.647958Z",
-     "iopub.status.idle": "2026-05-10T21:08:24.650531Z",
-     "shell.execute_reply": "2026-05-10T21:08:24.650099Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def objective(_xdata, mean, std):\n",
@@ -266,14 +238,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "optimization",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:08:24.651861Z",
-     "iopub.status.busy": "2026-05-10T21:08:24.651739Z",
-     "iopub.status.idle": "2026-05-10T21:09:08.516801Z",
-     "shell.execute_reply": "2026-05-10T21:09:08.516190Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -673,14 +638,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "model_predictions",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:09:08.518481Z",
-     "iopub.status.busy": "2026-05-10T21:09:08.518332Z",
-     "iopub.status.idle": "2026-05-10T21:09:16.278950Z",
-     "shell.execute_reply": "2026-05-10T21:09:16.278310Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -741,14 +699,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "temperature_plots",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:09:16.280775Z",
-     "iopub.status.busy": "2026-05-10T21:09:16.280630Z",
-     "iopub.status.idle": "2026-05-10T21:09:16.602923Z",
-     "shell.execute_reply": "2026-05-10T21:09:16.602411Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -812,14 +763,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "discretization",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:09:16.604568Z",
-     "iopub.status.busy": "2026-05-10T21:09:16.604435Z",
-     "iopub.status.idle": "2026-05-10T21:09:16.608648Z",
-     "shell.execute_reply": "2026-05-10T21:09:16.607984Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -867,14 +811,7 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "gamma_distribution_plot",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-10T21:09:16.609966Z",
-     "iopub.status.busy": "2026-05-10T21:09:16.609860Z",
-     "iopub.status.idle": "2026-05-10T21:09:16.709740Z",
-     "shell.execute_reply": "2026-05-10T21:09:16.709210Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/examples/02_Residence_Time_Analysis.ipynb
+++ b/examples/02_Residence_Time_Analysis.ipynb
@@ -59,14 +59,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "imports",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:47.598981Z",
-     "iopub.status.busy": "2026-04-23T18:41:47.598839Z",
-     "iopub.status.idle": "2026-04-23T18:41:48.650723Z",
-     "shell.execute_reply": "2026-04-23T18:41:48.650157Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -108,14 +101,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "generate_data",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:48.652156Z",
-     "iopub.status.busy": "2026-04-23T18:41:48.651977Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.071564Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.071151Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -169,14 +155,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "discretize_distribution",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:55.073088Z",
-     "iopub.status.busy": "2026-04-23T18:41:55.072981Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.076458Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.076016Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -220,14 +199,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "forward_calculation",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:55.077680Z",
-     "iopub.status.busy": "2026-04-23T18:41:55.077605Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.116256Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.115870Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -270,14 +242,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "forward_statistics",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:55.117534Z",
-     "iopub.status.busy": "2026-04-23T18:41:55.117455Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.175378Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.175005Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -332,14 +297,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "qatgtoe9iah",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:55.176639Z",
-     "iopub.status.busy": "2026-04-23T18:41:55.176547Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.180529Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.180164Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -381,14 +339,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "forward_plot",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:55.181761Z",
-     "iopub.status.busy": "2026-04-23T18:41:55.181686Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.535810Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.535268Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -496,14 +447,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "backward_calculation",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:55.537317Z",
-     "iopub.status.busy": "2026-04-23T18:41:55.537215Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.577109Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.576696Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -542,14 +486,7 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "backward_statistics",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:55.578305Z",
-     "iopub.status.busy": "2026-04-23T18:41:55.578225Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.639149Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.638711Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -609,14 +546,7 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "backward_plot",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:55.640610Z",
-     "iopub.status.busy": "2026-04-23T18:41:55.640509Z",
-     "iopub.status.idle": "2026-04-23T18:41:55.944748Z",
-     "shell.execute_reply": "2026-04-23T18:41:55.944327Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/examples/03_Pathogen_Removal_Bank_Filtration.ipynb
+++ b/examples/03_Pathogen_Removal_Bank_Filtration.ipynb
@@ -62,14 +62,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "imports",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:57.307760Z",
-     "iopub.status.busy": "2026-04-23T18:41:57.307518Z",
-     "iopub.status.idle": "2026-04-23T18:41:58.395803Z",
-     "shell.execute_reply": "2026-04-23T18:41:58.395307Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -121,14 +114,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "basic_example",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:58.397213Z",
-     "iopub.status.busy": "2026-04-23T18:41:58.397062Z",
-     "iopub.status.idle": "2026-04-23T18:41:58.400720Z",
-     "shell.execute_reply": "2026-04-23T18:41:58.400231Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -199,14 +185,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "ts3axiyoxf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:58.401967Z",
-     "iopub.status.busy": "2026-04-23T18:41:58.401878Z",
-     "iopub.status.idle": "2026-04-23T18:41:58.405253Z",
-     "shell.execute_reply": "2026-04-23T18:41:58.404849Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -275,14 +254,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "parallel_demonstration",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:58.406480Z",
-     "iopub.status.busy": "2026-04-23T18:41:58.406385Z",
-     "iopub.status.idle": "2026-04-23T18:41:58.408922Z",
-     "shell.execute_reply": "2026-04-23T18:41:58.408600Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -341,14 +313,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "design_optimization",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:58.410236Z",
-     "iopub.status.busy": "2026-04-23T18:41:58.410148Z",
-     "iopub.status.idle": "2026-04-23T18:41:58.413507Z",
-     "shell.execute_reply": "2026-04-23T18:41:58.413149Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -445,14 +410,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "data_generation",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:41:58.414700Z",
-     "iopub.status.busy": "2026-04-23T18:41:58.414628Z",
-     "iopub.status.idle": "2026-04-23T18:42:04.961187Z",
-     "shell.execute_reply": "2026-04-23T18:42:04.960746Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -502,14 +460,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "log_removal_calculation",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:42:04.962454Z",
-     "iopub.status.busy": "2026-04-23T18:42:04.962356Z",
-     "iopub.status.idle": "2026-04-23T18:42:05.086906Z",
-     "shell.execute_reply": "2026-04-23T18:42:05.086413Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -578,14 +529,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "time_series_plot",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:42:05.088281Z",
-     "iopub.status.busy": "2026-04-23T18:42:05.088190Z",
-     "iopub.status.idle": "2026-04-23T18:42:05.446923Z",
-     "shell.execute_reply": "2026-04-23T18:42:05.446447Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -667,14 +611,7 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "summary_stats",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-23T18:42:05.448471Z",
-     "iopub.status.busy": "2026-04-23T18:42:05.448385Z",
-     "iopub.status.idle": "2026-04-23T18:42:05.452578Z",
-     "shell.execute_reply": "2026-04-23T18:42:05.452155Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",

--- a/examples/04_Deposition_Analysis_Bank_Filtration.ipynb
+++ b/examples/04_Deposition_Analysis_Bank_Filtration.ipynb
@@ -57,14 +57,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "imports",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-04T19:17:20.194863Z",
-     "iopub.status.busy": "2026-04-04T19:17:20.194647Z",
-     "iopub.status.idle": "2026-04-04T19:17:21.001362Z",
-     "shell.execute_reply": "2026-04-04T19:17:21.001094Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -108,14 +101,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "aa19937d",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-04T19:17:21.002683Z",
-     "iopub.status.busy": "2026-04-04T19:17:21.002567Z",
-     "iopub.status.idle": "2026-04-04T19:17:23.083348Z",
-     "shell.execute_reply": "2026-04-04T19:17:23.083084Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -172,14 +158,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "2c720eba",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-04T19:17:23.084590Z",
-     "iopub.status.busy": "2026-04-04T19:17:23.084498Z",
-     "iopub.status.idle": "2026-04-04T19:17:23.087413Z",
-     "shell.execute_reply": "2026-04-04T19:17:23.087195Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -246,14 +225,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "forward_calculation",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-04T19:17:23.088650Z",
-     "iopub.status.busy": "2026-04-04T19:17:23.088553Z",
-     "iopub.status.idle": "2026-04-04T19:17:23.333339Z",
-     "shell.execute_reply": "2026-04-04T19:17:23.333073Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -350,14 +322,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "1b514a11",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-04T19:17:23.334654Z",
-     "iopub.status.busy": "2026-04-04T19:17:23.334562Z",
-     "iopub.status.idle": "2026-04-04T19:17:24.175450Z",
-     "shell.execute_reply": "2026-04-04T19:17:24.175193Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -496,14 +461,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "vz9j7vg1t4",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-04T19:17:24.176723Z",
-     "iopub.status.busy": "2026-04-04T19:17:24.176634Z",
-     "iopub.status.idle": "2026-04-04T19:17:24.333305Z",
-     "shell.execute_reply": "2026-04-04T19:17:24.333064Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",

--- a/examples/08_bank_filtration_timflow.ipynb
+++ b/examples/08_bank_filtration_timflow.ipynb
@@ -25,14 +25,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "install-imports",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-24T12:26:49.452093Z",
-     "iopub.status.busy": "2026-04-24T12:26:49.451915Z",
-     "iopub.status.idle": "2026-04-24T12:26:51.072643Z",
-     "shell.execute_reply": "2026-04-24T12:26:51.071965Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# This notebook needs the `timflow` PyPI package in addition to `gwtransport`.\n",
@@ -61,14 +54,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "vendored-helpers",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-24T12:26:51.074798Z",
-     "iopub.status.busy": "2026-04-24T12:26:51.074584Z",
-     "iopub.status.idle": "2026-04-24T12:26:51.087587Z",
-     "shell.execute_reply": "2026-04-24T12:26:51.087149Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def build_strip_model(\n",
@@ -361,14 +347,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "model-build",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-24T12:26:51.089196Z",
-     "iopub.status.busy": "2026-04-24T12:26:51.089022Z",
-     "iopub.status.idle": "2026-04-24T12:26:51.093217Z",
-     "shell.execute_reply": "2026-04-24T12:26:51.092507Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Geometry and aquifer properties\n",
@@ -395,14 +374,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "trace-edges",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-24T12:26:51.094609Z",
-     "iopub.status.busy": "2026-04-24T12:26:51.094508Z",
-     "iopub.status.idle": "2026-04-24T12:26:51.711836Z",
-     "shell.execute_reply": "2026-04-24T12:26:51.711282Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Place tube boundaries at equal-flux intervals on the mid-domain line,\n",
@@ -421,14 +393,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "fig-streamlines",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-24T12:26:51.713437Z",
-     "iopub.status.busy": "2026-04-24T12:26:51.713321Z",
-     "iopub.status.idle": "2026-04-24T12:26:51.911918Z",
-     "shell.execute_reply": "2026-04-24T12:26:51.911480Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -487,14 +452,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "fig-apvd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-24T12:26:51.913301Z",
-     "iopub.status.busy": "2026-04-24T12:26:51.913211Z",
-     "iopub.status.idle": "2026-04-24T12:26:52.197641Z",
-     "shell.execute_reply": "2026-04-24T12:26:52.197208Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -616,14 +574,7 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "dataset",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-24T12:26:52.199033Z",
-     "iopub.status.busy": "2026-04-24T12:26:52.198930Z",
-     "iopub.status.idle": "2026-04-24T12:26:52.994601Z",
-     "shell.execute_reply": "2026-04-24T12:26:52.994159Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df, tedges_ts = generate_temperature_example_data(\n",
@@ -677,14 +628,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "fig-timeseries",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-04-24T12:26:52.996215Z",
-     "iopub.status.busy": "2026-04-24T12:26:52.996108Z",
-     "iopub.status.idle": "2026-04-24T12:26:53.367337Z",
-     "shell.execute_reply": "2026-04-24T12:26:53.366951Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/examples/10_Advection_with_non_linear_sorption.ipynb
+++ b/examples/10_Advection_with_non_linear_sorption.ipynb
@@ -183,14 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:45.774639Z",
-     "iopub.status.busy": "2026-05-18T20:09:45.774504Z",
-     "iopub.status.idle": "2026-05-18T20:09:47.242520Z",
-     "shell.execute_reply": "2026-05-18T20:09:47.242017Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import matplotlib.pyplot as plt\n",
@@ -231,14 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:47.244095Z",
-     "iopub.status.busy": "2026-05-18T20:09:47.243948Z",
-     "iopub.status.idle": "2026-05-18T20:09:47.249796Z",
-     "shell.execute_reply": "2026-05-18T20:09:47.249136Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -274,14 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:47.271309Z",
-     "iopub.status.busy": "2026-05-18T20:09:47.271175Z",
-     "iopub.status.idle": "2026-05-18T20:09:47.422998Z",
-     "shell.execute_reply": "2026-05-18T20:09:47.422537Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -321,14 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:47.424260Z",
-     "iopub.status.busy": "2026-05-18T20:09:47.424166Z",
-     "iopub.status.idle": "2026-05-18T20:09:47.830615Z",
-     "shell.execute_reply": "2026-05-18T20:09:47.830069Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -380,14 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:47.832079Z",
-     "iopub.status.busy": "2026-05-18T20:09:47.831959Z",
-     "iopub.status.idle": "2026-05-18T20:09:47.836122Z",
-     "shell.execute_reply": "2026-05-18T20:09:47.835325Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -428,14 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:47.837686Z",
-     "iopub.status.busy": "2026-05-18T20:09:47.837580Z",
-     "iopub.status.idle": "2026-05-18T20:09:47.853713Z",
-     "shell.execute_reply": "2026-05-18T20:09:47.853148Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -475,14 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:47.854860Z",
-     "iopub.status.busy": "2026-05-18T20:09:47.854774Z",
-     "iopub.status.idle": "2026-05-18T20:09:48.043500Z",
-     "shell.execute_reply": "2026-05-18T20:09:48.043020Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -543,14 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:48.044882Z",
-     "iopub.status.busy": "2026-05-18T20:09:48.044774Z",
-     "iopub.status.idle": "2026-05-18T20:09:48.047787Z",
-     "shell.execute_reply": "2026-05-18T20:09:48.047364Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -588,14 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:48.049142Z",
-     "iopub.status.busy": "2026-05-18T20:09:48.049054Z",
-     "iopub.status.idle": "2026-05-18T20:09:48.081813Z",
-     "shell.execute_reply": "2026-05-18T20:09:48.081261Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -635,14 +572,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:48.083480Z",
-     "iopub.status.busy": "2026-05-18T20:09:48.083309Z",
-     "iopub.status.idle": "2026-05-18T20:09:48.289532Z",
-     "shell.execute_reply": "2026-05-18T20:09:48.289149Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -695,14 +625,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:48.291324Z",
-     "iopub.status.busy": "2026-05-18T20:09:48.291198Z",
-     "iopub.status.idle": "2026-05-18T20:09:48.355634Z",
-     "shell.execute_reply": "2026-05-18T20:09:48.355142Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -745,14 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-18T20:09:48.356824Z",
-     "iopub.status.busy": "2026-05-18T20:09:48.356740Z",
-     "iopub.status.idle": "2026-05-18T20:09:48.631458Z",
-     "shell.execute_reply": "2026-05-18T20:09:48.630920Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {

--- a/examples/11_Percolation_Unsaturated_Zone.ipynb
+++ b/examples/11_Percolation_Unsaturated_Zone.ipynb
@@ -45,14 +45,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "d2bb8e83",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T07:23:34.437139Z",
-     "iopub.status.busy": "2026-05-23T07:23:34.437004Z",
-     "iopub.status.idle": "2026-05-23T07:23:35.512697Z",
-     "shell.execute_reply": "2026-05-23T07:23:35.512213Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import warnings\n",
@@ -92,14 +85,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "f190e635",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T07:23:35.514143Z",
-     "iopub.status.busy": "2026-05-23T07:23:35.514021Z",
-     "iopub.status.idle": "2026-05-23T07:23:35.519116Z",
-     "shell.execute_reply": "2026-05-23T07:23:35.518587Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "def _f_at(t_days, k_scaling, tedges):\n",
@@ -169,14 +155,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "650df2bf",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T07:23:35.520371Z",
-     "iopub.status.busy": "2026-05-23T07:23:35.520287Z",
-     "iopub.status.idle": "2026-05-23T07:23:35.522118Z",
-     "shell.execute_reply": "2026-05-23T07:23:35.521697Z"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "THETA_R, THETA_S, K_S = 0.01, 0.337, 0.174  # m/day\n",
@@ -201,14 +180,7 @@
    "cell_type": "code",
    "execution_count": 4,
    "id": "c2bbe938",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T07:23:35.523313Z",
-     "iopub.status.busy": "2026-05-23T07:23:35.523201Z",
-     "iopub.status.idle": "2026-05-23T07:23:35.654043Z",
-     "shell.execute_reply": "2026-05-23T07:23:35.653487Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -270,14 +242,7 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "9864f2fb",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T07:23:35.655279Z",
-     "iopub.status.busy": "2026-05-23T07:23:35.655181Z",
-     "iopub.status.idle": "2026-05-23T07:23:35.725992Z",
-     "shell.execute_reply": "2026-05-23T07:23:35.724444Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -355,14 +320,7 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "b5ee0088",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-23T07:23:35.728325Z",
-     "iopub.status.busy": "2026-05-23T07:23:35.728209Z",
-     "iopub.status.idle": "2026-05-23T07:23:35.873057Z",
-     "shell.execute_reply": "2026-05-23T07:23:35.872627Z"
-    }
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -83,7 +83,12 @@ def test_ipynb(ipynb_path):
 
 def test_notebook_cells_executed(ipynb_path):
     """
-    Test that notebook cells have been executed by checking execution numbers.
+    Test that the notebook ran top-to-bottom and its output is committed.
+
+    Every code cell must have a non-null integer ``execution_count`` (an unexecuted cell has
+    ``None``), and the notebook must retain at least one committed cell output. The pre-commit
+    hook strips only the volatile ``metadata.execution`` timestamps, so ``execution_count`` and
+    cell outputs survive in version control and remain checkable here.
 
     Parameters
     ----------
@@ -93,11 +98,12 @@ def test_notebook_cells_executed(ipynb_path):
     Raises
     ------
     AssertionError
-        If any code cell lacks an execution number.
+        If any code cell lacks an execution number, or the notebook has no committed output.
     """
     with open(ipynb_path, encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=nbformat.NO_CONVERT)
 
+    has_output = False
     for i, cell in enumerate(nb.cells):
         if cell.cell_type == "code":
             execution_count = cell.get("execution_count")
@@ -107,6 +113,10 @@ def test_notebook_cells_executed(ipynb_path):
             assert isinstance(execution_count, int), (
                 f"Cell {i} in {ipynb_path} has invalid execution_count: {execution_count}"
             )
+            if cell.get("outputs"):
+                has_output = True
+
+    assert has_output, f"{ipynb_path} has no committed cell outputs; run the notebook and commit its output"
 
 
 @pytest.mark.xfail(reason="This notebook is expected to fail during execution")


### PR DESCRIPTION
## Summary

Re-running an example notebook rewrites the per-cell `metadata.execution` block — the iopub/shell **timestamps** recording the dates a cell last ran — producing noisy version-control diffs unrelated to the change (#177).

This adds a step to `.githooks/pre-commit` that strips **only** that timestamp block from staged `examples/*.ipynb`. `execution_count` and cell `outputs` are intentionally **kept**: together they record that the notebook ran top-to-bottom and what it produced, which the example tests verify. (Stripping the timestamps is the issue's actual ask — "the dates at which the cell ran"; counts and outputs are not dates.)

`tests/examples/test_examples.py`: `test_notebook_cells_executed` now verifies the notebook **ran and its output is committed** — every code cell has a non-null integer `execution_count` (an unexecuted cell is `None`) and the notebook retains at least one cell output. The failing-notebook xfail/detection tests are unchanged (they still detect the unexecuted fixture via its null `execution_count`).

The `pre-commit-check` CI job runs the hook and fails on any residual diff, so a notebook committed with stale `metadata.execution` is caught there.

Closes #177.

## Test plan

- `pytest tests/examples/test_examples.py -k "notebook_cells_executed or failing"` — 8 passed, 1 xfailed (the ran + output guard passes on every example notebook; failing-notebook detection still fires).
- Confirmed the strip diff is exactly the `metadata.execution` removal — `execution_count` and `outputs` untouched — and that it is idempotent (a second pass changes nothing).
- `ruff` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
