### PR TITLE
logremoval: time_until_log_removal_breach -- headroom before a target log removal is breached

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -74,6 +74,9 @@ convention = "numpy"
 "src/gwtransport/advection.py" = [
     "DOC502",  # Public entry points document ValueError; the raises happen inside _validate_advection_inputs
 ]
+"src/gwtransport/logremoval.py" = [
+    "DOC502",  # time_until_log_removal_breach documents ValueError; raises happen in the _validation atoms / gamma_find_flow_for_target_mean
+]
 "src/gwtransport/fronttracking/*.py" = [
     # Physics module: docstrings intentionally use unicode symbols (θ, α, ρ, ×, ≤, ≥) for math notation.
     "RUF002",  # Ambiguous unicode in docstrings (greek letters / math symbols are intentional)

--- a/src/gwtransport/logremoval.py
+++ b/src/gwtransport/logremoval.py
@@ -81,13 +81,25 @@ Available functions:
   effective mean log removal given gamma-distributed aquifer pore volume. Solves inverse problem:
   flow = apv_beta * mu * ln(10) / (10^(target_mean / apv_alpha) - 1).
 
+- :func:`time_until_log_removal_breach` - For a flow time series, the days at each step until the
+  flow first rises past the threshold flow Q* (where the effective mean log removal equals a
+  target), i.e. the headroom before the target is breached. NaN where it never breaches.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """
 
 import numpy as np
 import numpy.typing as npt
+import pandas as pd
 from scipy import optimize, stats
+
+from gwtransport._time import tedges_to_days
+from gwtransport._validation import (
+    _validate_no_nan,
+    _validate_non_negative_array,
+    _validate_tedges_parity,
+)
 
 
 def residence_time_to_log_removal(
@@ -594,3 +606,112 @@ def gamma_find_flow_for_target_mean(
 
     u_root = optimize.brentq(residual, 0.0, u_upper)
     return 1.0 / float(u_root)  # type: ignore[arg-type]
+
+
+def time_until_log_removal_breach(
+    *,
+    flow: npt.ArrayLike,
+    tedges: pd.DatetimeIndex,
+    apv_alpha: float,
+    apv_beta: float,
+    apv_loc: float = 0.0,
+    log10_decay_rate: float,
+    target_log_removal: float,
+) -> npt.NDArray[np.floating]:
+    """Days until the flow series breaches a target effective log removal.
+
+    For a (shifted) gamma-distributed aquifer pore volume, the effective parallel-mean log
+    removal decreases monotonically with flow: faster extraction shortens residence time and
+    removes fewer pathogens. The threshold flow ``Q*`` at which the effective mean equals
+    ``target_log_removal`` is given in closed form by :func:`gamma_find_flow_for_target_mean`;
+    the target is met while ``flow <= Q*`` and breached once ``flow > Q*``.
+
+    For each input bin this returns the headroom -- the number of days from the start of the
+    bin until the flow series first rises above ``Q*`` (the first breaching bin). A bin already
+    above ``Q*`` has zero headroom; a bin from which the flow never breaches again returns
+    ``NaN``. This is a *snapshot* evaluation of the effective mean at the instantaneous flow;
+    it does not integrate the transient residence-time evolution that follows a flow change.
+
+    Parameters
+    ----------
+    flow : array-like
+        Extraction flow rate, constant over each ``[tedges[i], tedges[i+1])`` bin (same volume
+        units as ``apv_beta`` per day). Non-negative. Length ``len(tedges) - 1``.
+    tedges : pandas.DatetimeIndex
+        Time bin edges. Length ``n + 1`` for ``n`` flow bins.
+    apv_alpha : float
+        Shape parameter of the gamma aquifer-pore-volume distribution. Positive.
+    apv_beta : float
+        Scale parameter of the gamma aquifer-pore-volume distribution (volume). Positive.
+    apv_loc : float, optional
+        Minimum aquifer pore volume (gamma location). Non-negative. Default ``0.0``.
+    log10_decay_rate : float
+        Log10 decay rate mu (log10/day). Positive.
+    target_log_removal : float
+        Target effective mean log removal to stay at or above. Positive.
+
+    Returns
+    -------
+    ndarray
+        Headroom in days for each flow bin (length ``len(tedges) - 1``). ``0.0`` for a bin
+        already in breach; ``NaN`` for a bin from which no later bin breaches the target.
+
+    Raises
+    ------
+    ValueError
+        If ``tedges`` does not have one more element than ``flow``, if ``flow`` contains NaN or
+        negative values, or (via :func:`gamma_find_flow_for_target_mean`) if the gamma
+        parameters, ``log10_decay_rate``, or ``target_log_removal`` are out of range.
+
+    See Also
+    --------
+    gamma_find_flow_for_target_mean : Closed-form threshold flow ``Q*``.
+    gamma_mean : Effective mean log removal for gamma-distributed residence time.
+    :ref:`concept-pore-volume-distribution` : Why residence times are distributed.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> tedges = pd.date_range("2025-01-01", periods=5, freq="D")
+    >>> flow = np.array([10.0, 11.0, 15.0, 16.0])  # rises past Q* (~12.8) at bin 2
+    >>> headroom = time_until_log_removal_breach(
+    ...     flow=flow,
+    ...     tedges=tedges,
+    ...     apv_alpha=2.0,
+    ...     apv_beta=100.0,
+    ...     log10_decay_rate=0.5,
+    ...     target_log_removal=2.0,
+    ... )
+    >>> headroom.tolist()
+    [2.0, 1.0, 0.0, 0.0]
+    """
+    flow_arr = np.asarray(flow, dtype=float)
+    _validate_tedges_parity(tedges, flow_arr, tedges_name="tedges", values_name="flow")
+    _validate_no_nan(flow_arr, name="flow")
+    _validate_non_negative_array(flow_arr, name="flow")
+
+    # Threshold flow Q*: gamma_find_flow_for_target_mean validates apv_*, log10_decay_rate and
+    # target_log_removal. The effective mean LR decreases with flow, so the target is met while
+    # flow <= Q* and breached once flow > Q*.
+    q_star = gamma_find_flow_for_target_mean(
+        target_mean=target_log_removal,
+        apv_alpha=apv_alpha,
+        apv_beta=apv_beta,
+        apv_loc=apv_loc,
+        log10_decay_rate=log10_decay_rate,
+    )
+
+    edge_days = tedges_to_days(tedges)
+    n = flow_arr.size
+    breach_idx = np.flatnonzero(flow_arr > q_star)
+    if breach_idx.size == 0:
+        return np.full(n, np.nan)
+
+    # First breaching bin at or after each bin i, via the sorted breach indices (no Python loop).
+    pos = np.searchsorted(breach_idx, np.arange(n), side="left")
+    has_future_breach = pos < breach_idx.size
+    first_breach = breach_idx[np.clip(pos, 0, breach_idx.size - 1)]
+    # first_breach >= i and edge_days is non-decreasing, so headroom is always >= 0.
+    headroom = edge_days[first_breach] - edge_days[:n]
+    return np.where(has_future_breach, headroom, np.nan)

--- a/tests/src/test_logremoval.py
+++ b/tests/src/test_logremoval.py
@@ -16,6 +16,7 @@ from gwtransport.logremoval import (
     log10_decay_rate_to_decay_rate,
     parallel_mean,
     residence_time_to_log_removal,
+    time_until_log_removal_breach,
 )
 from gwtransport.residence_time import residence_time as compute_residence_time
 
@@ -913,3 +914,109 @@ def test_residence_time_to_log_removal_negative_residence_time():
     """Negative residence time returns negative log removal; no validation is performed."""
     result = residence_time_to_log_removal(residence_times=-5.0, log10_decay_rate=0.2)
     assert_allclose(result, -1.0, rtol=1e-15)
+
+
+_PR6_APV = {"apv_alpha": 2.0, "apv_beta": 100.0, "log10_decay_rate": 0.5}
+_PR6_TARGET = 2.0
+
+
+def _pr6_q_star():
+    """Threshold flow Q* (effective LR == target) for the #92 test parameters."""
+    return gamma_find_flow_for_target_mean(target_mean=_PR6_TARGET, **_PR6_APV)
+
+
+class TestTimeUntilLogRemovalBreach:
+    """Tests for ``time_until_log_removal_breach`` (#92, margin-to-target-flow semantics)."""
+
+    def test_threshold_flow_yields_target_log_removal(self):
+        """Q* is exactly the flow at which the effective gamma-mean LR equals the target.
+
+        Pins the threshold semantics: at Q* the residence-time gamma has scale ``apv_beta/Q*``,
+        so :func:`gamma_mean` returns the target to machine precision.
+        """
+        q_star = _pr6_q_star()
+        lr_at_q_star = gamma_mean(
+            rt_alpha=_PR6_APV["apv_alpha"],
+            rt_beta=_PR6_APV["apv_beta"] / q_star,
+            log10_decay_rate=_PR6_APV["log10_decay_rate"],
+        )
+        assert_allclose(lr_at_q_star, _PR6_TARGET, rtol=1e-12)
+
+    def test_breach_detected_at_first_bin_above_threshold(self):
+        """Headroom counts days from each bin's start to the first future bin with flow > Q*."""
+        q_star = _pr6_q_star()  # ~12.79 for these parameters
+        tedges = pd.date_range("2025-01-01", periods=5, freq="D")  # daily edges 0..4
+        # Two bins safely below Q*, then two above: the breach starts at bin index 2.
+        flow = np.array([q_star * 0.5, q_star * 0.9, q_star * 1.2, q_star * 1.3])
+
+        headroom = time_until_log_removal_breach(flow=flow, tedges=tedges, target_log_removal=_PR6_TARGET, **_PR6_APV)
+        # Breach at day 2: headroom = [2-0, 2-1, 0, 0], exact edge arithmetic.
+        assert_allclose(headroom, [2.0, 1.0, 0.0, 0.0], rtol=0, atol=0)
+
+    def test_never_breaches_returns_nan(self):
+        """A flow series always at or below Q* never breaches: all-NaN headroom."""
+        q_star = _pr6_q_star()
+        tedges = pd.date_range("2025-01-01", periods=4, freq="D")
+        flow = np.full(3, q_star * 0.5)
+        headroom = time_until_log_removal_breach(flow=flow, tedges=tedges, target_log_removal=_PR6_TARGET, **_PR6_APV)
+        assert np.all(np.isnan(headroom))
+
+    def test_already_breaching_is_zero_headroom(self):
+        """A flow series entirely above Q* is in breach everywhere: zero headroom."""
+        q_star = _pr6_q_star()
+        tedges = pd.date_range("2025-01-01", periods=4, freq="D")
+        flow = np.full(3, q_star * 1.5)
+        headroom = time_until_log_removal_breach(flow=flow, tedges=tedges, target_log_removal=_PR6_TARGET, **_PR6_APV)
+        assert_allclose(headroom, 0.0, rtol=0, atol=0)
+
+    def test_analytic_ramp_crossing_time(self):
+        """A linearly ramping flow gives headroom equal to the exact edge-grid crossing gap."""
+        q_star = _pr6_q_star()
+        tedges = pd.date_range("2025-01-01", periods=11, freq="D")  # daily edges 0..10
+        flow = np.linspace(q_star * 0.6, q_star * 1.4, 10)  # monotone, crosses Q* once
+
+        headroom = time_until_log_removal_breach(flow=flow, tedges=tedges, target_log_removal=_PR6_TARGET, **_PR6_APV)
+
+        first_breach = int(np.flatnonzero(flow > q_star)[0])
+        edge_days = np.arange(11.0)
+        idx = np.arange(10)
+        # Bins before the crossing count days to the first breaching edge; from the crossing on, 0.
+        expected = np.where(idx < first_breach, edge_days[first_breach] - edge_days[:10], 0.0)
+        assert_allclose(headroom, expected, rtol=0, atol=0)
+
+    def test_validation_rejects_bad_inputs(self):
+        """tedges/flow parity, NaN, and negative flow are rejected at the boundary."""
+        tedges = pd.date_range("2025-01-01", periods=4, freq="D")  # needs 3 flow bins
+        common = {"target_log_removal": _PR6_TARGET, **_PR6_APV}
+        with pytest.raises(ValueError, match="tedges"):
+            time_until_log_removal_breach(flow=np.ones(2), tedges=tedges, **common)
+        with pytest.raises(ValueError, match="non-negative"):
+            time_until_log_removal_breach(flow=np.array([1.0, -1.0, 1.0]), tedges=tedges, **common)
+        with pytest.raises(ValueError, match="NaN"):
+            time_until_log_removal_breach(flow=np.array([1.0, np.nan, 1.0]), tedges=tedges, **common)
+
+    def test_exact_threshold_flow_is_not_a_breach(self):
+        """Flow exactly equal to Q* is not a breach (strict ``>``); such bins return NaN.
+
+        Pins the boundary so a future change of ``>`` to ``>=`` would fail this test.
+        """
+        q_star = _pr6_q_star()
+        tedges = pd.date_range("2025-01-01", periods=4, freq="D")
+        flow = np.full(3, q_star)  # exactly at the threshold
+        headroom = time_until_log_removal_breach(flow=flow, tedges=tedges, target_log_removal=_PR6_TARGET, **_PR6_APV)
+        assert np.all(np.isnan(headroom))
+
+    def test_non_uniform_edges_and_positive_loc(self):
+        """Headroom counts day-offsets (not bin indices) and handles apv_loc > 0 (numerical Q*).
+
+        A 5-day-wide middle bin makes the day-offset headroom (6, 5, 0) differ from a naive
+        bin-count (2, 1, 0), pinning that ``edge_days`` -- not the bin index -- drives the result.
+        A positive ``apv_loc`` exercises the brentq branch of ``gamma_find_flow_for_target_mean``.
+        """
+        apv = {"apv_alpha": 2.0, "apv_beta": 100.0, "apv_loc": 5.0, "log10_decay_rate": 0.5}
+        q_star = gamma_find_flow_for_target_mean(target_mean=_PR6_TARGET, **apv)
+        # Edges at days [0, 1, 6, 7]: breach starts at the wide bin's left edge (day 6).
+        tedges = pd.DatetimeIndex(["2025-01-01", "2025-01-02", "2025-01-07", "2025-01-08"])
+        flow = np.array([q_star * 0.5, q_star * 0.5, q_star * 1.5])
+        headroom = time_until_log_removal_breach(flow=flow, tedges=tedges, target_log_removal=_PR6_TARGET, **apv)
+        assert_allclose(headroom, [6.0, 5.0, 0.0], rtol=0, atol=0)


### PR DESCRIPTION
## Summary

Adds `logremoval.time_until_log_removal_breach`: a time series of how much margin a given extraction schedule has before it breaches a target pathogen log removal.

For a (shifted) gamma-distributed aquifer pore volume, the effective parallel-mean log removal decreases monotonically with flow (faster extraction → shorter residence → less removal). The threshold flow `Q*` at which the effective mean equals `target_log_removal` is the closed form already provided by `gamma_find_flow_for_target_mean`; the target is met while `flow ≤ Q*` and breached once `flow > Q*`. For each input bin the function returns the headroom — days from that bin's start until the flow series first rises above `Q*` — `0.0` for a bin already in breach, `NaN` for a bin from which the flow never breaches again. It is a snapshot evaluation at the instantaneous flow; integrating the residence-time transient after a flow change is a deferred follow-up.

A note on the issue's "step the flow up to `x`" framing: under the snapshot model a constant boost gives a constant effective log removal, so it has no meaningful crossing time. This v1 instead reports the margin of the *actual* flow trajectory against the target-log-removal flow `Q*` — the directly useful and exactly testable quantity.

Closes #92.

## Test plan

`pytest tests/src/test_logremoval.py` (new `TestTimeUntilLogRemovalBreach`, 8 tests):

- `Q*` pins the threshold: `gamma_mean` at `Q*` equals the target (rtol 1e-12).
- breach detection with flow straddling `Q*` (exact edge arithmetic); never-breaches → all NaN; already-breaching → all 0; an analytic ramp crossing.
- exact-threshold boundary (`flow == Q*` is *not* a breach — guards `>` vs `>=`); non-uniform `tedges` with `apv_loc > 0` (confirms day-offsets, not bin counts, and the numerical `Q*` path).
- input validation (tedges/flow parity, NaN, negative flow).
- `ruff` clean; the docstring doctest runs.

## Contributor License Agreement

- [ ] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
