### PR TITLE
Bump version to 0.35.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "requests>=2.19.0",
   "scipy>=1.13.0",
 ]
-version = "0.34.0"
+version = "0.35.0"
 [project.optional-dependencies]
 test = [
   "nbconvert>=7.1.0",


### PR DESCRIPTION
## Summary

Minor version bump from `0.34.0` to `0.35.0` in `pyproject.toml`.

## Test plan

No code changes; version metadata only. CI checks apply.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
