### PR TITLE
Rewrite diffusion_fast_fast as a fast approximate all-flow transport

### DIFF
--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -30,6 +30,14 @@ diffusion_fast
    :undoc-members:
    :show-inheritance:
 
+diffusion_fast_fast
+===================
+
+.. automodule:: gwtransport.diffusion_fast_fast
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 diffusion
 =========
 

--- a/docs/source/user_guide/assumptions.rst
+++ b/docs/source/user_guide/assumptions.rst
@@ -28,6 +28,8 @@ Module Reference
      - :py:func:`~gwtransport.logremoval.residence_time_to_log_removal`, :py:func:`~gwtransport.logremoval.gamma_mean`, :py:func:`~gwtransport.logremoval.parallel_mean`
    * - ``diffusion_fast``
      - :py:func:`~gwtransport.diffusion_fast.infiltration_to_extraction`
+   * - ``diffusion_fast_fast``
+     - :py:func:`~gwtransport.diffusion_fast_fast.infiltration_to_extraction`
    * - ``diffusion``
      - :py:func:`~gwtransport.diffusion.infiltration_to_extraction`
    * - ``gamma``
@@ -77,6 +79,7 @@ What appears as "dispersion" at one scale becomes "advection through heterogenei
 When using the ``advection`` module alone, only macrodispersion (spreading from the pore volume distribution) is modeled. To add microdispersion (:math:`\alpha_L`) and molecular diffusion (:math:`D_m`), use either :mod:`gwtransport.diffusion_fast` or :mod:`gwtransport.diffusion`. Both implement the *same* physics — the Kreft-Zuber flux concentration on a bundle of 1D streamtubes, with retardation and the moving-frame variance :math:`D_t = D_m \tau + \alpha_L \xi` — and both accept per-streamtube :math:`L`, :math:`D_m` and :math:`\alpha_L` arrays (one value per aquifer pore volume). They differ only in how the bin-averaged breakthrough is evaluated:
 
 - **Choose** :mod:`gwtransport.diffusion_fast` **by default.** It evaluates the breakthrough in closed form on only the non-zero breakthrough band, is roughly 80–90× faster (more at the weak-to-moderate dispersion of realistic problems), and reproduces :mod:`gwtransport.diffusion` to machine precision when the output (``cout``) grid is at or finer than the flow grid.
+- **Choose** :mod:`gwtransport.diffusion_fast_fast` **when you want a fast approximate forward result and can tolerate a small error** (regularly-sampled monitoring data, exploratory or ensemble runs). It applies advection, macrodispersion, and microdispersion (:math:`\alpha_L`) *exactly* on the native cumulative-volume grid and treats molecular diffusion (:math:`D_m`) as a time-domain Gaussian, in one fast pass for *any* flow (constant or variable — no fallback). It is accurate to ~3e-4 whenever mechanical dispersion is present (:math:`\alpha_L > 0`, the usual case, and flow-independent), degrading to ~1e-2 for sharp inputs in the molecular-diffusion-dominated regime (:math:`\alpha_L \approx 0`). It is **approximate** — it does *not* reproduce :mod:`gwtransport.diffusion_fast` to machine precision; use :mod:`gwtransport.diffusion_fast` when you need exact results, especially in the molecular-dominated regime. Its reverse (deconvolution) is exact (it builds the :mod:`gwtransport.diffusion_fast` operator).
 - **Choose** :mod:`gwtransport.diffusion` **only when the output (``cout``) grid is coarser than the flow detail:** it integrates the full ``tedges``-resolution flow within each output bin, whereas ``diffusion_fast`` treats the through-flow as constant within each output bin — a ~0.1%-of-peak difference for a rapidly-varying ``cin`` over wide output bins under variable flow. Otherwise the two are machine-precision identical in *every* regime, including retardation (:math:`R \neq 1`) together with molecular diffusion (:math:`D_m > 0`).
 
 .. _assumption-steady-streamlines:
@@ -595,6 +598,9 @@ Quick Reference: Assumptions by Module
    * - ``diffusion_fast``
      - :ref:`Steady streamlines <assumption-steady-streamlines>`
      - — (fast closed form, relaxes advection-only assumption)
+   * - ``diffusion_fast_fast``
+     - :ref:`Steady streamlines <assumption-steady-streamlines>`
+     - — (fast *approximate* all-flow transport; use ``diffusion_fast`` for machine precision)
    * - ``diffusion``
      - :ref:`Steady streamlines <assumption-steady-streamlines>`
      - — (quadrature, relaxes advection-only assumption)

--- a/docs/source/user_guide/concepts.rst
+++ b/docs/source/user_guide/concepts.rst
@@ -179,6 +179,7 @@ In pore volume units, :math:`\sigma_{V,disp}` is flow-independent, while :math:`
 
 - **Gamma-parameterized APVD**: Use :mod:`gwtransport.diffusion_fast` (standard approach).
 - **Discrete streamline volumes**: Use :mod:`gwtransport.diffusion_fast` or :mod:`gwtransport.diffusion`.
+- **Fast approximate forward (any flow)**: Use :mod:`gwtransport.diffusion_fast_fast` when a small error (~3e-4 with microdispersion present) is acceptable in exchange for speed.
 
 .. _concept-variance-components:
 

--- a/src/gwtransport/_diffusion_shared.py
+++ b/src/gwtransport/_diffusion_shared.py
@@ -1,0 +1,312 @@
+"""
+Shared closed-form helpers for the Kreft-Zuber flux-concentration transport modules.
+
+This private module holds the pieces common to :mod:`gwtransport.diffusion_fast` and
+:mod:`gwtransport.diffusion_fast_fast`: the breakthrough antiderivative, the retardation
+flux-coefficient correction, input validation, and the small per-streamtube / spin-up
+helpers. Both modules import from here so the closed-form math is defined once and produces
+bit-identical floating-point results regardless of which module evaluates it.
+
+This file is part of gwtransport which is released under AGPL-3.0 license.
+See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
+"""
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from scipy.special import erf, erfcx
+
+from gwtransport._time import dt_to_days
+
+# Minimum coefficient sum to consider an output bin valid.
+_EPSILON_COEFF_SUM = 1e-10
+
+# sqrt(pi), used in the closed-form breakthrough antiderivative.
+_SQRT_PI = np.sqrt(np.pi)
+
+# Floor on the moving-frame dispersion product D_t [m^2] to keep the erf argument finite
+# for pre-breakthrough / zero-dispersion edges (where D_t -> 0).
+_DT_FLOOR = 1e-30
+
+
+def _breakthrough_antideriv(
+    step_widths: npt.NDArray[np.floating], dt_var: npt.NDArray[np.floating]
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+    r"""Closed-form antiderivative of the resident concentration, evaluated per edge.
+
+    Returns :math:`I(x) = \tfrac12 x + \tfrac12[x\,\operatorname{erf}(x/s) + (s/\sqrt\pi)e^{-(x/s)^2}]`
+    with :math:`s = 2\sqrt{D_t}`, alongside ``s`` and the Gaussian factor ``exp(-(x/s)^2)`` (both
+    reused by the retardation correction). Shared by the dense kernel
+    (:func:`gwtransport.diffusion_fast._flux_breakthrough_fraction`) and the banded build, so both
+    compute identical floating-point results for the same inputs.
+
+    Returns
+    -------
+    antideriv : ndarray
+        The antiderivative :math:`I(x)`.
+    s : ndarray
+        ``2 * sqrt(D_t)``.
+    gaussian : ndarray
+        ``exp(-(x/s)^2)``.
+    """
+    s = 2.0 * np.sqrt(dt_var)
+    with np.errstate(over="ignore", invalid="ignore"):
+        u = step_widths / s
+        gaussian = np.exp(-(u * u))
+        antideriv = 0.5 * step_widths + 0.5 * (step_widths * erf(u) + (s / _SQRT_PI) * gaussian)
+    return antideriv, s, gaussian
+
+
+def _retardation_excess_density(
+    *,
+    x_lo: npt.NDArray[np.floating],
+    x_hi: npt.NDArray[np.floating],
+    dx: npt.NDArray[np.floating],
+    d_lo: npt.NDArray[np.floating],
+    d_hi: npt.NDArray[np.floating],
+    s_lo: npt.NDArray[np.floating],
+    s_hi: npt.NDArray[np.floating],
+    g_lo: npt.NDArray[np.floating],
+    g_hi: npt.NDArray[np.floating],
+) -> npt.NDArray[np.floating]:
+    r"""Closed-form bin-average of the Gaussian density ``<g>`` for the retardation correction.
+
+    When ``R != 1`` and ``D_m > 0`` the per-edge antiderivative bakes in an effective flux
+    coefficient ``dD_t/dx = R*D_m/v + alpha_L`` (because ``d(tau)/dx = R/v`` under retardation),
+    whereas Kreft-Zuber wants ``D_L/v = D_m/v + alpha_L``. The excess ``(R-1)*D_m/v`` is removed
+    by subtracting it times ``<g>``, the bin-average of the Gaussian density
+    ``g = e^{-x^2/(4 D_t)} / (2 sqrt(pi D_t))``. Within a bin ``D_t`` is linear in ``x``, so ``<g>``
+    is closed form: substituting ``w = D_t`` in ``int g dx`` gives
+    ``int w^{-1/2} e^{-w/(4 m^2) - c^2/(4 m^2 w)} dw`` -- a pair of error functions -- with slope
+    ``m = dD_t/dx`` and intercept ``c = D_t(x=0)``. Reusing the antiderivative's Gaussian factor
+    ``G = e^{-x^2/(4 D_t)}``, ``erfcx`` keeps the (always non-negative) ``u+`` branch overflow-free;
+    the ``u-`` branch splits: ``erfcx`` where ``u- >= 0``, ``erf`` elsewhere. Each transcendental is
+    evaluated on its own subset (fancy indexing) rather than over the full array. The slope->0
+    (constant-``D_t``) limit is the exact ``[C_R(x_hi) - C_R(x_lo)] / dx``, applied only on that subset.
+
+    Parameters
+    ----------
+    x_lo, x_hi : ndarray
+        Breakthrough coordinate ``step_widths`` at the lower / upper cout edge of each bin.
+    dx : ndarray
+        ``x_hi - x_lo``.
+    d_lo, d_hi : ndarray
+        Moving-frame dispersion product ``D_t`` at the lower / upper edge.
+    s_lo, s_hi : ndarray
+        ``2 * sqrt(D_t)`` at the lower / upper edge.
+    g_lo, g_hi : ndarray
+        Gaussian factor ``exp(-(x/s)^2)`` at the lower / upper edge.
+
+    Returns
+    -------
+    ndarray
+        Bin-averaged Gaussian density ``<g>``.
+    """
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        slope = (d_hi - d_lo) / dx
+        intercept = d_lo - slope * x_lo
+        abs_int = np.abs(intercept)
+        # s = 2*sqrt(D_t) is already computed, so slope*s = 2*slope*sqrt(D_t).
+        two_m_sqrt_lo = slope * s_lo
+        two_m_sqrt_hi = slope * s_hi
+        um_lo = (d_lo - abs_int) / two_m_sqrt_lo
+        um_hi = (d_hi - abs_int) / two_m_sqrt_hi
+        up_lo = (d_lo + abs_int) / two_m_sqrt_lo
+        up_hi = (d_hi + abs_int) / two_m_sqrt_hi
+        t_plus = g_lo * erfcx(up_lo) - g_hi * erfcx(up_hi)
+        t_minus = np.empty_like(t_plus)
+        pos = um_lo >= 0.0
+        neg = ~pos
+        t_minus[pos] = g_lo[pos] * erfcx(um_lo[pos]) - g_hi[pos] * erfcx(um_hi[pos])
+        c_minus = np.exp((intercept[neg] - abs_int[neg]) / (2.0 * slope[neg] ** 2))
+        t_minus[neg] = c_minus * (erf(um_hi[neg]) - erf(um_lo[neg]))
+        density_binavg = (t_minus + t_plus) / (2.0 * dx)
+        flat = np.abs(d_hi - d_lo) <= 1e-9 * np.maximum(d_lo, d_hi)
+        d_bar_s = 2.0 * np.sqrt(0.5 * (d_lo[flat] + d_hi[flat]))
+        density_binavg[flat] = 0.5 * (erf(x_hi[flat] / d_bar_s) - erf(x_lo[flat] / d_bar_s)) / dx[flat]
+        density_binavg[dx <= 0.0] = 0.0
+    return density_binavg
+
+
+def _cout_cumulative_volume(
+    *,
+    flow_out: npt.NDArray[np.floating] | None,
+    cout_tedges: pd.DatetimeIndex,
+    cout_tedges_days: npt.NDArray[np.floating],
+    tedges_days: npt.NDArray[np.floating],
+    cumulative_volume_at_cin: npt.NDArray[np.floating],
+) -> npt.NDArray[np.floating]:
+    """Cumulative through-flow volume at each cout edge, on the infiltration volume axis.
+
+    When ``flow_out`` is given (the user-specified extraction-side flow) the cout-edge volumes are
+    its cumulative integral, anchored at the first cout edge inside the flow record (so an output
+    window starting before the input data stays correctly aligned). Otherwise the cout edges are
+    interpolated from the infiltration cumulative-volume curve. Shared by
+    :func:`gwtransport.diffusion_fast._closed_form_coeff_matrix` and
+    :func:`gwtransport.diffusion_fast_fast.infiltration_to_extraction` so the forward (approximate)
+    and reverse (exact) paths place the cout grid on identical volume coordinates.
+
+    Parameters
+    ----------
+    flow_out : ndarray or None
+        Extraction flow rate [m3/day] on the output grid (length ``len(cout_tedges) - 1``), or None
+        to interpolate the cout edges from the infiltration curve.
+    cout_tedges : DatetimeIndex
+        Output time-bin edges (used only for the ``flow_out`` bin widths).
+    cout_tedges_days : ndarray
+        Output edges as days relative to the (work) infiltration reference.
+    tedges_days : ndarray
+        Infiltration edges as days relative to the same reference.
+    cumulative_volume_at_cin : ndarray
+        Cumulative infiltrated volume at each infiltration edge.
+
+    Returns
+    -------
+    ndarray
+        Cumulative volume at each cout edge (length ``len(cout_tedges)``).
+    """
+    if flow_out is None:
+        return np.interp(cout_tedges_days, tedges_days, cumulative_volume_at_cin)
+    cumsum_out = np.concatenate(([0.0], np.cumsum(flow_out * dt_to_days(cout_tedges))))
+    in_range = (cout_tedges_days >= tedges_days[0]) & (cout_tedges_days <= tedges_days[-1])
+    i0 = int(np.argmax(in_range)) if np.any(in_range) else 0
+    v_at_i0 = float(np.interp(cout_tedges_days[i0], tedges_days, cumulative_volume_at_cin))
+    return v_at_i0 + (cumsum_out - cumsum_out[i0])
+
+
+def _extend_tedges_flag(spinup: str | float | None) -> bool:
+    """Translate the public ``spinup`` parameter to the internal extend flag.
+
+    ``"constant"`` (default) extends ``tedges`` by 100 years on each side so a constant
+    warm-start fills the left-edge spin-up region; ``None`` disables the extension (spin-up
+    cout becomes NaN). Mirrors :func:`gwtransport.diffusion._diffusion_extend_tedges_flag`.
+
+    Returns
+    -------
+    bool
+        True if ``tedges`` should be extended (warm-start), False otherwise.
+
+    Raises
+    ------
+    ValueError
+        If ``spinup`` is a string other than ``"constant"``.
+    NotImplementedError
+        If ``spinup`` is a float (fraction-threshold mode is not implemented).
+    """
+    if spinup is None:
+        return False
+    if isinstance(spinup, str):
+        if spinup != "constant":
+            msg = f"spinup string must be 'constant'; got {spinup!r}"
+            raise ValueError(msg)
+        return True
+    msg = f"spinup only supports None or 'constant'; float thresholds are not implemented (got {spinup!r})"
+    raise NotImplementedError(msg)
+
+
+def _broadcast_to_pore_volumes(
+    values: npt.NDArray[np.floating] | float, n_pore_volumes: int
+) -> npt.NDArray[np.floating]:
+    """Return a per-pore-volume array: a scalar broadcasts to all streamtubes, an array passes through.
+
+    Length is validated upstream by :func:`_validate_inputs`, so a non-scalar array is
+    returned as-is (assumed length ``n_pore_volumes``).
+
+    Returns
+    -------
+    ndarray, shape (n_pore_volumes,)
+        Per-streamtube values.
+    """
+    arr = np.atleast_1d(np.asarray(values, dtype=float))
+    return np.broadcast_to(arr, (n_pore_volumes,)) if arr.size == 1 else arr
+
+
+def _validate_inputs(
+    *,
+    cin_or_cout: np.ndarray,
+    flow: np.ndarray,
+    tedges: pd.DatetimeIndex,
+    cout_tedges: pd.DatetimeIndex,
+    aquifer_pore_volumes: np.ndarray,
+    streamline_length: npt.NDArray[np.floating] | float,
+    molecular_diffusivity: npt.NDArray[np.floating] | float,
+    longitudinal_dispersivity: npt.NDArray[np.floating] | float,
+    retardation_factor: float,
+    is_forward: bool,
+    flow_out: np.ndarray | None = None,
+) -> None:
+    """Validate inputs for infiltration_to_extraction and extraction_to_infiltration.
+
+    ``streamline_length`` / ``molecular_diffusivity`` / ``longitudinal_dispersivity`` may be
+    a scalar or an array of length ``len(aquifer_pore_volumes)`` (one value per streamtube).
+
+    Raises
+    ------
+    ValueError
+        If array lengths are inconsistent, molecular_diffusivity or
+        longitudinal_dispersivity are negative, cin or cout or flow contain NaN values,
+        aquifer_pore_volumes contains non-positive values, streamline_length is
+        non-positive, or retardation_factor is below 1 (anti-retardation is not physical for
+        the supported sorption isotherms).
+    """
+    if is_forward:
+        if len(tedges) != len(cin_or_cout) + 1:
+            msg = "tedges must have one more element than cin"
+            raise ValueError(msg)
+    elif len(cout_tedges) != len(cin_or_cout) + 1:
+        msg = "cout_tedges must have one more element than cout"
+        raise ValueError(msg)
+    if len(tedges) != len(flow) + 1:
+        msg = "tedges must have one more element than flow"
+        raise ValueError(msg)
+    n_pore_volumes = len(aquifer_pore_volumes)
+    for name, arr in (
+        ("streamline_length", streamline_length),
+        ("molecular_diffusivity", molecular_diffusivity),
+        ("longitudinal_dispersivity", longitudinal_dispersivity),
+    ):
+        if np.size(arr) not in {1, n_pore_volumes}:
+            msg = f"{name} must be a scalar or have length len(aquifer_pore_volumes) = {n_pore_volumes}"
+            raise ValueError(msg)
+    if np.any(np.asarray(molecular_diffusivity) < 0):
+        msg = "molecular_diffusivity must be non-negative"
+        raise ValueError(msg)
+    if np.any(np.asarray(longitudinal_dispersivity) < 0):
+        msg = "longitudinal_dispersivity must be non-negative"
+        raise ValueError(msg)
+    if np.any(np.isnan(cin_or_cout)):
+        msg = f"{'cin' if is_forward else 'cout'} contains NaN values, which are not allowed"
+        raise ValueError(msg)
+    if np.any(np.isnan(flow)):
+        msg = "flow contains NaN values, which are not allowed"
+        raise ValueError(msg)
+    if np.any(flow < 0):
+        msg = "flow must be non-negative (negative flow not supported)"
+        raise ValueError(msg)
+    if np.any(aquifer_pore_volumes <= 0):
+        msg = "aquifer_pore_volumes must be positive"
+        raise ValueError(msg)
+    if np.any(np.asarray(streamline_length) <= 0):
+        msg = "streamline_length must be positive"
+        raise ValueError(msg)
+    if retardation_factor < 1.0:
+        msg = "retardation_factor must be >= 1.0"
+        raise ValueError(msg)
+    if flow_out is None:
+        # The output-grid extraction flow is only unambiguous when the cout grid matches
+        # the flow grid; otherwise it must be supplied (it defines the cout-bin volumes and
+        # the outlet velocity used by the retardation correction).
+        if not tedges.equals(cout_tedges):
+            msg = "flow_out is required when cout_tedges differs from tedges"
+            raise ValueError(msg)
+    else:
+        n_cout = len(cout_tedges) - 1
+        if len(flow_out) != n_cout:
+            msg = f"flow_out must have length len(cout_tedges) - 1 = {n_cout}, got {len(flow_out)}"
+            raise ValueError(msg)
+        if np.any(np.isnan(flow_out)):
+            msg = "flow_out contains NaN values, which are not allowed"
+            raise ValueError(msg)
+        if np.any(flow_out < 0):
+            msg = "flow_out must be non-negative (negative flow not supported)"
+            raise ValueError(msg)

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -74,22 +74,21 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from scipy.special import erf, erfcx
 
 from gwtransport import gamma
+from gwtransport._diffusion_shared import (
+    _DT_FLOOR,
+    _EPSILON_COEFF_SUM,
+    _breakthrough_antideriv,
+    _broadcast_to_pore_volumes,
+    _cout_cumulative_volume,
+    _extend_tedges_flag,
+    _retardation_excess_density,
+    _validate_inputs,
+)
 from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport.residence_time import residence_time
 from gwtransport.utils import cumulative_flow_volume, solve_inverse_transport
-
-# Minimum coefficient sum to consider an output bin valid.
-_EPSILON_COEFF_SUM = 1e-10
-
-# sqrt(pi), used in the closed-form breakthrough antiderivative.
-_SQRT_PI = np.sqrt(np.pi)
-
-# Floor on the moving-frame dispersion product D_t [m^2] to keep the erf argument finite
-# for pre-breakthrough / zero-dispersion edges (where D_t -> 0).
-_DT_FLOOR = 1e-30
 
 # Default saturation threshold U for the banded build: a cout/cin pair is only evaluated
 # while the breakthrough |x|/(2*sqrt(D_t)) <= U; beyond it the bin-averaged C_F is saturated
@@ -98,105 +97,6 @@ _DT_FLOOR = 1e-30
 # to the dense one. Smaller U narrows the band -> faster, at the cost of dropping breakthrough
 # tails of order exp(-U^2).
 _DEFAULT_SATURATION_THRESHOLD = 7.0
-
-
-def _breakthrough_antideriv(
-    step_widths: npt.NDArray[np.floating], dt_var: npt.NDArray[np.floating]
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    r"""Closed-form antiderivative of the resident concentration, evaluated per edge.
-
-    Returns :math:`I(x) = \tfrac12 x + \tfrac12[x\,\operatorname{erf}(x/s) + (s/\sqrt\pi)e^{-(x/s)^2}]`
-    with :math:`s = 2\sqrt{D_t}`, alongside ``s`` and the Gaussian factor ``exp(-(x/s)^2)`` (both
-    reused by the retardation correction). Shared by the dense kernel
-    (:func:`_flux_breakthrough_fraction`) and the banded build, so both compute identical
-    floating-point results for the same inputs.
-
-    Returns
-    -------
-    antideriv : ndarray
-        The antiderivative :math:`I(x)`.
-    s : ndarray
-        ``2 * sqrt(D_t)``.
-    gaussian : ndarray
-        ``exp(-(x/s)^2)``.
-    """
-    s = 2.0 * np.sqrt(dt_var)
-    with np.errstate(over="ignore", invalid="ignore"):
-        u = step_widths / s
-        gaussian = np.exp(-(u * u))
-        antideriv = 0.5 * step_widths + 0.5 * (step_widths * erf(u) + (s / _SQRT_PI) * gaussian)
-    return antideriv, s, gaussian
-
-
-def _retardation_excess_density(
-    *,
-    x_lo: npt.NDArray[np.floating],
-    x_hi: npt.NDArray[np.floating],
-    dx: npt.NDArray[np.floating],
-    d_lo: npt.NDArray[np.floating],
-    d_hi: npt.NDArray[np.floating],
-    s_lo: npt.NDArray[np.floating],
-    s_hi: npt.NDArray[np.floating],
-    g_lo: npt.NDArray[np.floating],
-    g_hi: npt.NDArray[np.floating],
-) -> npt.NDArray[np.floating]:
-    r"""Closed-form bin-average of the Gaussian density ``<g>`` for the retardation correction.
-
-    When ``R != 1`` and ``D_m > 0`` the per-edge antiderivative bakes in an effective flux
-    coefficient ``dD_t/dx = R*D_m/v + alpha_L`` (because ``d(tau)/dx = R/v`` under retardation),
-    whereas Kreft-Zuber wants ``D_L/v = D_m/v + alpha_L``. The excess ``(R-1)*D_m/v`` is removed
-    by subtracting it times ``<g>``, the bin-average of the Gaussian density
-    ``g = e^{-x^2/(4 D_t)} / (2 sqrt(pi D_t))``. Within a bin ``D_t`` is linear in ``x``, so ``<g>``
-    is closed form: substituting ``w = D_t`` in ``int g dx`` gives
-    ``int w^{-1/2} e^{-w/(4 m^2) - c^2/(4 m^2 w)} dw`` -- a pair of error functions -- with slope
-    ``m = dD_t/dx`` and intercept ``c = D_t(x=0)``. Reusing the antiderivative's Gaussian factor
-    ``G = e^{-x^2/(4 D_t)}``, ``erfcx`` keeps the (always non-negative) ``u+`` branch overflow-free;
-    the ``u-`` branch splits: ``erfcx`` where ``u- >= 0``, ``erf`` elsewhere. Each transcendental is
-    evaluated on its own subset (fancy indexing) rather than over the full array. The slope->0
-    (constant-``D_t``) limit is the exact ``[C_R(x_hi) - C_R(x_lo)] / dx``, applied only on that subset.
-
-    Parameters
-    ----------
-    x_lo, x_hi : ndarray
-        Breakthrough coordinate ``step_widths`` at the lower / upper cout edge of each bin.
-    dx : ndarray
-        ``x_hi - x_lo``.
-    d_lo, d_hi : ndarray
-        Moving-frame dispersion product ``D_t`` at the lower / upper edge.
-    s_lo, s_hi : ndarray
-        ``2 * sqrt(D_t)`` at the lower / upper edge.
-    g_lo, g_hi : ndarray
-        Gaussian factor ``exp(-(x/s)^2)`` at the lower / upper edge.
-
-    Returns
-    -------
-    ndarray
-        Bin-averaged Gaussian density ``<g>``.
-    """
-    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
-        slope = (d_hi - d_lo) / dx
-        intercept = d_lo - slope * x_lo
-        abs_int = np.abs(intercept)
-        # s = 2*sqrt(D_t) is already computed, so slope*s = 2*slope*sqrt(D_t).
-        two_m_sqrt_lo = slope * s_lo
-        two_m_sqrt_hi = slope * s_hi
-        um_lo = (d_lo - abs_int) / two_m_sqrt_lo
-        um_hi = (d_hi - abs_int) / two_m_sqrt_hi
-        up_lo = (d_lo + abs_int) / two_m_sqrt_lo
-        up_hi = (d_hi + abs_int) / two_m_sqrt_hi
-        t_plus = g_lo * erfcx(up_lo) - g_hi * erfcx(up_hi)
-        t_minus = np.empty_like(t_plus)
-        pos = um_lo >= 0.0
-        neg = ~pos
-        t_minus[pos] = g_lo[pos] * erfcx(um_lo[pos]) - g_hi[pos] * erfcx(um_hi[pos])
-        c_minus = np.exp((intercept[neg] - abs_int[neg]) / (2.0 * slope[neg] ** 2))
-        t_minus[neg] = c_minus * (erf(um_hi[neg]) - erf(um_lo[neg]))
-        density_binavg = (t_minus + t_plus) / (2.0 * dx)
-        flat = np.abs(d_hi - d_lo) <= 1e-9 * np.maximum(d_lo, d_hi)
-        d_bar_s = 2.0 * np.sqrt(0.5 * (d_lo[flat] + d_hi[flat]))
-        density_binavg[flat] = 0.5 * (erf(x_hi[flat] / d_bar_s) - erf(x_lo[flat] / d_bar_s)) / dx[flat]
-        density_binavg[dx <= 0.0] = 0.0
-    return density_binavg
 
 
 def _flux_breakthrough_fraction(
@@ -299,53 +199,6 @@ def _flux_breakthrough_fraction(
         excess = np.where(velocity > 0.0, (retardation_factor - 1.0) * molecular_diffusivity / velocity, 0.0)
         frac -= excess[:, None] * density_binavg
     return frac
-
-
-def _extend_tedges_flag(spinup: str | float | None) -> bool:
-    """Translate the public ``spinup`` parameter to the internal extend flag.
-
-    ``"constant"`` (default) extends ``tedges`` by 100 years on each side so a constant
-    warm-start fills the left-edge spin-up region; ``None`` disables the extension (spin-up
-    cout becomes NaN). Mirrors :func:`gwtransport.diffusion._diffusion_extend_tedges_flag`.
-
-    Returns
-    -------
-    bool
-        True if ``tedges`` should be extended (warm-start), False otherwise.
-
-    Raises
-    ------
-    ValueError
-        If ``spinup`` is a string other than ``"constant"``.
-    NotImplementedError
-        If ``spinup`` is a float (fraction-threshold mode is not implemented).
-    """
-    if spinup is None:
-        return False
-    if isinstance(spinup, str):
-        if spinup != "constant":
-            msg = f"spinup string must be 'constant'; got {spinup!r}"
-            raise ValueError(msg)
-        return True
-    msg = f"diffusion_fast's spinup only supports None or 'constant'; float thresholds are not implemented (got {spinup!r})"
-    raise NotImplementedError(msg)
-
-
-def _broadcast_to_pore_volumes(
-    values: npt.NDArray[np.floating] | float, n_pore_volumes: int
-) -> npt.NDArray[np.floating]:
-    """Return a per-pore-volume array: a scalar broadcasts to all streamtubes, an array passes through.
-
-    Length is validated upstream by :func:`_validate_inputs`, so a non-scalar array is
-    returned as-is (assumed length ``n_pore_volumes``).
-
-    Returns
-    -------
-    ndarray, shape (n_pore_volumes,)
-        Per-streamtube values.
-    """
-    arr = np.atleast_1d(np.asarray(values, dtype=float))
-    return np.broadcast_to(arr, (n_pore_volumes,)) if arr.size == 1 else arr
 
 
 def _accumulate_pv_banded(
@@ -519,14 +372,13 @@ def _closed_form_coeff_matrix(
     # window that starts before the input data stays correctly aligned); otherwise
     # interpolated from the infiltration curve.
     cumulative_volume_at_cin = cumulative_flow_volume(flow, dt_to_days(work_tedges))
-    if flow_out is not None:
-        cumsum_out = np.concatenate(([0.0], np.cumsum(flow_out * dt_to_days(cout_tedges))))
-        in_range = (cout_tedges_days >= tedges_days[0]) & (cout_tedges_days <= tedges_days[-1])
-        i0 = int(np.argmax(in_range)) if np.any(in_range) else 0
-        v_at_i0 = float(np.interp(cout_tedges_days[i0], tedges_days, cumulative_volume_at_cin))
-        cumulative_volume_at_cout = v_at_i0 + (cumsum_out - cumsum_out[i0])
-    else:
-        cumulative_volume_at_cout = np.interp(cout_tedges_days, tedges_days, cumulative_volume_at_cin)
+    cumulative_volume_at_cout = _cout_cumulative_volume(
+        flow_out=flow_out,
+        cout_tedges=cout_tedges,
+        cout_tedges_days=cout_tedges_days,
+        tedges_days=tedges_days,
+        cumulative_volume_at_cin=cumulative_volume_at_cin,
+    )
 
     # Residence time identifies cout bins with complete breakthrough (NaN beyond data).
     rt_at_cout_tedges = residence_time(
@@ -1040,94 +892,3 @@ def gamma_extraction_to_infiltration(
         spinup=spinup,
         saturation_threshold=saturation_threshold,
     )
-
-
-def _validate_inputs(
-    *,
-    cin_or_cout: np.ndarray,
-    flow: np.ndarray,
-    tedges: pd.DatetimeIndex,
-    cout_tedges: pd.DatetimeIndex,
-    aquifer_pore_volumes: np.ndarray,
-    streamline_length: npt.NDArray[np.floating] | float,
-    molecular_diffusivity: npt.NDArray[np.floating] | float,
-    longitudinal_dispersivity: npt.NDArray[np.floating] | float,
-    retardation_factor: float,
-    is_forward: bool,
-    flow_out: np.ndarray | None = None,
-) -> None:
-    """Validate inputs for infiltration_to_extraction and extraction_to_infiltration.
-
-    ``streamline_length`` / ``molecular_diffusivity`` / ``longitudinal_dispersivity`` may be
-    a scalar or an array of length ``len(aquifer_pore_volumes)`` (one value per streamtube).
-
-    Raises
-    ------
-    ValueError
-        If array lengths are inconsistent, molecular_diffusivity or
-        longitudinal_dispersivity are negative, cin or cout or flow contain NaN values,
-        aquifer_pore_volumes contains non-positive values, streamline_length is
-        non-positive, or retardation_factor is below 1 (anti-retardation is not physical for
-        the supported sorption isotherms).
-    """
-    if is_forward:
-        if len(tedges) != len(cin_or_cout) + 1:
-            msg = "tedges must have one more element than cin"
-            raise ValueError(msg)
-    elif len(cout_tedges) != len(cin_or_cout) + 1:
-        msg = "cout_tedges must have one more element than cout"
-        raise ValueError(msg)
-    if len(tedges) != len(flow) + 1:
-        msg = "tedges must have one more element than flow"
-        raise ValueError(msg)
-    n_pore_volumes = len(aquifer_pore_volumes)
-    for name, arr in (
-        ("streamline_length", streamline_length),
-        ("molecular_diffusivity", molecular_diffusivity),
-        ("longitudinal_dispersivity", longitudinal_dispersivity),
-    ):
-        if np.size(arr) not in {1, n_pore_volumes}:
-            msg = f"{name} must be a scalar or have length len(aquifer_pore_volumes) = {n_pore_volumes}"
-            raise ValueError(msg)
-    if np.any(np.asarray(molecular_diffusivity) < 0):
-        msg = "molecular_diffusivity must be non-negative"
-        raise ValueError(msg)
-    if np.any(np.asarray(longitudinal_dispersivity) < 0):
-        msg = "longitudinal_dispersivity must be non-negative"
-        raise ValueError(msg)
-    if np.any(np.isnan(cin_or_cout)):
-        msg = f"{'cin' if is_forward else 'cout'} contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(np.isnan(flow)):
-        msg = "flow contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(flow < 0):
-        msg = "flow must be non-negative (negative flow not supported)"
-        raise ValueError(msg)
-    if np.any(aquifer_pore_volumes <= 0):
-        msg = "aquifer_pore_volumes must be positive"
-        raise ValueError(msg)
-    if np.any(np.asarray(streamline_length) <= 0):
-        msg = "streamline_length must be positive"
-        raise ValueError(msg)
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
-    if flow_out is None:
-        # The output-grid extraction flow is only unambiguous when the cout grid matches
-        # the flow grid; otherwise it must be supplied (it defines the cout-bin volumes and
-        # the outlet velocity used by the retardation correction).
-        if not tedges.equals(cout_tedges):
-            msg = "flow_out is required when cout_tedges differs from tedges"
-            raise ValueError(msg)
-    else:
-        n_cout = len(cout_tedges) - 1
-        if len(flow_out) != n_cout:
-            msg = f"flow_out must have length len(cout_tedges) - 1 = {n_cout}, got {len(flow_out)}"
-            raise ValueError(msg)
-        if np.any(np.isnan(flow_out)):
-            msg = "flow_out contains NaN values, which are not allowed"
-            raise ValueError(msg)
-        if np.any(flow_out < 0):
-            msg = "flow_out must be non-negative (negative flow not supported)"
-            raise ValueError(msg)

--- a/src/gwtransport/diffusion_fast_fast.py
+++ b/src/gwtransport/diffusion_fast_fast.py
@@ -1,0 +1,785 @@
+"""
+Fast *approximate* 1D advection-dispersion transport (Kreft-Zuber flux concentration).
+
+This module computes the same physics as :mod:`gwtransport.diffusion_fast` -- the bin-averaged
+Kreft-Zuber (1978) flux concentration ``C_F`` on a bundle of 1D streamtubes -- but trades exactness
+for a single fast (~1.5 ms) native-grid evaluation that does not depend on the flow being constant.
+It is **approximate**: where :mod:`gwtransport.diffusion_fast` reproduces the quadrature reference to
+machine precision, this module is accurate to ~3e-4 in the common regime and degrades in a
+documented corner (below). When you need machine precision, use :mod:`gwtransport.diffusion_fast`.
+
+How it works -- an operator split in two coordinates
+----------------------------------------------------
+
+The moving-frame dispersion product ``D_t = D_m*tau + alpha_L*xi`` mixes a *time* term (molecular
+diffusion ``D_m*tau``) and a *volume* term (microdispersion ``alpha_L*xi``). The two are split into
+the coordinate each is stationary in, so the dominant part is built once and is flow-independent:
+
+1. **Advection + macrodispersion + microdispersion** are the *exact* skewed ``D_m=0`` Kreft-Zuber
+   breakthrough, applied banded on the **native cumulative-volume grid**. The whole aquifer pore
+   volume distribution (APVD) is pre-summed into a single 1D antiderivative ``Ibar(dV)`` -- exact
+   for any APVD shape -- finely sampled once and read back by interpolation. This part is
+   volume-stationary, hence **flow-independent** (constant and strongly variable flow alike).
+2. **Molecular diffusion** is a symmetric **time-domain Gaussian** applied to the outlet signal
+   (variance ``2*D_m*tau_bt*(R*Vbar/L)^2/Q^2``). This is the only modelling approximation: the true
+   Kreft-Zuber molecular breakthrough is skewed, and at realistic (sub-bin) spreading the Gaussian
+   is nearly a no-op, so the molecular term is dropped rather than skewed.
+
+``tedges`` need **not** be regularly spaced and ``cout_tedges`` need not equal ``tedges`` (supply
+``flow_out`` when they differ): step 1 runs on the native cumulative-volume grid for any spacing.
+Only the molecular Gaussian assumes a roughly regular grid -- it convolves in bin-index space using
+the mean bin width -- so a strongly irregular grid adds a small extra error to the (usually
+sub-dominant) molecular term; use :mod:`gwtransport.diffusion_fast` for the molecular-dominated +
+irregular-grid corner.
+
+Accuracy (vs :mod:`gwtransport.diffusion_fast`, flow-independent unless noted)
+------------------------------------------------------------------------------
+
+- **~3e-4 whenever mechanical dispersion is present** (``alpha_L > 0`` -- the typical groundwater
+  regime, Peclet number >> 1), constant *and* variable flow. Here molecular diffusion is
+  sub-dominant, so approximating it barely matters.
+- In the **molecular-diffusion-dominated** corner (``alpha_L`` ~ 0): ~1e-4 for smooth inputs, but
+  degrading to ~1e-2 for sharp inputs (and ~5e-2 for sharp inputs with a very wide / bimodal APVD or
+  a large single pore volume), because the symmetric time-Gaussian cannot reproduce the skewed
+  molecular breakthrough. **Use** :mod:`gwtransport.diffusion_fast` **for exact results in this
+  regime.**
+
+The inverse (:func:`extraction_to_infiltration`) is exact: it builds the true
+:mod:`gwtransport.diffusion_fast` forward operator and deconvolves it (the Tikhonov solve dominates
+the cost, and deconvolution wants the true operator). A round trip therefore recovers the input to
+the forward accuracy.
+
+Available functions:
+
+- :func:`infiltration_to_extraction` -- forward transport (approximate).
+- :func:`extraction_to_infiltration` -- inverse via Tikhonov regularisation (exact operator).
+- :func:`gamma_infiltration_to_extraction` -- gamma-distributed APVD (forward).
+- :func:`gamma_extraction_to_infiltration` -- same, inverse.
+
+References
+----------
+Kreft, A., & Zuber, A. (1978). On the physical meaning of the dispersion equation and its
+solutions for different initial and boundary conditions. Chemical Engineering Science,
+33(11), 1471-1480.
+
+This file is part of gwtransport which is released under AGPL-3.0 license.
+See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
+"""
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from scipy.ndimage import gaussian_filter1d
+
+from gwtransport import gamma
+from gwtransport._diffusion_shared import (
+    _DT_FLOOR,
+    _EPSILON_COEFF_SUM,
+    _breakthrough_antideriv,
+    _broadcast_to_pore_volumes,
+    _cout_cumulative_volume,
+    _extend_tedges_flag,
+    _validate_inputs,
+)
+from gwtransport._time import dt_to_days, tedges_to_days
+from gwtransport.diffusion_fast import _DEFAULT_SATURATION_THRESHOLD, _closed_form_coeff_matrix
+from gwtransport.residence_time import residence_time
+from gwtransport.utils import cumulative_flow_volume, solve_inverse_transport
+
+# Samples per native bin used to discretise the 1D breakthrough antiderivative ``Ibar``. Higher =
+# more accurate ``Ibar`` interpolation (advection+micro error ~ O(1/_KERNEL_FINE^2)) at the cost of
+# a larger one-time precompute; 16 gives ~1e-4 in the advection+micro part, which is below the
+# molecular-Gaussian floor, so it is not exposed as a user knob.
+_KERNEL_FINE = 16
+
+# Upper bound on the number of fine ``Ibar`` samples. Caps the one-time precompute when the
+# breakthrough band spans far more than the record (e.g. tiny flow -> enormous front offset); the
+# affected output bins are masked by residence time anyway, so coarsening the band there is benign.
+_MAX_KERNEL_SAMPLES = 20000
+
+
+def _summed_antideriv(
+    *,
+    aquifer_pore_volumes: npt.NDArray[np.floating],
+    streamline_length: npt.NDArray[np.floating],
+    longitudinal_dispersivity: npt.NDArray[np.floating],
+    retardation_factor: float,
+    mean_bin_volume: float,
+    saturation_threshold: float,
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], float, float, float]:
+    r"""Precompute the APVD-summed breakthrough antiderivative ``Ibar(dV)`` on a fine 1D grid.
+
+    For one streamtube the bin-averaged ``D_m=0`` flux fraction over a cout bin equals the second
+    difference of the antiderivative ``I(x)`` (:func:`gwtransport._diffusion_shared._breakthrough_antideriv`)
+    of the resident concentration in the breakthrough coordinate ``x = (dV - r_vpv)*L/r_vpv``
+    (``r_vpv = R*V_pore``). The antiderivative *with respect to cumulative volume* ``dV`` is
+    ``(r_vpv/L)*I(x(dV))``; averaging it over the APVD gives a single 1D function
+
+    .. math::
+
+        \bar I(\Delta V) = \operatorname{mean}_{pv}\Bigl[\tfrac{r_{vpv}}{L}\,
+        I\bigl((\Delta V - r_{vpv})L/r_{vpv}\bigr)\Bigr],\quad D_t = \alpha_L\,\xi,
+
+    whose edge-differences reproduce the per-streamtube-averaged ``C_F`` **exactly** for any APVD
+    (the ``r_vpv/L`` Jacobian and the cout-bin volume normalisation cancel the per-streamtube ``dx``).
+    Only the interpolation of ``Ibar`` is approximate.
+
+    The grid is **uniform** over the breakthrough band ``[off_lo, off_hi]`` (front ``r_vpv`` plus the
+    conservative ``alpha_L`` dispersion smear, unioned over streamtubes) plus a margin, sampled at
+    ``mean_bin_volume / _KERNEL_FINE`` (uniformity lets :func:`_eval_antideriv` interpolate by
+    fractional indexing instead of a per-point search). For ``alpha_L > 0`` ``Ibar`` is smooth and
+    the interpolation error is ``O(1/_KERNEL_FINE^2)``; at ``alpha_L = 0`` it has a kink at each
+    ``r_vpv`` and the error is ``O(1/_KERNEL_FINE)`` (sub-1e-3, well below the molecular floor).
+
+    Returns
+    -------
+    grid : ndarray
+        Cumulative-volume offsets ``dV`` (uniformly spaced, strictly increasing).
+    ibar : ndarray
+        ``Ibar`` sampled at ``grid``.
+    mean_r_vpv : float
+        ``R * mean(V_pore)`` -- the saturated offset (``Ibar -> dV - mean_r_vpv`` above the band).
+    off_lo, off_hi : float
+        Lower / upper cumulative-volume offset of the breakthrough band.
+    """
+    r_vpv = retardation_factor * aquifer_pore_volumes
+    mean_r_vpv = float(r_vpv.mean())
+    u = saturation_threshold
+    # D_m=0 dispersion half-widths in the breakthrough coordinate x (front D_t = alpha_L*L): the
+    # pre side shrinks (|x| = U*2*sqrt(alpha_L*L)); the post side grows with slope alpha_L, giving
+    # the quadratic root x = 2U^2*alpha_L + 2U*sqrt(U^2*alpha_L^2 + alpha_L*L). Mapped to volume
+    # offsets via r_vpv/L and unioned over streamtubes (conservative, never under-covers the band).
+    pre_x = u * 2.0 * np.sqrt(longitudinal_dispersivity * streamline_length)
+    post_x = 2.0 * u * u * longitudinal_dispersivity + 2.0 * u * np.sqrt(
+        u * u * longitudinal_dispersivity**2 + longitudinal_dispersivity * streamline_length
+    )
+    off_lo = float(np.min(r_vpv - (r_vpv / streamline_length) * pre_x))
+    off_hi = float(np.max(r_vpv + (r_vpv / streamline_length) * post_x))
+
+    margin = 4.0 * mean_bin_volume
+    span = (off_hi - off_lo) + 2.0 * margin
+    dv_fine = mean_bin_volume / _KERNEL_FINE
+    if span / dv_fine > _MAX_KERNEL_SAMPLES:
+        dv_fine = span / _MAX_KERNEL_SAMPLES
+    grid = np.arange(off_lo - margin, off_hi + margin + dv_fine, dv_fine)
+
+    x = (grid[None, :] - r_vpv[:, None]) * streamline_length[:, None] / r_vpv[:, None]
+    dt_var = np.maximum(longitudinal_dispersivity[:, None] * np.maximum(x + streamline_length[:, None], 0.0), _DT_FLOOR)
+    antideriv, _, _ = _breakthrough_antideriv(x, dt_var)
+    ibar = ((r_vpv[:, None] / streamline_length[:, None]) * antideriv).mean(axis=0)
+    return grid, ibar, mean_r_vpv, off_lo, off_hi
+
+
+def _eval_antideriv(
+    dv: npt.NDArray[np.floating],
+    grid: npt.NDArray[np.floating],
+    ibar: npt.NDArray[np.floating],
+    mean_r_vpv: float,
+) -> npt.NDArray[np.floating]:
+    """Evaluate ``Ibar`` at arbitrary cumulative-volume offsets.
+
+    Linear interpolation on the *uniform* precomputed grid by fractional indexing (no per-point
+    search -- the gather is evaluated at ``O(N*band)`` points, so this dominates the runtime).
+    Below the grid ``Ibar = 0`` (not broken through); above it ``Ibar = dV - mean_r_vpv`` (saturated,
+    the exact linear asymptote).
+
+    Returns
+    -------
+    ndarray
+        ``Ibar(dv)`` with the same shape as ``dv``.
+    """
+    g0 = grid[0]
+    dstep = grid[1] - grid[0]
+    f = (dv - g0) / dstep
+    i0 = np.clip(np.floor(f).astype(np.intp), 0, grid.size - 2)
+    out = ibar[i0] + (f - i0) * (ibar[i0 + 1] - ibar[i0])
+    out = np.where(dv < g0, 0.0, out)
+    return np.where(dv > grid[-1], dv - mean_r_vpv, out)
+
+
+def _advection_micro_native(
+    *,
+    cin: npt.NDArray[np.floating],
+    cumulative_volume_at_cin: npt.NDArray[np.floating],
+    cumulative_volume_at_cout: npt.NDArray[np.floating],
+    grid: npt.NDArray[np.floating],
+    ibar: npt.NDArray[np.floating],
+    mean_r_vpv: float,
+    off_lo: float,
+    off_hi: float,
+    warmstart: bool,
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+    """Apply the exact ``D_m=0`` breakthrough banded on the native cumulative-volume grid.
+
+    For each cout bin, gathers the band of cin edges whose breakthrough offset falls in
+    ``[off_lo, off_hi]`` (a conservative fixed window from ``searchsorted``, mirroring
+    :func:`gwtransport.diffusion_fast._accumulate_pv_banded`), evaluates ``Ibar`` at the native edge
+    offsets, and telescopes the edge-differences into per-cin-bin coefficients. With ``warmstart``
+    the grid is extended by one wide virtual bin each side carrying the constant boundary value
+    (``cin[0]`` / ``cin[-1]``), reproducing the 100-year warm-start.
+
+    Returns
+    -------
+    cout_micro : ndarray
+        Advection + macro + micro outlet concentration, length ``len(cumulative_volume_at_cout) - 1``.
+    row_sum : ndarray
+        Per-bin coefficient sum (1 where fully broken through; used to mask spin-up when not warm-started).
+    """
+    vi = cumulative_volume_at_cin
+    vc = cumulative_volume_at_cout
+    if warmstart:
+        big = abs(off_hi) + abs(off_lo) + (vc[-1] - vc[0]) + (vi[-1] - vi[0]) + 1.0
+        vi_ext = np.concatenate([[vi[0] - big], vi, [vi[-1] + big]])
+        cin_ext = np.concatenate([[cin[0]], cin, [cin[-1]]])
+    else:
+        vi_ext = vi
+        cin_ext = cin
+
+    vc_lo, vc_hi = vc[:-1], vc[1:]
+    w = vc_hi - vc_lo
+    vc_mid = 0.5 * (vc_lo + vc_hi)
+    # Conservative two-sided fixed window: center on the front, widen to the farthest cin edge whose
+    # offset is still inside the band on either side. The +1 absorbs the edge consumed by the
+    # telescoping difference and searchsorted rounding (an under-sized window silently drops mass).
+    center = np.searchsorted(vi_ext, vc_mid - mean_r_vpv)
+    j_lo = np.searchsorted(vi_ext, vc_lo - off_hi, side="left")
+    j_hi = np.searchsorted(vi_ext, vc_hi - off_lo, side="right")
+    hw_lo = int(np.max(center - j_lo)) + 1
+    hw_hi = int(np.max(j_hi - center)) + 1
+
+    cols = center[:, None] + np.arange(-hw_lo, hw_hi + 1)[None, :]
+    vi_band = vi_ext[np.clip(cols, 0, len(vi_ext) - 1)]
+    ibar_hi = _eval_antideriv(vc_hi[:, None] - vi_band, grid, ibar, mean_r_vpv)
+    ibar_lo = _eval_antideriv(vc_lo[:, None] - vi_band, grid, ibar, mean_r_vpv)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        frac_edge = np.where(w[:, None] > 0.0, (ibar_hi - ibar_lo) / w[:, None], 0.0)
+    coeff = frac_edge[:, :-1] - frac_edge[:, 1:]
+    cin_bin = np.clip(cols[:, :-1], 0, len(cin_ext) - 1)
+    cout_micro = (coeff * cin_ext[cin_bin]).sum(axis=1)
+    return cout_micro, coeff.sum(axis=1)
+
+
+def _valid_cout_bins(
+    *,
+    flow: npt.NDArray[np.floating],
+    work_tedges: pd.DatetimeIndex,
+    cout_tedges: pd.DatetimeIndex,
+    aquifer_pore_volumes: npt.NDArray[np.floating],
+    retardation_factor: float,
+) -> npt.NDArray[np.bool_]:
+    """Output bins with complete breakthrough information for every streamtube.
+
+    Uses the same residence-time validity criterion as
+    :func:`gwtransport.diffusion_fast._closed_form_coeff_matrix`: a cout bin is valid when the
+    residence time is finite (not beyond the flow record) at both of its edges for all streamtubes.
+    ``work_tedges`` is the 100-year-extended grid when warm-starting (so spin-up bins are valid) and
+    the raw grid otherwise.
+
+    Returns
+    -------
+    ndarray of bool, shape (len(cout_tedges) - 1,)
+        True where the output bin is fully informed.
+    """
+    rt = residence_time(
+        flow=flow,
+        flow_tedges=work_tedges,
+        index=cout_tedges,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        retardation_factor=retardation_factor,
+        direction="extraction_to_infiltration",
+    )
+    return ~np.any(np.isnan(rt[:, :-1]) | np.isnan(rt[:, 1:]), axis=0)
+
+
+def infiltration_to_extraction(
+    *,
+    cin: npt.ArrayLike,
+    flow: npt.ArrayLike,
+    tedges: pd.DatetimeIndex,
+    cout_tedges: pd.DatetimeIndex,
+    aquifer_pore_volumes: npt.ArrayLike,
+    streamline_length: npt.NDArray[np.floating] | float,
+    molecular_diffusivity: npt.NDArray[np.floating] | float,
+    longitudinal_dispersivity: npt.NDArray[np.floating] | float,
+    retardation_factor: float = 1.0,
+    flow_out: npt.ArrayLike | None = None,
+    spinup: str | float | None = "constant",
+    saturation_threshold: float = _DEFAULT_SATURATION_THRESHOLD,
+) -> npt.NDArray[np.floating]:
+    """Compute extracted concentration with advection and longitudinal dispersion (approximate).
+
+    Fast *approximate* counterpart of :func:`gwtransport.diffusion_fast.infiltration_to_extraction`.
+    The advection + macrodispersion + microdispersion (``alpha_L``) part is the exact skewed
+    ``D_m=0`` Kreft-Zuber breakthrough applied on the native cumulative-volume grid; molecular
+    diffusion (``D_m``) is a symmetric time-domain Gaussian. The result is flow-independent and
+    accurate to ~3e-4 whenever ``alpha_L > 0`` (the typical regime), degrading to ~1e-2 (sharp
+    inputs) in the molecular-diffusion-dominated corner (``alpha_L`` ~ 0). For machine precision, use
+    :mod:`gwtransport.diffusion_fast`.
+
+    Parameters
+    ----------
+    cin : array-like
+        Concentration of the compound in the infiltrating water. Length ``len(tedges) - 1``.
+    flow : array-like
+        Flow rate of water in the aquifer [m3/day]. Length ``len(tedges) - 1``.
+    tedges : pandas.DatetimeIndex
+        Time edges for cin and flow data. Length ``len(cin) + 1``.
+    cout_tedges : pandas.DatetimeIndex
+        Time edges for output data bins. Length ``len(output) + 1``.
+    aquifer_pore_volumes : array-like
+        Aquifer pore volumes [m3] -- one independent streamtube per entry. Any distribution shape
+        (the APVD is pre-summed exactly).
+    streamline_length : float or ndarray
+        Travel distance L [m]: a scalar (shared by all streamtubes) or an array with one
+        value per aquifer pore volume. Must be positive.
+    molecular_diffusivity : float or ndarray
+        Effective molecular diffusivity D_m [m2/day]: scalar or one value per pore volume.
+        Must be non-negative.
+    longitudinal_dispersivity : float or ndarray
+        Longitudinal dispersivity alpha_L [m]: scalar or one value per pore volume.
+        Must be non-negative.
+    retardation_factor : float, optional
+        Retardation factor (default 1.0). Values > 1.0 indicate slower transport.
+    flow_out : array-like or None, optional
+        Extraction flow rate [m3/day] on the output grid (aligned to ``cout_tedges``,
+        length ``len(cout_tedges) - 1``). Required when ``cout_tedges`` differs from ``tedges``;
+        may be omitted only when ``cout_tedges`` equals ``tedges``. Default None.
+    spinup : {"constant"} | None, optional
+        ``"constant"`` (default) extends ``tedges`` by 100 years on each side so a constant
+        warm-start fills the left-edge spin-up region; ``None`` leaves spin-up cout as NaN.
+    saturation_threshold : float, optional
+        Breakthrough-band cutoff ``U`` (default 7.0). Sets how far into the breakthrough tail the
+        banded build reaches; see :func:`gwtransport.diffusion_fast.infiltration_to_extraction`.
+
+    Returns
+    -------
+    numpy.ndarray
+        Bin-averaged Kreft-Zuber flux concentration ``C_F`` in the extracted water. Length
+        ``len(cout_tedges) - 1``. NaN where no infiltration data has broken through.
+
+    See Also
+    --------
+    gwtransport.diffusion_fast.infiltration_to_extraction : Exact (machine-precision) counterpart;
+        use it when approximation is unacceptable, especially in the molecular-dominant regime.
+    gwtransport.diffusion.infiltration_to_extraction : Quadrature reference.
+    extraction_to_infiltration : Inverse operation (exact operator).
+    :ref:`concept-dispersion-scales` : Macrodispersion vs microdispersion.
+    """
+    tedges = pd.DatetimeIndex(tedges)
+    cout_tedges = pd.DatetimeIndex(cout_tedges)
+    cin = np.asarray(cin, dtype=float)
+    flow = np.asarray(flow, dtype=float)
+    aquifer_pore_volumes = np.asarray(aquifer_pore_volumes, dtype=float)
+    if flow_out is not None:
+        flow_out = np.asarray(flow_out, dtype=float)
+
+    _validate_inputs(
+        cin_or_cout=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        streamline_length=streamline_length,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
+        is_forward=True,
+        flow_out=flow_out,
+    )
+
+    n_pv = len(aquifer_pore_volumes)
+    streamline_length = _broadcast_to_pore_volumes(streamline_length, n_pv)
+    molecular_diffusivity = _broadcast_to_pore_volumes(molecular_diffusivity, n_pv)
+    longitudinal_dispersivity = _broadcast_to_pore_volumes(longitudinal_dispersivity, n_pv)
+
+    n_cout = len(cout_tedges) - 1
+    tedges_days = tedges_to_days(tedges)
+    cout_tedges_days = tedges_to_days(cout_tedges, ref=tedges[0])
+    cumulative_volume_at_cin = cumulative_flow_volume(flow, dt_to_days(tedges))
+    total_volume = float(cumulative_volume_at_cin[-1])
+    if total_volume <= 0.0:
+        # No through-flow: nothing breaks through (matches diffusion_fast's all-NaN result).
+        return np.full(n_cout, np.nan)
+
+    cumulative_volume_at_cout = _cout_cumulative_volume(
+        flow_out=flow_out,
+        cout_tedges=cout_tedges,
+        cout_tedges_days=cout_tedges_days,
+        tedges_days=tedges_days,
+        cumulative_volume_at_cin=cumulative_volume_at_cin,
+    )
+
+    mean_bin_volume = total_volume / len(flow)
+    grid, ibar, mean_r_vpv, off_lo, off_hi = _summed_antideriv(
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        streamline_length=streamline_length,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
+        mean_bin_volume=mean_bin_volume,
+        saturation_threshold=saturation_threshold,
+    )
+
+    extend = _extend_tedges_flag(spinup)
+    cout_micro, row_sum = _advection_micro_native(
+        cin=cin,
+        cumulative_volume_at_cin=cumulative_volume_at_cin,
+        cumulative_volume_at_cout=cumulative_volume_at_cout,
+        grid=grid,
+        ibar=ibar,
+        mean_r_vpv=mean_r_vpv,
+        off_lo=off_lo,
+        off_hi=off_hi,
+        warmstart=extend,
+    )
+
+    # Molecular diffusion: a single mean-streamtube time-domain Gaussian on the outlet signal.
+    # sigma_t^2 = 2*D_m*tau_bt*(r_vpv/L)^2/Q^2, with tau_bt = R*mean(V_pore)/Q the mean breakthrough
+    # time and Q = total_volume/total_time the flow-weighted mean throughflow (= mean(flow) on a
+    # uniform grid). Applied before masking so it operates on NaN-free values; edge-padded.
+    total_days = float(tedges_days[-1] - tedges_days[0])
+    q_mean = total_volume / total_days
+    tau_bt = retardation_factor * float(aquifer_pore_volumes.mean()) / q_mean
+    sigma_t2 = (
+        2.0 * float(molecular_diffusivity.mean()) * tau_bt * (mean_r_vpv / float(streamline_length.mean())) ** 2
+    ) / q_mean**2
+    # The smear acts on cout_micro, so sigma_t (days) is converted with the OUTPUT-grid mean bin
+    # width (not the flow grid -- they differ for a coarse cout grid). A smear wider than the record
+    # washes the signal to a constant and cannot be resolved; cap it (tiny flow drives sigma_bins ->
+    # huge, but those bins are masked by residence time below anyway).
+    mean_cout_dt = (cout_tedges_days[-1] - cout_tedges_days[0]) / n_cout
+    sigma_bins = min(np.sqrt(sigma_t2) / mean_cout_dt, float(n_cout))
+    cout = cout_micro if sigma_bins == 0.0 else gaussian_filter1d(cout_micro, sigma_bins, mode="nearest", truncate=6.0)
+
+    # Mask bins beyond the data range (and, without warm-start, incompletely-broken-through spin-up
+    # bins). residence_time uses the extended grid when warm-starting so spin-up bins stay valid.
+    work_tedges = tedges
+    if extend:
+        edge_values = tedges.to_numpy().copy()
+        delta = np.timedelta64(36500, "D")
+        edge_values[0] -= delta
+        edge_values[-1] += delta
+        work_tedges = pd.DatetimeIndex(edge_values)
+    valid = _valid_cout_bins(
+        flow=flow,
+        work_tedges=work_tedges,
+        cout_tedges=cout_tedges,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        retardation_factor=retardation_factor,
+    )
+    cout = cout.copy()
+    cout[(row_sum < _EPSILON_COEFF_SUM) | ~valid] = np.nan
+    return cout
+
+
+def extraction_to_infiltration(
+    *,
+    cout: npt.ArrayLike,
+    flow: npt.ArrayLike,
+    tedges: pd.DatetimeIndex,
+    cout_tedges: pd.DatetimeIndex,
+    aquifer_pore_volumes: npt.ArrayLike,
+    streamline_length: npt.NDArray[np.floating] | float,
+    molecular_diffusivity: npt.NDArray[np.floating] | float,
+    longitudinal_dispersivity: npt.NDArray[np.floating] | float,
+    retardation_factor: float = 1.0,
+    regularization_strength: float = 1e-10,
+    flow_out: npt.ArrayLike | None = None,
+    spinup: str | float | None = "constant",
+    saturation_threshold: float = _DEFAULT_SATURATION_THRESHOLD,
+) -> npt.NDArray[np.floating]:
+    """Reconstruct infiltration concentration from extracted water (deconvolution, exact operator).
+
+    Builds the **exact** closed-form forward coefficient matrix of
+    :func:`gwtransport.diffusion_fast.extraction_to_infiltration` and solves ``W @ cin = cout`` by
+    Tikhonov regularization. Unlike the approximate forward, the reverse uses the true operator: the
+    deconvolution cost is dominated by the solve, not the matrix build, and an accurate operator is
+    what the ill-posed inverse needs. A forward-then-inverse round trip recovers the input to the
+    forward accuracy.
+
+    Parameters
+    ----------
+    cout : array-like
+        Concentration of the compound in extracted water. Length ``len(cout_tedges) - 1``.
+    flow : array-like
+        Flow rate of water in the aquifer [m3/day]. Length ``len(tedges) - 1``.
+    tedges : pandas.DatetimeIndex
+        Time edges for cin (output) and flow data. Length ``len(flow) + 1``.
+    cout_tedges : pandas.DatetimeIndex
+        Time edges for cout data bins. Length ``len(cout) + 1``.
+    aquifer_pore_volumes : array-like
+        Aquifer pore volumes [m3] -- one independent streamtube per entry.
+    streamline_length : float or ndarray
+        Travel distance L [m]: scalar or one value per pore volume. Must be positive.
+    molecular_diffusivity : float or ndarray
+        Effective molecular diffusivity D_m [m2/day]: scalar or one value per pore volume.
+        Must be non-negative.
+    longitudinal_dispersivity : float or ndarray
+        Longitudinal dispersivity alpha_L [m]: scalar or one value per pore volume.
+        Must be non-negative.
+    retardation_factor : float, optional
+        Retardation factor (default 1.0).
+    regularization_strength : float, optional
+        Tikhonov regularization parameter (default 1e-10).
+    flow_out : array-like or None, optional
+        Extraction flow rate [m3/day] on the output grid (aligned to ``cout_tedges``). See
+        :func:`infiltration_to_extraction`. Default None.
+    spinup : {"constant"} | None, optional
+        See :func:`infiltration_to_extraction`. Default ``"constant"``.
+    saturation_threshold : float, optional
+        See :func:`infiltration_to_extraction`. Default 7.0.
+
+    Returns
+    -------
+    numpy.ndarray
+        Bin-averaged concentration in the infiltrating water. Length ``len(tedges) - 1``.
+        NaN where no extraction data constrains the bin.
+
+    Warns
+    -----
+    UserWarning
+        When the forward matrix is rank-deficient (constant flow with residence time an
+        integer multiple of the time step). Adjust ``aquifer_pore_volumes`` slightly
+        (e.g. multiply by 1.001) to fix.
+
+    See Also
+    --------
+    infiltration_to_extraction : Forward operation (approximate).
+    gwtransport.diffusion_fast.extraction_to_infiltration : Same exact matrix build and solve.
+    :ref:`concept-dispersion-scales` : Macrodispersion vs microdispersion.
+    """
+    tedges = pd.DatetimeIndex(tedges)
+    cout_tedges = pd.DatetimeIndex(cout_tedges)
+    cout = np.asarray(cout, dtype=float)
+    flow = np.asarray(flow, dtype=float)
+    aquifer_pore_volumes = np.asarray(aquifer_pore_volumes, dtype=float)
+    if flow_out is not None:
+        flow_out = np.asarray(flow_out, dtype=float)
+
+    _validate_inputs(
+        cin_or_cout=cout,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        streamline_length=streamline_length,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
+        is_forward=False,
+        flow_out=flow_out,
+    )
+
+    n_pv = len(aquifer_pore_volumes)
+    streamline_length = _broadcast_to_pore_volumes(streamline_length, n_pv)
+    molecular_diffusivity = _broadcast_to_pore_volumes(molecular_diffusivity, n_pv)
+    longitudinal_dispersivity = _broadcast_to_pore_volumes(longitudinal_dispersivity, n_pv)
+
+    n_cin = len(tedges) - 1
+    w_forward, valid_cout_bins = _closed_form_coeff_matrix(
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        flow_out=flow_out,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        streamline_length=streamline_length,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
+        extend_tedges=_extend_tedges_flag(spinup),
+        saturation_threshold=saturation_threshold,
+    )
+
+    return solve_inverse_transport(
+        w_forward=w_forward,
+        observed=cout,
+        n_output=n_cin,
+        regularization_strength=regularization_strength,
+        valid_rows=valid_cout_bins,
+        warn_rank_deficient=True,
+    )
+
+
+def gamma_infiltration_to_extraction(
+    *,
+    cin: npt.ArrayLike,
+    flow: npt.ArrayLike,
+    tedges: pd.DatetimeIndex,
+    cout_tedges: pd.DatetimeIndex,
+    mean: float | None = None,
+    std: float | None = None,
+    loc: float = 0.0,
+    alpha: float | None = None,
+    beta: float | None = None,
+    n_bins: int = 100,
+    streamline_length: float,
+    molecular_diffusivity: float,
+    longitudinal_dispersivity: float,
+    retardation_factor: float = 1.0,
+    flow_out: npt.ArrayLike | None = None,
+    spinup: str | float | None = "constant",
+    saturation_threshold: float = _DEFAULT_SATURATION_THRESHOLD,
+) -> npt.NDArray[np.floating]:
+    """Compute extracted concentration for a gamma-distributed pore volume distribution (approximate).
+
+    Convenience wrapper around :func:`infiltration_to_extraction` that discretizes a (shifted)
+    gamma aquifer pore-volume distribution into ``n_bins`` equal-probability streamtubes. Provide
+    either (mean, std) or (alpha, beta); ``loc`` defaults to 0. Approximate -- see
+    :func:`infiltration_to_extraction`.
+
+    Parameters
+    ----------
+    cin : array-like
+        Concentration of the compound in infiltrating water.
+    flow : array-like
+        Flow rate of water in the aquifer [m3/day].
+    tedges : pandas.DatetimeIndex
+        Time edges for cin and flow data. Length ``len(cin) + 1``.
+    cout_tedges : pandas.DatetimeIndex
+        Time edges for output data bins.
+    mean, std : float, optional
+        Mean and standard deviation of the gamma pore-volume distribution.
+    loc : float, optional
+        Location (minimum pore volume), ``0 <= loc < mean``. Default 0.0.
+    alpha, beta : float, optional
+        Shape and scale parameters of the gamma distribution (alternative to mean/std).
+    n_bins : int, optional
+        Number of equal-probability streamtubes. Default 100.
+    streamline_length : float
+        Travel distance L [m], applied to all gamma streamtubes. Must be positive.
+    molecular_diffusivity : float
+        Effective molecular diffusivity D_m [m2/day], applied to all streamtubes. Must be
+        non-negative.
+    longitudinal_dispersivity : float
+        Longitudinal dispersivity alpha_L [m], applied to all streamtubes. Must be non-negative.
+    retardation_factor : float, optional
+        Retardation factor (default 1.0).
+    flow_out : array-like or None, optional
+        Extraction flow rate [m3/day] on the output grid. See
+        :func:`infiltration_to_extraction`. Default None.
+    spinup : {"constant"} | None, optional
+        See :func:`infiltration_to_extraction`. Default ``"constant"``.
+    saturation_threshold : float, optional
+        See :func:`infiltration_to_extraction`. Default 7.0.
+
+    Returns
+    -------
+    numpy.ndarray
+        Bin-averaged Kreft-Zuber flux concentration ``C_F`` in the extracted water.
+
+    See Also
+    --------
+    infiltration_to_extraction : Transport with an explicit pore volume distribution.
+    gamma_extraction_to_infiltration : Reverse operation.
+    gwtransport.gamma.bins : Create gamma distribution bins.
+    :ref:`concept-gamma-distribution` : Two-parameter pore volume model.
+    """
+    bins = gamma.bins(mean=mean, std=std, loc=loc, alpha=alpha, beta=beta, n_bins=n_bins)
+    return infiltration_to_extraction(
+        cin=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        aquifer_pore_volumes=bins["expected_values"],
+        streamline_length=streamline_length,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
+        flow_out=flow_out,
+        spinup=spinup,
+        saturation_threshold=saturation_threshold,
+    )
+
+
+def gamma_extraction_to_infiltration(
+    *,
+    cout: npt.ArrayLike,
+    flow: npt.ArrayLike,
+    tedges: pd.DatetimeIndex,
+    cout_tedges: pd.DatetimeIndex,
+    mean: float | None = None,
+    std: float | None = None,
+    loc: float = 0.0,
+    alpha: float | None = None,
+    beta: float | None = None,
+    n_bins: int = 100,
+    streamline_length: float,
+    molecular_diffusivity: float,
+    longitudinal_dispersivity: float,
+    retardation_factor: float = 1.0,
+    regularization_strength: float = 1e-10,
+    flow_out: npt.ArrayLike | None = None,
+    spinup: str | float | None = "constant",
+    saturation_threshold: float = _DEFAULT_SATURATION_THRESHOLD,
+) -> npt.NDArray[np.floating]:
+    """Reconstruct infiltration concentration for a gamma-distributed pore volume distribution.
+
+    Convenience wrapper around :func:`extraction_to_infiltration` that discretizes a (shifted)
+    gamma aquifer pore-volume distribution into ``n_bins`` equal-probability streamtubes. Provide
+    either (mean, std) or (alpha, beta); ``loc`` defaults to 0. Uses the exact forward operator (see
+    :func:`extraction_to_infiltration`).
+
+    Parameters
+    ----------
+    cout : array-like
+        Concentration of the compound in extracted water.
+    flow : array-like
+        Flow rate of water in the aquifer [m3/day].
+    tedges : pandas.DatetimeIndex
+        Time edges for cin (output) and flow data. Length ``len(flow) + 1``.
+    cout_tedges : pandas.DatetimeIndex
+        Time edges for cout data bins. Length ``len(cout) + 1``.
+    mean, std : float, optional
+        Mean and standard deviation of the gamma pore-volume distribution.
+    loc : float, optional
+        Location (minimum pore volume), ``0 <= loc < mean``. Default 0.0.
+    alpha, beta : float, optional
+        Shape and scale parameters of the gamma distribution (alternative to mean/std).
+    n_bins : int, optional
+        Number of equal-probability streamtubes. Default 100.
+    streamline_length : float
+        Travel distance L [m], applied to all gamma streamtubes. Must be positive.
+    molecular_diffusivity : float
+        Effective molecular diffusivity D_m [m2/day], applied to all streamtubes. Must be
+        non-negative.
+    longitudinal_dispersivity : float
+        Longitudinal dispersivity alpha_L [m], applied to all streamtubes. Must be non-negative.
+    retardation_factor : float, optional
+        Retardation factor (default 1.0).
+    regularization_strength : float, optional
+        Tikhonov regularization parameter (default 1e-10).
+    flow_out : array-like or None, optional
+        Extraction flow rate [m3/day] on the output grid. See
+        :func:`infiltration_to_extraction`. Default None.
+    spinup : {"constant"} | None, optional
+        See :func:`infiltration_to_extraction`. Default ``"constant"``.
+    saturation_threshold : float, optional
+        See :func:`infiltration_to_extraction`. Default 7.0.
+
+    Returns
+    -------
+    numpy.ndarray
+        Bin-averaged concentration in the infiltrating water. Length ``len(tedges) - 1``.
+
+    See Also
+    --------
+    extraction_to_infiltration : Deconvolution with an explicit pore volume distribution.
+    gamma_infiltration_to_extraction : Forward operation.
+    gwtransport.gamma.bins : Create gamma distribution bins.
+    :ref:`concept-gamma-distribution` : Two-parameter pore volume model.
+    """
+    bins = gamma.bins(mean=mean, std=std, loc=loc, alpha=alpha, beta=beta, n_bins=n_bins)
+    return extraction_to_infiltration(
+        cout=cout,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        aquifer_pore_volumes=bins["expected_values"],
+        streamline_length=streamline_length,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        retardation_factor=retardation_factor,
+        regularization_strength=regularization_strength,
+        flow_out=flow_out,
+        spinup=spinup,
+        saturation_threshold=saturation_threshold,
+    )

--- a/tests/src/test_diffusion_fast_fast.py
+++ b/tests/src/test_diffusion_fast_fast.py
@@ -1,0 +1,792 @@
+"""Tests for gwtransport.diffusion_fast_fast.
+
+diffusion_fast_fast is a fast *approximate* forward transport: the advection + macrodispersion +
+microdispersion part is the exact D_m=0 Kreft-Zuber breakthrough on the native cumulative-volume
+grid, and molecular diffusion is a symmetric time-domain Gaussian (the documented limit). Its
+reference is gwtransport.diffusion_fast (machine-precision exact), which is itself anchored to the
+gwtransport.diffusion Gauss-Legendre quadrature.
+
+Tolerances here are deliberately approximate and pinned per regime to the measured worst case
+(comments record the measurement) -- never blanket-loose. The reverse path is exact (it builds the
+diffusion_fast operator), so reverse tests stay at atol 0.
+"""
+
+import time
+import warnings as warn_module
+
+import numpy as np
+import pandas as pd
+import pytest
+from numpy.testing import assert_allclose
+
+import gwtransport.diffusion_fast_fast as fff_module
+from gwtransport import gamma
+from gwtransport.advection import infiltration_to_extraction as advection_i2e
+from gwtransport.diffusion_fast import extraction_to_infiltration as df_e2i
+from gwtransport.diffusion_fast import gamma_extraction_to_infiltration as df_gamma_e2i
+from gwtransport.diffusion_fast import gamma_infiltration_to_extraction as df_gamma_i2e
+from gwtransport.diffusion_fast import infiltration_to_extraction as df_i2e
+from gwtransport.diffusion_fast_fast import (
+    extraction_to_infiltration,
+    gamma_extraction_to_infiltration,
+    gamma_infiltration_to_extraction,
+    infiltration_to_extraction,
+)
+
+SL = 80.0
+
+
+def _make_transport_data(*, n_days=200, flow_rate=100.0):
+    """Aligned daily grid with constant flow."""
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    return tedges, tedges.copy(), np.full(n_days, flow_rate)
+
+
+def _apv(n_bins):
+    return np.array([500.0]) if n_bins == 1 else gamma.bins(mean=500.0, std=120.0, n_bins=n_bins)["expected_values"]
+
+
+def _build_w_via_probes(call_fn, n):
+    """Reconstruct the (n_out, n) coefficient matrix by feeding canonical basis vectors.
+
+    Independent of the module internals (probes the public API), so column-mass checks against it
+    are not tautological.
+    """
+    cout0 = call_fn(np.zeros(n))
+    w = np.zeros((len(cout0), n))
+    for j in range(n):
+        ej = np.zeros(n)
+        ej[j] = 1.0
+        cout = call_fn(ej)
+        w[:, j] = np.where(np.isnan(cout), 0.0, cout)
+    return w
+
+
+def _peak_rel(actual, ref, *, skip=8):
+    """Peak-relative error on the jointly-finite interior (excludes the boundary smear region)."""
+    mask = ~np.isnan(actual) & ~np.isnan(ref)
+    mask[:skip] = False
+    mask[-skip:] = False
+    assert mask.sum() > 10
+    return np.nanmax(np.abs(actual[mask] - ref[mask])) / np.nanmax(np.abs(ref[mask]))
+
+
+def _pulse(n, start=None):
+    c = np.zeros(n)
+    s = n // 4 if start is None else start
+    c[s : s + 4] = 1.0
+    return c
+
+
+def _step(n):
+    c = np.full(n, 2.0)
+    c[n // 3 :] = 8.0
+    return c
+
+
+def _smooth(n, freq=8.0):
+    return np.sin(np.linspace(0.0, freq * np.pi, n)) * 3.0 + 6.0
+
+
+def _variable_flow(n, cv, seed):
+    return 100.0 * np.exp(np.random.default_rng(seed).normal(0.0, cv, n))
+
+
+# =============================================================================
+# Step 1 in isolation: advection + microdispersion (D_m = 0) vs diffusion_fast(D_m = 0).
+# This is the dominant, skew-carrying part and the delicate banded-index code; validate it first.
+# =============================================================================
+
+
+@pytest.mark.parametrize("spinup", ["constant", None])
+@pytest.mark.parametrize("retardation", [1.0, 2.7])
+@pytest.mark.parametrize("flow_kind", ["const", "var"])
+@pytest.mark.parametrize("inp", ["pulse", "step"])
+def test_step1_advection_micro_parity(inp, flow_kind, retardation, spinup):
+    """D_m=0 advection+micro matches diffusion_fast to ~1e-4 (the exact skewed kernel), incl. sharp
+    pulse AND step, constant AND variable flow, with retardation. Tight because step 1 is the
+    near-exact part (only the Ibar interpolation is approximate at the default fineness)."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0) if flow_kind == "const" else _variable_flow(n, 0.4, seed=3)
+    cin = _pulse(n) if inp == "pulse" else _step(n)
+    kw = {
+        "cin": cin,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": _apv(25),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.0,
+        "longitudinal_dispersivity": 1.0,
+        "retardation_factor": retardation,
+        "spinup": spinup,
+    }
+    cout_ff = infiltration_to_extraction(**kw)
+    cout_df = df_i2e(**kw)
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))
+    # measured worst case ~2.9e-4 (variable-flow pulse); bound at 5e-4.
+    assert _peak_rel(cout_ff, cout_df) < 5e-4
+
+
+def test_step1_zero_dispersion_single_pv_is_exact():
+    """alpha_L=0, D_m=0, single streamtube is pure advection: the antiderivative is the exact step
+    ramp and the aligned grid evaluates it off the lone kink cell, so parity is machine precision
+    (not just ~1e-4). Robust to the pore volume (kink alignment)."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    cin = _pulse(n)
+    for v_pore in (500.0, 517.3, 623.1):
+        kw = {
+            "cin": cin,
+            "flow": flow,
+            "tedges": tedges,
+            "cout_tedges": tedges.copy(),
+            "aquifer_pore_volumes": np.array([v_pore]),
+            "streamline_length": SL,
+            "molecular_diffusivity": 0.0,
+            "longitudinal_dispersivity": 0.0,
+        }
+        assert _peak_rel(infiltration_to_extraction(**kw), df_i2e(**kw)) < 1e-12
+
+
+def test_step1_kernel_fineness_convergence(monkeypatch):
+    """The only step-1 approximation is the Ibar interpolation; its error must DECREASE monotonically
+    as _KERNEL_FINE increases (guards against a nearest-neighbour / constant-offset interp bug)."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    kw = {
+        "cin": _pulse(n),
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": _apv(25),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.0,
+        "longitudinal_dispersivity": 1.0,
+    }
+    cout_df = df_i2e(**kw)
+    errs = []
+    for fine in (16, 64, 256):
+        monkeypatch.setattr(fff_module, "_KERNEL_FINE", fine)
+        errs.append(_peak_rel(infiltration_to_extraction(**kw), cout_df))
+    assert errs[0] > errs[1] > errs[2]  # strictly decreasing
+    assert errs[2] < 2e-6  # measured 4.6e-7 at fine=256
+
+
+# =============================================================================
+# Full method (advection+micro + molecular Gaussian) vs diffusion_fast, per-regime bounds.
+# =============================================================================
+
+
+@pytest.mark.parametrize("flow_kind", ["const", "cv01", "cv03", "cv06"])
+@pytest.mark.parametrize("inp", ["pulse", "smooth"])
+def test_full_typical_alpha_present_flow_independent(inp, flow_kind):
+    """With mechanical dispersion present (alpha_L>0, the typical regime) the method is ~3e-4 and
+    flow-independent: CV 0.6 is no worse than constant flow."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = {
+        "const": np.full(n, 100.0),
+        "cv01": _variable_flow(n, 0.1, 1),
+        "cv03": _variable_flow(n, 0.3, 2),
+        "cv06": _variable_flow(n, 0.6, 5),
+    }[flow_kind]
+    cin = _pulse(n) if inp == "pulse" else _smooth(n)
+    kw = {
+        "cin": cin,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": _apv(25),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+        "retardation_factor": 2.0,
+    }
+    cout_ff = infiltration_to_extraction(**kw)
+    cout_df = df_i2e(**kw)
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))
+    assert _peak_rel(cout_ff, cout_df) < 1e-3  # measured worst ~6.8e-4 (R=2.0 sharp pulse)
+
+
+def test_flow_independence_with_microdispersion():
+    """With alpha_L>0 the error is genuinely flow-INDEPENDENT (the advection+micro part is
+    volume-stationary): the strongly-variable-flow error must stay within a small factor of the
+    constant-flow error, not just below the absolute bound. A flow-dependent regression would
+    degrade with CV while still passing the per-regime bound."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    apv = _apv(25)
+    cin = _smooth(n)
+    common = {
+        "cin": cin,
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": apv,
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+        "retardation_factor": 2.0,
+    }
+
+    def err(flow):
+        return _peak_rel(infiltration_to_extraction(flow=flow, **common), df_i2e(flow=flow, **common))
+
+    err_const = err(np.full(n, 100.0))
+    err_cv06 = err(_variable_flow(n, 0.6, seed=5))
+    assert err_cv06 < 3.0 * max(err_const, 1e-6)  # measured ratio ~1.6
+
+
+@pytest.mark.parametrize(
+    ("d_m", "alpha_l", "inp", "bound", "note"),
+    [
+        (0.0, 2.0, "pulse", 2e-4, "micro-dominant pulse, measured 8e-5"),
+        (0.3, 0.0, "smooth", 5e-4, "molecular-dominant smooth, measured 9e-5"),
+        (0.3, 0.0, "pulse", 6e-3, "molecular-dominant sharp D_m=0.3, measured 4e-3"),
+        (1.0, 0.0, "pulse", 1.5e-2, "molecular-dominant sharp D_m=1.0, measured 1e-2"),
+    ],
+)
+def test_full_regime_bounds(d_m, alpha_l, inp, bound, note):
+    """Per-regime accuracy bounds pinned to the measured worst case (see `note`). Sharp inputs are
+    crossed only with the micro-dominant / molecular-dominant buckets that own the loose bounds."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cin = _pulse(n) if inp == "pulse" else _smooth(n)
+    kw = {
+        "cin": cin,
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": _apv(25),
+        "streamline_length": SL,
+        "molecular_diffusivity": d_m,
+        "longitudinal_dispersivity": alpha_l,
+    }
+    assert _peak_rel(infiltration_to_extraction(**kw), df_i2e(**kw)) < bound, note
+
+
+def test_full_bimodal_apvd():
+    """A bimodal APVD (no gamma assumption): tight when alpha_L>0, loose only molecular-dominant sharp."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    bimodal = np.array([300.0, 320.0, 340.0, 900.0, 920.0, 940.0])
+    base = {
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": bimodal,
+        "streamline_length": SL,
+    }
+    # alpha_L present -> tight
+    ff = infiltration_to_extraction(cin=_smooth(n), molecular_diffusivity=0.1, longitudinal_dispersivity=1.0, **base)
+    df = df_i2e(cin=_smooth(n), molecular_diffusivity=0.1, longitudinal_dispersivity=1.0, **base)
+    assert _peak_rel(ff, df) < 5e-4
+    # molecular-dominant sharp -> the wide-APVD corner, measured ~4.9e-2
+    ffp = infiltration_to_extraction(cin=_pulse(n), molecular_diffusivity=0.3, longitudinal_dispersivity=0.0, **base)
+    dfp = df_i2e(cin=_pulse(n), molecular_diffusivity=0.3, longitudinal_dispersivity=0.0, **base)
+    assert _peak_rel(ffp, dfp) < 6e-2
+
+
+def test_full_per_pore_volume_arrays_mixed_diffusivity_retardation():
+    """Per-streamtube L / D_m / alpha_L arrays with D_m mixed zero/non-zero and R != 1."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    kw = {
+        "cin": _smooth(n),
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": np.array([350.0, 450.0, 500.0, 600.0, 700.0, 850.0]),
+        "streamline_length": np.array([70.0, 75.0, 80.0, 85.0, 90.0, 100.0]),
+        "molecular_diffusivity": np.array([0.0, 0.05, 0.0, 0.08, 0.0, 0.03]),
+        "longitudinal_dispersivity": np.array([0.5, 1.0, 1.5, 1.0, 2.0, 0.8]),
+        "retardation_factor": 2.7,
+    }
+    cout_ff = infiltration_to_extraction(**kw)
+    cout_df = df_i2e(**kw)
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))
+    assert _peak_rel(cout_ff, cout_df) < 5e-4  # measured ~7.7e-5
+
+
+@pytest.mark.parametrize("retardation", [1.0, 2.5])
+def test_molecular_term_is_load_bearing(retardation):
+    """Pin the molecular-dominant floor AND prove the time-Gaussian is doing real work: at a large
+    pore volume (sigma_bins ~ 2.4) the molecular smear must bring the result far closer to
+    diffusion_fast than the smear-free (advection-only) approximation would -- a sigma regression
+    (e.g. sigma collapsing to 0, or a wrong R / mean_r_vpv dependence in sigma_t^2) would blow the
+    error up to ~0.9 and trip the floor. Parametrized over R to guard the R term in sigma_t^2."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    base = {
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": np.array([4000.0 / retardation]),  # keep r_vpv ~ 4000 across R
+        "streamline_length": SL,
+        "longitudinal_dispersivity": 0.0,
+        "retardation_factor": retardation,
+    }
+    ref = df_i2e(cin=_pulse(n), molecular_diffusivity=0.3, **base)
+    with_smear = infiltration_to_extraction(cin=_pulse(n), molecular_diffusivity=0.3, **base)
+    no_smear = infiltration_to_extraction(cin=_pulse(n), molecular_diffusivity=0.0, **base)
+    err_with = _peak_rel(with_smear, ref)
+    err_without = _peak_rel(no_smear, ref)
+    assert err_with < 6e-2  # measured floor ~3-5e-2
+    assert err_with < err_without / 3.0  # measured >20x improvement; guards sigma regressions
+
+
+# =============================================================================
+# flow_out / non-aligned output grid (exercises the shared _cout_cumulative_volume anchoring).
+# =============================================================================
+
+
+def test_flow_out_equals_flow_matches_omitted():
+    """Passing flow_out == flow on an aligned grid is identical to omitting it (same Vc)."""
+    n = 180
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    common = {
+        "cin": _smooth(n),
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": _apv(10),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+    }
+    a = infiltration_to_extraction(**common)
+    b = infiltration_to_extraction(**common, flow_out=flow.copy())
+    assert_allclose(a, b, atol=0.0, rtol=0.0, equal_nan=True)
+
+
+def test_coarse_cout_grid_with_flow_out():
+    """A coarser cout grid + flow_out (the anchored-cumsum Vc branch) matches diffusion_fast to the
+    forward accuracy."""
+    n = 180
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    cout_tedges = pd.date_range("2020-01-01", periods=n // 3 + 1, freq="3D")
+    flow_out = np.full(len(cout_tedges) - 1, 100.0)
+    kw = {
+        "cin": _smooth(n),
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": _apv(10),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+        "flow_out": flow_out,
+    }
+    cout_ff = infiltration_to_extraction(**kw)
+    cout_df = df_i2e(**kw)
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))
+    assert _peak_rel(cout_ff, cout_df) < 1e-3  # measured ~5e-6
+
+
+def test_coarse_cout_grid_molecular_smear_uses_output_bin_width():
+    """The molecular sigma must be converted with the OUTPUT-grid bin width, not the flow-grid width.
+    On a 4x-coarser cout grid with a non-negligible smear (large PV, moderate D_m), using the wrong
+    (flow-grid) width over-smears 4x and blows the error up to tens of percent; the correct width
+    matches diffusion_fast to ~1e-4. alpha_L>0 keeps step 1 exact so this isolates the smear width."""
+    n = 360
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    cout_tedges = pd.date_range("2020-01-01", periods=n // 4 + 1, freq="4D")
+    flow_out = np.full(len(cout_tedges) - 1, 100.0)
+    kw = {
+        "cin": _smooth(n, freq=12.0),
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([1000.0]),  # sigma_bins ~ O(1) on the cout grid
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.5,
+        "longitudinal_dispersivity": 1.0,
+        "flow_out": flow_out,
+    }
+    assert _peak_rel(infiltration_to_extraction(**kw), df_i2e(**kw)) < 1e-3  # measured ~1.4e-4
+
+
+# =============================================================================
+# Physical invariants (tight -- these stay tight even though the module is approximate).
+# =============================================================================
+
+
+@pytest.mark.parametrize("retardation", [1.0, 2.5])
+def test_constant_input_constant_output(retardation):
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cout = infiltration_to_extraction(
+        cin=np.full(n, 10.0),
+        flow=np.full(n, 100.0),
+        tedges=tedges,
+        cout_tedges=tedges.copy(),
+        aquifer_pore_volumes=_apv(25),
+        streamline_length=SL,
+        molecular_diffusivity=0.05,
+        longitudinal_dispersivity=1.0,
+        retardation_factor=retardation,
+    )
+    valid = ~np.isnan(cout)
+    assert valid.sum() > 50
+    assert_allclose(cout[valid], 10.0, atol=1e-9, rtol=0)  # measured ~1.8e-15
+
+
+def test_output_bounded_by_input():
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cin = _smooth(n, freq=4.0)
+    cout = infiltration_to_extraction(
+        cin=cin,
+        flow=np.full(n, 100.0),
+        tedges=tedges,
+        cout_tedges=tedges.copy(),
+        aquifer_pore_volumes=_apv(25),
+        streamline_length=SL,
+        molecular_diffusivity=0.05,
+        longitudinal_dispersivity=1.0,
+    )
+    valid = ~np.isnan(cout)
+    assert np.all(cout[valid] >= cin.min() - 1e-12)
+    assert np.all(cout[valid] <= cin.max() + 1e-12)
+
+
+def test_zero_diffusion_matches_advection():
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cin = _smooth(n, freq=4.0)
+    cout_ff = infiltration_to_extraction(
+        cin=cin,
+        flow=np.full(n, 100.0),
+        tedges=tedges,
+        cout_tedges=tedges.copy(),
+        aquifer_pore_volumes=np.array([500.0]),
+        streamline_length=SL,
+        molecular_diffusivity=0.0,
+        longitudinal_dispersivity=0.0,
+    )
+    cout_adv = advection_i2e(
+        cin=cin,
+        flow=np.full(n, 100.0),
+        tedges=tedges,
+        cout_tedges=tedges.copy(),
+        aquifer_pore_volumes=np.array([500.0]),
+    )
+    assert _peak_rel(cout_ff, cout_adv) < 1e-12
+
+
+# =============================================================================
+# Mass conservation: tight at constant flow; characterised (NOT conserved) at variable flow.
+# =============================================================================
+
+
+def test_column_mass_exact_at_constant_flow():
+    """At constant flow the time-Gaussian conserves volumetric column mass exactly (time integral =
+    volume integral), so the probe-built operator's volume-weighted column sums equal the infiltrated
+    volume per cin bin to machine precision -- a genuine conservation check (holds for D_m>0)."""
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+
+    def call(cin_arr):
+        return infiltration_to_extraction(
+            cin=cin_arr,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges.copy(),
+            aquifer_pore_volumes=np.array([500.0]),
+            streamline_length=SL,
+            molecular_diffusivity=0.3,
+            longitudinal_dispersivity=1.0,
+        )
+
+    w = _build_w_via_probes(call, n)
+    v_in = flow * 1.0
+    ratios = (v_in[:, None] * w).sum(axis=0)[20:180] / v_in[20:180]
+    assert_allclose(ratios, 1.0, atol=1e-12, rtol=0)
+
+
+def test_column_mass_conserved_at_variable_flow_matches_diffusion_fast():
+    """Under variable flow, on fully-broken-through interior bins the approximate operator conserves
+    volumetric column mass just as the exact diffusion_fast does -- the method does not introduce
+    extra mass error. (The molecular smear is mass-neutral at the sub-bin sigma of realistic D_m;
+    the smear itself is guarded by test_molecular_term_is_load_bearing.) Probe-built W, so
+    non-tautological."""
+    n = 60
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = _variable_flow(n, 0.5, seed=5)
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": np.array([500.0]),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.3,
+        "longitudinal_dispersivity": 1.0,
+    }
+    w_ff = _build_w_via_probes(lambda c: infiltration_to_extraction(cin=c, **common), n)
+    w_df = _build_w_via_probes(lambda c: df_i2e(cin=c, **common), n)
+    v_in = flow * 1.0
+    # Fully-broken-through interior bins (both operators have full column support there).
+    full = (w_ff.sum(axis=0) > 1.0 - 1e-3) & (w_df.sum(axis=0) > 1.0 - 1e-3)
+    full[:8] = False
+    full[-8:] = False
+    assert full.sum() > 10
+    cm_ff = (v_in[:, None] * w_ff).sum(axis=0)[full] / v_in[full]
+    cm_df = (v_in[:, None] * w_df).sum(axis=0)[full] / v_in[full]
+    assert np.max(np.abs(cm_ff - 1.0)) < 1e-8  # conserves like the exact operator (measured ~3e-10)
+    assert np.max(np.abs(cm_ff - cm_df)) < 1e-8  # introduces no extra mass error (measured ~9e-11)
+
+
+# =============================================================================
+# spinup=None (partial breakthrough) and edge cases.
+# =============================================================================
+
+
+def test_spinup_none_partial_breakthrough_masks_like_diffusion_fast():
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cin = np.linspace(2.0, 9.0, n)
+    kw = {
+        "cin": cin,
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": np.array([900.0]),  # long spin-up region of partial breakthrough
+        "streamline_length": 60.0,
+        "molecular_diffusivity": 0.1,
+        "longitudinal_dispersivity": 1.0,
+        "spinup": None,
+    }
+    cout_ff = infiltration_to_extraction(**kw)
+    cout_df = df_i2e(**kw)
+    # Confirm partial-breakthrough bins exist (row sums strictly between 0 and 1).
+    w = _build_w_via_probes(lambda c: df_i2e(**{**kw, "cin": c}), n)
+    rowsum = w.sum(axis=1)
+    assert ((rowsum > 1e-6) & (rowsum < 1.0 - 1e-6)).sum() >= 3
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))
+    assert _peak_rel(cout_ff, cout_df) < 1e-3  # measured ~3.1e-4
+
+
+@pytest.mark.parametrize("flow_rate", [0.0, 1e-6])
+def test_degenerate_flow_all_nan_like_diffusion_fast(flow_rate):
+    """Zero / tiny flow: nothing breaks through within the (extended) record -> all NaN, matching
+    diffusion_fast, without crashing or exploding the kernel grid / molecular sigma."""
+    n = 50
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    kw = {
+        "cin": np.linspace(1.0, 5.0, n),
+        "flow": np.full(n, flow_rate),
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": np.array([500.0]),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+    }
+    cout_ff = infiltration_to_extraction(**kw)
+    cout_df = df_i2e(**kw)
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))
+    assert np.all(np.isnan(cout_ff))
+
+
+def test_band_wider_than_series():
+    """Large PV / short series so the breakthrough band spans more than the record; the native build
+    must stay correct (warm-start baseline + masking) and match diffusion_fast."""
+    n = 12
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    kw = {
+        "cin": np.linspace(1.0, 5.0, n),
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": np.array([5000.0]),  # residence ~50 bins >> n
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.1,
+        "longitudinal_dispersivity": 1.0,
+    }
+    cout_ff = infiltration_to_extraction(**kw)
+    cout_df = df_i2e(**kw)
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))
+    assert_allclose(cout_ff, cout_df, atol=1e-9, rtol=0, equal_nan=True)
+
+
+# =============================================================================
+# Reverse (exact operator) + gamma wrappers.
+# =============================================================================
+
+
+def test_reverse_byte_identical_to_diffusion_fast():
+    """The reverse builds the diffusion_fast operator and solve, so it is bit-identical."""
+    tedges, cout_tedges, flow = _make_transport_data(n_days=120)
+    n = len(flow)
+    kw = {
+        "cout": np.sin(np.linspace(0.0, 6.0 * np.pi, n)) + 5.0,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": _apv(5),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+    }
+    with warn_module.catch_warnings():
+        warn_module.simplefilter("ignore")
+        assert_allclose(extraction_to_infiltration(**kw), df_e2i(**kw), atol=0.0, rtol=0.0, equal_nan=True)
+
+
+def test_reverse_forwards_retardation_and_flow_out():
+    """The reverse must forward EVERY transport parameter into the diffusion_fast operator, not just
+    the aligned-grid R=1 defaults: byte-identical with retardation AND on a coarse cout grid with
+    flow_out. (Guards a dropped retardation_factor / flow_out in the _closed_form_coeff_matrix call.)"""
+    n = 150
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    cout_tedges = pd.date_range("2020-01-01", periods=n // 3 + 1, freq="3D")
+    kw = {
+        "cout": np.sin(np.linspace(0.0, 6.0 * np.pi, len(cout_tedges) - 1)) + 5.0,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": _apv(5),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+        "retardation_factor": 2.7,
+        "flow_out": np.full(len(cout_tedges) - 1, 100.0),
+    }
+    with warn_module.catch_warnings():
+        warn_module.simplefilter("ignore")
+        assert_allclose(extraction_to_infiltration(**kw), df_e2i(**kw), atol=0.0, rtol=0.0, equal_nan=True)
+
+
+def test_round_trip_recovers_to_forward_accuracy():
+    """Forward (approximate) then inverse (exact operator) recovers cin to ~ the forward accuracy
+    (the inverse cannot beat the approximate forward), not to machine precision."""
+    tedges, cout_tedges, flow = _make_transport_data(n_days=200)
+    n = len(flow)
+    cin = np.sin(np.linspace(0.0, 2.0 * np.pi, n)) + 5.0
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([517.0]),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.01,
+        "longitudinal_dispersivity": 1.0,
+    }
+    cout = infiltration_to_extraction(cin=cin, **common)
+    cout_clean = np.where(np.isnan(cout), np.nanmean(cout), cout)
+    with warn_module.catch_warnings():
+        warn_module.simplefilter("ignore")
+        cin_rec = extraction_to_infiltration(cout=cout_clean, **common)
+    valid = ~np.isnan(cin_rec) & ~np.isnan(cout)
+    valid[:30] = False
+    valid[-30:] = False
+    assert valid.sum() > 100
+    assert _peak_rel(cin_rec, cin, skip=30) < 5e-3  # forward-accuracy-limited
+
+
+def test_gamma_forward_matches_diffusion_fast():
+    tedges, cout_tedges, flow = _make_transport_data(n_days=150)
+    n = len(flow)
+    kw = {
+        "cin": np.sin(np.linspace(0.0, 6.0 * np.pi, n)) + 4.0,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "mean": 500.0,
+        "std": 120.0,
+        "n_bins": 25,
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+    }
+    cout_ff = gamma_infiltration_to_extraction(**kw)
+    cout_df = df_gamma_i2e(**kw)
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))
+    assert _peak_rel(cout_ff, cout_df) < 5e-4  # measured ~4.5e-6
+
+
+def test_gamma_reverse_byte_identical():
+    tedges, cout_tedges, flow = _make_transport_data(n_days=140)
+    n = len(flow)
+    kw = {
+        "cout": np.sin(np.linspace(0.0, 6.0 * np.pi, n)) + 5.0,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "mean": 501.3,
+        "std": 100.0,
+        "n_bins": 20,
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+    }
+    with warn_module.catch_warnings():
+        warn_module.simplefilter("ignore")
+        assert_allclose(gamma_extraction_to_infiltration(**kw), df_gamma_e2i(**kw), atol=0.0, rtol=0.0, equal_nan=True)
+
+
+# =============================================================================
+# Performance smoke + input validation.
+# =============================================================================
+
+
+def test_large_n_is_fast():
+    """A large series must stay well under O(N^2): n=20000 single call in a fraction of a second
+    (catches an accidental quadratic regression without asserting a brittle absolute runtime)."""
+    n = 20000
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = _variable_flow(n, 0.3, seed=1)
+    cin = np.sin(np.linspace(0.0, 200.0 * np.pi, n)) + 5.0
+    kw = {
+        "cin": cin,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": _apv(50),
+        "streamline_length": SL,
+        "molecular_diffusivity": 0.05,
+        "longitudinal_dispersivity": 1.0,
+    }
+    infiltration_to_extraction(**kw)  # warm-up / import jit
+    t0 = time.perf_counter()
+    infiltration_to_extraction(**kw)
+    assert time.perf_counter() - t0 < 1.0
+
+
+def test_flow_out_required_when_grids_differ():
+    n = 30
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cout_tedges = pd.date_range("2020-01-02", periods=n + 1, freq="D")
+    with pytest.raises(ValueError, match="flow_out is required"):
+        infiltration_to_extraction(
+            cin=np.ones(n),
+            flow=np.full(n, 100.0),
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            streamline_length=SL,
+            molecular_diffusivity=0.05,
+            longitudinal_dispersivity=1.0,
+        )
+
+
+def test_negative_diffusivity_rejected():
+    tedges, cout_tedges, flow = _make_transport_data(n_days=30)
+    with pytest.raises(ValueError, match="molecular_diffusivity must be non-negative"):
+        infiltration_to_extraction(
+            cin=np.ones(len(flow)),
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            streamline_length=SL,
+            molecular_diffusivity=-1.0,
+            longitudinal_dispersivity=1.0,
+        )


### PR DESCRIPTION
## Summary

`diffusion_fast_fast` is reworked into a single **fast approximate** forward transport that works for **any flow** (constant or variable, regular or irregular grid), replacing the earlier constant-flow convolution-kernel build that delegated to `diffusion_fast` outside its shift-invariant regime.

It computes the same physics as `diffusion_fast` — the bin-averaged Kreft–Zuber (1978) flux concentration `C_F` on a bundle of 1D streamtubes — but **operator-splits** the moving-frame dispersion `D_t = D_m·τ + α_L·ξ` into the coordinate each mechanism is stationary in, so the dominant part is built once and is flow-independent:

1. **Advection + macrodispersion + microdispersion (`α_L`)** — the *exact* skewed `D_m = 0` Kreft–Zuber breakthrough, applied banded on the **native cumulative-volume grid**. The whole aquifer pore-volume distribution is pre-summed into a single 1-D antiderivative `Ī(ΔV)` (exact for any APVD shape), finely sampled once and read back by fractional-index interpolation.
2. **Molecular diffusion (`D_m`)** — a symmetric **time-domain Gaussian** on the outlet signal (the documented limit; the true molecular breakthrough is skewed, and at realistic sub-bin spreading the Gaussian is nearly a no-op).

The inverse (`extraction_to_infiltration`) stays **exact**: it builds the true `diffusion_fast` forward operator and deconvolves it via Tikhonov (the solve dominates the cost, and deconvolution wants the true operator). A round trip therefore recovers the input to the forward accuracy.

### Accuracy (vs `diffusion_fast`, flow-independent unless noted)

| regime | smooth input | sharp pulse |
|---|---|---|
| **mechanical dispersion present** (`α_L > 0`, the typical Pe ≫ 1 case), constant + variable flow (CV ≤ 0.6) | ~1e-5 | ~3e-4 |
| molecular-diffusion-dominated (`α_L ≈ 0`), D_m ≲ 0.3 | ~1e-4 | ~4e-3 |
| molecular-diffusion-dominated, large D_m / large or bimodal APVD | ~1e-3 | ~1e-2 – 5e-2 |

Machine precision is **given up by design**. `diffusion_fast` remains the exact reference and the recommended choice when exactness matters — especially in the molecular-diffusion-dominated regime. The molecular Gaussian is the documented limit (an exact skewed molecular kernel was considered and deferred).

## Changes

- Rewrite `src/gwtransport/diffusion_fast_fast.py`: `_summed_antideriv` (the `Ī` precompute), `_advection_micro_native` (the banded native-grid apply), `_eval_antideriv` (uniform-grid fractional-index interp), and the molecular time-Gaussian. Removes the shift-invariance detection, kernel build, and delegation. No fallback.
- Add `_cout_cumulative_volume` to `_diffusion_shared` so the forward and reverse paths place the `cout` grid on identical volume coordinates; `diffusion_fast` is refactored to reuse it (behaviour unchanged — its tests still pass).
- Rewrite `tests/src/test_diffusion_fast_fast.py` with per-regime tolerances pinned to the measured worst case (comments record each measurement).
- Update `docs/source/user_guide/assumptions.rst` and `concepts.rst` to describe the approximate, all-flow contract.

## Test plan

- `tests/src/test_diffusion_fast_fast.py` (56 tests): step-1 (D_m=0) isolation vs `diffusion_fast` incl. sharp pulse/step × constant/variable flow × retardation; kernel-fineness convergence; full-method per-regime accuracy sweep (constant + CV 0.1/0.3/0.6, micro/molecular-dominant, bimodal/wide/per-PV APVD); flow-independence; molecular-floor σ guard; flow_out / coarse-`cout`-grid path; tight invariants (constant-input→constant, output-bounded, zero-diffusion→advection); constant-flow column-mass conservation and variable-flow column-mass parity vs `diffusion_fast`; spin-up partial breakthrough; zero/tiny flow and band-wider-than-series edge cases; reverse byte-identity (incl. retardation + flow_out) and round-trip; large-N performance smoke; input validation.
- Full unit suite: `pytest tests/src -n auto` → **1436 passed, 2 skipped**.
- `ruff format`, `ruff check`, and `ty check` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
