### PR TITLE
Replace dense advection weight build with an exact banded per-streamtube builder

### DIFF
--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -15,12 +15,12 @@ Available functions:
   (cout = cin). No support for custom output time edges. Use case: Deterministic transport
   with single flow path.
 
-- :func:`infiltration_to_extraction` - Arbitrary pore volume distribution, convolution.
+- :func:`infiltration_to_extraction` - Arbitrary pore volume distribution, flow-weighted averaging.
   Supports explicit distribution of aquifer pore volumes with flow-weighted averaging.
   Flexible output time resolution via cout_tedges. Use case: Known pore volume distribution
   from streamline analysis.
 
-- :func:`gamma_infiltration_to_extraction` - Gamma-distributed pore volumes, convolution.
+- :func:`gamma_infiltration_to_extraction` - Gamma-distributed pore volumes, flow-weighted averaging.
   Models aquifer heterogeneity with 2-parameter gamma distribution. Parameterizable via
   (alpha, beta) or (mean, std). Discretizes gamma distribution into equal-probability bins.
   Use case: Heterogeneous aquifer with calibrated gamma parameters.
@@ -403,7 +403,7 @@ def gamma_infiltration_to_extraction(
     of the aquifer. The aquifer pore volume is approximated by a (shifted) gamma distribution
     parameterized by either (mean, std, loc) or (alpha, beta, loc).
 
-    This function represents infiltration to extraction modeling (equivalent to convolution).
+    This function represents infiltration to extraction modeling by flow-weighted averaging.
 
     Provide either (mean, std) or (alpha, beta); ``loc`` is optional and defaults to 0.
 
@@ -574,7 +574,7 @@ def gamma_extraction_to_infiltration(
     of the aquifer. The aquifer pore volume is approximated by a (shifted) gamma distribution
     parameterized by either (mean, std, loc) or (alpha, beta, loc).
 
-    This function represents extraction to infiltration modeling (equivalent to deconvolution).
+    This function inverts the forward flow-weighted averaging (deconvolution).
     It is symmetric to gamma_infiltration_to_extraction.
 
     Provide either (mean, std) or (alpha, beta); ``loc`` is optional and defaults to 0.
@@ -627,7 +627,7 @@ def gamma_extraction_to_infiltration(
     See Also
     --------
     extraction_to_infiltration : Deconvolution with explicit pore volume distribution
-    gamma_infiltration_to_extraction : Forward operation (convolution)
+    gamma_infiltration_to_extraction : Forward operation (flow-weighted averaging)
     gwtransport.gamma.bins : Create gamma distribution bins
     gwtransport.diffusion.extraction_to_infiltration : Deconvolution with microdispersion and molecular diffusion
     :ref:`concept-gamma-distribution` : Two-parameter pore volume model
@@ -742,12 +742,16 @@ def infiltration_to_extraction(
     This function implements an infiltration to extraction advection model where cin and flow values
     correspond to the same aligned time bins defined by tedges.
 
-    The algorithm:
-    1. Computes residence times for each pore volume at cout time edges
-    2. Calculates infiltration time edges by subtracting residence times
-    3. Determines temporal overlaps between infiltration and cin time windows
-    4. Creates flow-weighted overlap matrices normalized by total weights
-    5. Computes weighted contributions and averages across pore volumes
+    Pure advection is volume-stationary, so the weights are built on the
+    cumulative-throughflow-volume axis rather than by inverting residence times:
+
+    1. Map the cin and cout time edges to cumulative throughflow volume.
+    2. Back-project each cout bin by every retarded pore volume to its
+       infiltration-time source window. The window spans one cout bin's worth of
+       volume, so it overlaps only a narrow band of cin bins.
+    3. Compute the flow-weighted time overlap of each window with those cin bins,
+       normalize per streamtube (each row sums to 1), and average over the
+       streamtubes whose source window lies fully inside the cin range.
 
 
     Parameters
@@ -1044,7 +1048,7 @@ def extraction_to_infiltration(
     See Also
     --------
     gamma_extraction_to_infiltration : Deconvolution with gamma-distributed pore volumes
-    infiltration_to_extraction : Forward operation (convolution)
+    infiltration_to_extraction : Forward operation (flow-weighted averaging)
     extraction_to_infiltration_series : Simple time-shift for single pore volume
     gwtransport.residence_time.residence_time : Compute residence times from flow and pore volume
     gwtransport.utils.solve_tikhonov : Solver used for inversion

--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -14,8 +14,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from gwtransport._time import tedges_to_days
-from gwtransport.residence_time import residence_time
-from gwtransport.utils import partial_isin
+from gwtransport.utils import cumulative_flow_volume
 
 
 def _infiltration_to_extraction_weights(
@@ -29,18 +28,37 @@ def _infiltration_to_extraction_weights(
     """
     Compute raw streamtube-bundle weights for infiltration to extraction transformation.
 
-    Builds the per-cout-bin sum of streamtube-normalized overlap matrices,
-    plus the count of contributing streamtubes per cout bin and the
-    zero-flow cout-bin mask. The caller decides how to convert these into
-    final weights (strict-validity, count-mean, or padded "constant"
-    spin-up); see :func:`_resolve_spinup_mask` and
-    :func:`_pad_tedges_for_spinup`.
+    Builds the per-cout-bin sum of streamtube-normalized overlap rows, plus the
+    count of contributing streamtubes per cout bin and the zero-flow cout-bin
+    mask. The caller decides how to convert these into final weights
+    (strict-validity, count-mean, or padded "constant" spin-up); see
+    :func:`_resolve_spinup_mask` and :func:`_resolve_spinup_inputs`.
 
-    The per-streamtube weight is the literal mass-flux / water-flux ratio
-    for that streamtube and cout bin: each row sums to 1 to ULP. Equal-mass
-    pore-volume bins from a gamma APVD discretization carry equal flow at
-    the outlet (steady-streamline assumption), so the bundle output is the
-    arithmetic mean over contributing streamtubes.
+    The per-streamtube weight is the literal mass-flux / water-flux ratio for
+    that streamtube and cout bin: each contributing row sums to 1 to ULP.
+    Equal-mass pore-volume bins from a gamma APVD discretization carry equal
+    flow at the outlet (steady-streamline assumption), so the bundle output is
+    the arithmetic mean over contributing streamtubes.
+
+    Pure advection (``D_m = 0``, ``alpha_L = 0``) is volume-stationary. Let
+    ``Vi`` be the cumulative throughflow volume at the cin edges and ``Vc`` the
+    same cumulative volume sampled at the cout edges. A streamtube of retarded
+    pore volume ``r = R * V_pore`` carries each cout edge back to the
+    infiltration time at cumulative volume ``Vc_edge - r``. The cout bin's
+    source window in infiltration time spans one cout bin's worth of volume, so
+    it overlaps only a few cin bins -- the weights are gathered on that narrow
+    band rather than the full ``O(n_cin)`` row, giving ``O(n_pv * n_cout *
+    band)`` work instead of the dense ``O(n_pv * n_cout * n_cin)``. The overlap
+    is the flow-weighted time overlap normalized by the window's total in-range
+    flow, so each contributing row sums to 1 exactly. It is the exact
+    flow-weighted overlap on the nonzero band -- matching the dense
+    ``residence_time`` + ``partial_isin`` reference to machine precision (and the
+    exact-arithmetic result to ~1e-15), not an approximation.
+
+    A streamtube whose source volume leaves ``[Vi[0], Vi[-1]]`` -- or a cout
+    edge outside the cin time range -- maps to NaN and is **dropped, not
+    clipped**: its whole window for that cout bin is discarded (mirroring the
+    dense build, where a single NaN residence-time edge poisons the row).
 
     Parameters
     ----------
@@ -64,86 +82,73 @@ def _infiltration_to_extraction_weights(
         to ``c`` (not ``n_pv`` and not 1).
     contributing_bins : numpy.ndarray of int
         Shape: (len(cout_tedges) - 1,). Number of streamtubes that
-        actually contributed to each cout bin (had nonzero flow-weighted
-        overlap with the cin range).
+        actually contributed to each cout bin (had a source window fully
+        inside the cin volume range).
     zero_flow_cout : numpy.ndarray of bool
         Shape: (len(cout_tedges) - 1,). True for cout bins with zero
         time-averaged extraction flow over their interval.
     """
-    # Convert time edges to days
     cin_tedges_days = tedges_to_days(tedges)
     cout_tedges_days = tedges_to_days(cout_tedges, ref=tedges[0])
+    flow = np.asarray(flow, dtype=float)
 
-    # Detect zero-flow cout bins: a cout bin is "zero-flow" when the time-
-    # averaged extraction flow over its interval is zero. Compute via the
-    # cout-vs-cin time-overlap matrix.
-    cout_in_cin_overlap = partial_isin(bin_edges_in=cout_tedges_days, bin_edges_out=cin_tedges_days)
-    flow_during_cout = cout_in_cin_overlap @ flow
-    zero_flow_cout = flow_during_cout == 0
-
-    # Pre-compute all residence times and infiltration edges
-    rt_edges_2d = residence_time(
-        flow=flow,
-        flow_tedges=tedges,
-        index=cout_tedges,
-        aquifer_pore_volumes=aquifer_pore_volumes,
-        retardation_factor=retardation_factor,
-        direction="extraction_to_infiltration",
-    )
-    infiltration_tedges_2d = cout_tedges_days[None, :] - rt_edges_2d
-
-    # Pre-compute valid bins
-    valid_bins_2d = ~(np.isnan(infiltration_tedges_2d[:, :-1]) | np.isnan(infiltration_tedges_2d[:, 1:]))
-
-    # Pre-compute cin time range for clip optimization (computed once, used n_bins times)
-    cin_time_min = cin_tedges_days[0]
-    cin_time_max = cin_tedges_days[-1]
-
-    n_pv = len(aquifer_pore_volumes)
     n_cout = len(cout_tedges) - 1
     n_cin = len(tedges) - 1
-    accumulated_weights = np.zeros((n_cout, n_cin))
-    contributing_bins = np.zeros(n_cout, dtype=int)
+    n_pv = len(aquifer_pore_volumes)
 
-    # Loop over each pore volume
-    for i in range(n_pv):
-        if not np.any(valid_bins_2d[i, :]):
-            continue
+    # Cumulative throughflow volume at cin edges (Vi) and sampled at cout edges (Vc).
+    vi = cumulative_flow_volume(flow, np.diff(cin_tedges_days))
+    vc = np.interp(cout_tedges_days, cin_tedges_days, vi)
 
-        # Clip optimization: check for temporal overlap before expensive computation.
-        infiltration_times = infiltration_tedges_2d[i, :]
-        valid_infiltration_times = infiltration_times[~np.isnan(infiltration_times)]
+    # A cout bin's time-averaged extraction flow is zero exactly when no throughflow
+    # volume passes during the bin, i.e. its cumulative-volume width is zero. This is
+    # bit-identical to the dense flow-overlap-matrix product but is O(n_cout), not O(N^2).
+    zero_flow_cout = np.diff(vc) == 0
 
-        if len(valid_infiltration_times) == 0:
-            continue
+    if n_pv == 0:
+        return np.zeros((n_cout, n_cin)), np.zeros(n_cout, dtype=np.intp), zero_flow_cout
 
-        infiltration_min = valid_infiltration_times[0]  # monotonic, first element is min
-        infiltration_max = valid_infiltration_times[-1]  # monotonic, last element is max
+    r = np.sort(np.asarray(aquifer_pore_volumes, dtype=float) * retardation_factor)
 
-        # Two intervals overlap iff max(starts) < min(ends).
-        has_overlap = max(infiltration_min, cin_time_min) < min(infiltration_max, cin_time_max)
-        if not has_overlap:
-            continue
+    # Back-project every cout edge by every streamtube to its infiltration TIME.
+    # Out-of-range cout edges have no source volume; NaN there propagates so the
+    # adjacent windows are dropped (not clipped), matching the dense build.
+    edge_in_range = (cout_tedges_days >= cin_tedges_days[0]) & (cout_tedges_days <= cin_tedges_days[-1])
+    src_volume = np.where(edge_in_range, vc, np.nan)[None, :] - r[:, None]  # (n_pv, n_cout + 1)
+    infil_days = np.interp(src_volume.ravel(), vi, cin_tedges_days, left=np.nan, right=np.nan).reshape(src_volume.shape)
+    win_lo, win_hi = infil_days[:, :-1], infil_days[:, 1:]  # (n_pv, n_cout) infiltration-time window per cout bin
+    contained = np.isfinite(win_lo) & np.isfinite(win_hi)
 
-        # partial_isin returns shape (n_cout, n_cin) here: bin_edges_in has length
-        # n_cout+1 (one infiltration-time edge per cout edge), bin_edges_out has
-        # length n_cin+1 (the cin time edges).
-        overlap_matrix = partial_isin(bin_edges_in=infiltration_tedges_2d[i, :], bin_edges_out=cin_tedges_days)
+    # Each source window spans one cout bin's worth of volume, so it overlaps a
+    # narrow band of cin bins; size the band off the widest contained window.
+    # NaN windows (dropped streamtubes) sort to the array end in searchsorted and
+    # are masked out below (band ignores them, in_cin zeros their flux).
+    j_lo = np.clip(np.searchsorted(cin_tedges_days, win_lo, side="right") - 1, 0, n_cin - 1)
+    j_hi = np.clip(np.searchsorted(cin_tedges_days, win_hi, side="left"), 0, n_cin)
+    band = min(int(np.max(np.where(contained, j_hi - j_lo, 0))) + 1, n_cin)
 
-        # Per-streamtube row sums to 1 by construction (mass-flux / water-flux).
-        # Rows where row_sums == 0 (zero-flow / zero-overlap) are not normalized
-        # and therefore not counted as "contributing" — those bins are deferred
-        # to the policy resolver instead.
-        flow_weighted_overlap = overlap_matrix * flow[None, :]
-        row_sums = np.sum(flow_weighted_overlap, axis=1)
-        valid_rows_pv = row_sums > 0
-        normalized_overlap = np.zeros_like(flow_weighted_overlap)
-        normalized_overlap[valid_rows_pv, :] = flow_weighted_overlap[valid_rows_pv, :] / row_sums[valid_rows_pv, None]
+    cols = j_lo[:, :, None] + np.arange(band)[None, None, :]  # (n_pv, n_cout, band) cin bin index
+    in_cin = contained[:, :, None] & (cols < n_cin)
+    cols = np.clip(cols, 0, n_cin - 1)
+    # Flow-weighted time overlap of each window with each banded cin bin.
+    overlap = np.maximum(
+        0.0,
+        np.minimum(win_hi[:, :, None], cin_tedges_days[cols + 1])
+        - np.maximum(win_lo[:, :, None], cin_tedges_days[cols]),
+    )
+    flux = np.where(in_cin, flow[cols] * overlap, 0.0)
+    window_flux = flux.sum(axis=2)  # (n_pv, n_cout) total in-range flow per window
+    contributes = contained & (window_flux > 0)
+    contributing_bins = contributes.sum(axis=0).astype(np.intp)
 
-        accumulated_weights[valid_rows_pv, :] += normalized_overlap[valid_rows_pv, :]
-        contributing_bins[valid_rows_pv] += 1
+    # Per-streamtube normalized row (sums to 1); scatter-add into the dense matrix.
+    weights = np.zeros(flux.shape)
+    np.divide(flux, window_flux[:, :, None], out=weights, where=contributes[:, :, None])
+    cout_idx = np.broadcast_to(np.arange(n_cout)[None, :, None], cols.shape)
+    flat = (cout_idx * n_cin + cols).ravel()
+    summed = np.bincount(flat, weights=weights.ravel(), minlength=n_cout * n_cin).astype(float, copy=False)
 
-    return accumulated_weights, contributing_bins, zero_flow_cout
+    return summed.reshape(n_cout, n_cin), contributing_bins, zero_flow_cout
 
 
 def _resolve_spinup_mask(

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -1,10 +1,13 @@
 import warnings
+from fractions import Fraction
 
 import numpy as np
 import pandas as pd
 import pytest
 
 from gwtransport import advection as adv_mod
+from gwtransport import gamma
+from gwtransport._time import tedges_to_days
 from gwtransport.advection import (
     _validate_advection_inputs,
     extraction_to_infiltration,
@@ -21,7 +24,8 @@ from gwtransport.advection_utils import (
     _resolve_spinup_mask,
 )
 from gwtransport.fronttracking.math import ConstantRetardation
-from gwtransport.utils import compute_time_edges
+from gwtransport.residence_time import residence_time
+from gwtransport.utils import compute_time_edges, partial_isin, solve_inverse_transport
 
 # ===============================================================================
 # FIXTURES
@@ -3855,3 +3859,564 @@ def test_validate_advection_inputs_raises_on_bad_input(path, mutate, match_regex
     bad = mutate(_good_advection_inputs())
     with pytest.raises(ValueError, match=match_regex):
         _validate_advection_inputs(**bad)
+
+
+# =============================================================================
+# Fast banded builder: dense + rational oracles and the exactness suite.
+#
+# The package builder (advection_utils._infiltration_to_extraction_weights)
+# performs the dense build's exact per-streamtube time-domain arithmetic but
+# only on the nonzero band (the source window overlaps a few cin bins), so it is
+# machine-precision identical to the dense build at O(n_pv * n_cout * band)
+# instead of O(n_pv * n_cout * n_cin). Two independent oracles pin it:
+#
+#   _dense_weights_reference -- the relocated O(n_pv * N^2) dense full-overlap
+#       build (residence_time + partial_isin) the banded builder replaced. The
+#       builder reproduces it to float reordering noise (~1e-14); accumulated
+#       parity uses atol=1e-12 (two independent float paths), structure exactly.
+#   _exact_rational_advection -- fractions.Fraction overlap arithmetic on the
+#       cumulative-volume axis, the absolute truth; the builder matches it to
+#       ~1e-15 (machine precision) on every grid including sub-bin cout.
+#
+# Both encode the drop-not-clip contract: a streamtube contributes to a cout bin
+# only if its source window is fully inside [Vi[0], Vi[-1]].
+# =============================================================================
+
+
+def _dense_weights_reference(*, tedges, cout_tedges, aquifer_pore_volumes, flow, retardation_factor):
+    """Relocated copy of the original dense full-overlap-matrix builder.
+
+    Loops over pore volumes, back-projects the cout edges with ``residence_time``,
+    and accumulates per-streamtube flow-normalized ``partial_isin`` overlap rows.
+    A streamtube whose source window leaves the cin range yields a NaN
+    residence-time edge -> NaN overlap row -> dropped (not counted, not clipped).
+    Returns the same ``(accumulated_weights, contributing_bins, zero_flow_cout)``
+    triple as the package builder.
+    """
+    cin_tedges_days = tedges_to_days(tedges)
+    cout_tedges_days = tedges_to_days(cout_tedges, ref=tedges[0])
+    flow = np.asarray(flow, dtype=float)
+
+    cout_in_cin_overlap = partial_isin(bin_edges_in=cout_tedges_days, bin_edges_out=cin_tedges_days)
+    zero_flow_cout = (cout_in_cin_overlap @ flow) == 0
+
+    rt_edges_2d = residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        index=cout_tedges,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        retardation_factor=retardation_factor,
+        direction="extraction_to_infiltration",
+    )
+    infiltration_tedges_2d = cout_tedges_days[None, :] - rt_edges_2d
+    valid_bins_2d = ~(np.isnan(infiltration_tedges_2d[:, :-1]) | np.isnan(infiltration_tedges_2d[:, 1:]))
+    cin_min, cin_max = cin_tedges_days[0], cin_tedges_days[-1]
+
+    n_pv = len(aquifer_pore_volumes)
+    n_cout = len(cout_tedges) - 1
+    n_cin = len(tedges) - 1
+    accumulated = np.zeros((n_cout, n_cin))
+    contributing = np.zeros(n_cout, dtype=np.intp)
+
+    for i in range(n_pv):
+        if not np.any(valid_bins_2d[i, :]):
+            continue
+        infil = infiltration_tedges_2d[i, :]
+        valid_times = infil[~np.isnan(infil)]
+        if len(valid_times) == 0 or not (max(valid_times[0], cin_min) < min(valid_times[-1], cin_max)):
+            continue
+        overlap_matrix = partial_isin(bin_edges_in=infil, bin_edges_out=cin_tedges_days)
+        flow_weighted = overlap_matrix * flow[None, :]
+        row_sums = flow_weighted.sum(axis=1)
+        valid = row_sums > 0
+        normalized = np.zeros_like(flow_weighted)
+        normalized[valid, :] = flow_weighted[valid, :] / row_sums[valid, None]
+        accumulated[valid, :] += normalized[valid, :]
+        contributing[valid] += 1
+
+    return accumulated, contributing, zero_flow_cout
+
+
+def _exact_rational_advection(*, tedges, cout_tedges, aquifer_pore_volumes, flow, retardation_factor):
+    """Exact Fraction overlap arithmetic on the cumulative-volume axis.
+
+    Independent of both the package and the dense reference. Encodes the
+    drop-not-clip contract: only streamtubes whose source window lies fully
+    inside ``[Vi[0], Vi[-1]]`` contribute. Returns ``(accumulated_weights,
+    contributing_bins)`` as float64 arrays converted from exact Fractions.
+    """
+    cin_days = [Fraction(x) for x in tedges_to_days(tedges)]
+    cout_days = [Fraction(x) for x in tedges_to_days(cout_tedges, ref=tedges[0])]
+    flow_f = [Fraction(x) for x in np.asarray(flow, dtype=float)]
+    n_cin = len(cin_days) - 1
+    n_cout = len(cout_days) - 1
+    r = sorted(Fraction(retardation_factor) * Fraction(v) for v in np.asarray(aquifer_pore_volumes, dtype=float))
+
+    vi = [Fraction(0)]
+    for j in range(n_cin):
+        vi.append(vi[-1] + flow_f[j] * (cin_days[j + 1] - cin_days[j]))
+    vi_lo, vi_hi = vi[0], vi[-1]
+
+    def interp_v(t):
+        if t <= cin_days[0]:
+            return vi[0]
+        if t >= cin_days[-1]:
+            return vi[-1]
+        j = 0
+        while cin_days[j + 1] < t:
+            j += 1
+        width = cin_days[j + 1] - cin_days[j]
+        if width == 0:
+            return vi[j]
+        return vi[j] + (t - cin_days[j]) / width * (vi[j + 1] - vi[j])
+
+    vc = [interp_v(t) for t in cout_days]
+    edge_in_range = [cin_days[0] <= t <= cin_days[-1] for t in cout_days]
+
+    accumulated = np.zeros((n_cout, n_cin))
+    contributing = np.zeros(n_cout, dtype=np.intp)
+    for i in range(n_cout):
+        lo_v, hi_v = vc[i], vc[i + 1]
+        w = hi_v - lo_v
+        if w == 0 or not (edge_in_range[i] and edge_in_range[i + 1]):
+            continue
+        row = [Fraction(0)] * n_cin
+        ncontrib = 0
+        for rp in r:
+            a, b = lo_v - rp, hi_v - rp
+            if a < vi_lo or b > vi_hi:  # window not fully contained -> dropped
+                continue
+            ncontrib += 1
+            for m in range(n_cin):
+                overlap = min(b, vi[m + 1]) - max(a, vi[m])
+                if overlap > 0:
+                    row[m] += overlap / w
+        contributing[i] = ncontrib
+        accumulated[i, :] = [float(x) for x in row]
+    return accumulated, contributing
+
+
+def _forward_via(builder, *, cin, flow, tedges, cout_tedges, aquifer_pore_volumes, retardation_factor, spinup):
+    """Drive ``builder`` through the public forward spin-up pipeline.
+
+    Mirrors :func:`infiltration_to_extraction` exactly but lets the weight
+    builder be swapped (package builder vs dense oracle) so the two can be
+    compared through identical spin-up resolution.
+    """
+    weight_tedges, weight_flow, weight_cin, threshold, _ = _resolve_spinup_inputs(
+        spinup,
+        tedges=tedges,
+        flow=flow,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        retardation_factor=retardation_factor,
+        cin=cin,
+    )
+    acc, contrib, zero_flow = builder(
+        tedges=weight_tedges,
+        cout_tedges=cout_tedges,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        flow=weight_flow,
+        retardation_factor=retardation_factor,
+    )
+    w, invalid = _resolve_spinup_mask(
+        accumulated_weights=acc,
+        contributing_bins=contrib,
+        zero_flow_cout=zero_flow,
+        n_pv=len(aquifer_pore_volumes),
+        spinup=threshold,
+    )
+    assert weight_cin is not None  # cin is always supplied in these tests
+    out = w.dot(weight_cin)
+    out[invalid] = np.nan
+    return out, contrib
+
+
+_BANDED_APVD = {
+    "single": np.array([500.0]),
+    "bimodal": np.array([120.0, 130.0, 900.0, 950.0]),
+    "uniform_wide": np.linspace(50.0, 800.0, 12),
+    "heavy_tail": np.array([50.0, 60.0, 70.0, 2000.0]),
+    "gamma": gamma.bins(mean=300.0, std=120.0, n_bins=24)["expected_values"],
+}
+
+
+def _banded_tedges(n, kind, seed):
+    """Return tedges for a regular or irregular cin grid of n bins."""
+    if kind == "regular":
+        return pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    rng = np.random.default_rng(seed)
+    widths = 0.3 + rng.uniform(0.0, 1.7, n)
+    return pd.Timestamp("2020-01-01") + pd.to_timedelta(np.concatenate([[0.0], np.cumsum(widths)]), unit="D")
+
+
+def _banded_cout(tedges, kind):
+    """Return cout_tedges: aligned, coarse (every 3rd edge), or fine (each cin
+    bin split into 3 equal sub-bins -- irregular when ``tedges`` are irregular).
+
+    The fine grid is a clean equal subdivision (no random near-coincident edges)
+    so its smallest bin volume is bounded; pathologically tiny cout bins are
+    exercised separately by the rational-oracle tests at small cumulative volume.
+    """
+    if kind == "same":
+        return tedges
+    if kind == "coarse":
+        return tedges[::3]
+    d = tedges_to_days(tedges)
+    pts = np.unique(np.concatenate([np.linspace(d[i], d[i + 1], 4) for i in range(len(d) - 1)]))
+    return tedges[0] + pd.to_timedelta(pts, unit="D")
+
+
+@pytest.mark.parametrize("apv_name", list(_BANDED_APVD))
+def test_banded_builder_triple_parity_vs_dense(apv_name):
+    """Banded builder reproduces the dense oracle's full triple across
+    {APVD shape} x {const, CV 0.1/0.3/0.6 flow} x {regular, irregular tedges}
+    x {cout=tedges, coarse, fine} x {R = 1, 2.7}.
+
+    contributing_bins and zero_flow_cout match *exactly* (integer / bool);
+    accumulated_weights matches to atol=1e-12 -- the builder runs the dense
+    build's arithmetic on the nonzero band, so the only difference is float
+    reordering between the two paths (np.interp vs residence_time +
+    partial_isin). Sub-bin cout exactness is pinned tighter against the rational
+    oracle in test_banded_builder_exact_vs_rational."""
+    apv = _BANDED_APVD[apv_name]
+    n = 60
+    seed0 = list(_BANDED_APVD).index(apv_name) * 100
+    flows = {
+        "const": np.full(n, 100.0),
+        "cv0.1": 100.0 * (1 + 0.1 * np.sin(np.arange(n) * 2 * np.pi / 17)),
+        "cv0.3": 100.0 * (1 + 0.3 * np.sin(np.arange(n) * 2 * np.pi / 17)),
+        "cv0.6": 100.0 * (1 + 0.6 * np.sin(np.arange(n) * 2 * np.pi / 13)),
+    }
+    for tk in ("regular", "irregular"):
+        tedges = _banded_tedges(n, tk, seed0)
+        for fname, flow in flows.items():
+            for ck in ("same", "coarse", "fine"):
+                cout = _banded_cout(tedges, ck)
+                for r_factor in (1.0, 2.7):
+                    kw = {
+                        "tedges": tedges,
+                        "cout_tedges": cout,
+                        "aquifer_pore_volumes": apv,
+                        "flow": flow,
+                        "retardation_factor": r_factor,
+                    }
+                    acc, contrib, zf = _infiltration_to_extraction_weights(**kw)
+                    acc_d, contrib_d, zf_d = _dense_weights_reference(**kw)
+                    tag = f"{apv_name}/{tk}/{fname}/{ck}/R{r_factor}"
+                    np.testing.assert_array_equal(contrib, contrib_d, err_msg=f"contributing {tag}")
+                    np.testing.assert_array_equal(zf, zf_d, err_msg=f"zero_flow {tag}")
+                    # atol=1e-13: observed worst is ~3e-14 (two independent float paths);
+                    # tighter exactness is pinned by the rational oracle (atol=1e-14).
+                    np.testing.assert_allclose(acc, acc_d, atol=1e-13, rtol=0, err_msg=f"accumulated {tag}")
+
+
+def test_banded_builder_boundary_touch_contributing():
+    """A back-projected window edge landing exactly on Vi[0]/Vi[-1] counts as
+    contained (inclusive), pinning the searchsorted '<' vs '<=' sides.
+
+    Constant flow 100 m3/d, daily bins => Vi = [0, 100, 200, ...]. With apv
+    chosen so r = R*PV is an exact multiple of 100, several cout bins have a
+    source-window edge exactly on a data boundary. The banded contributing
+    count must match the dense oracle bit-for-bit at those touches."""
+    n = 30
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    # r in {100, 500, 1500} m3 -> window edges land exactly on Vi multiples.
+    apv = np.array([100.0, 500.0, 1500.0])
+    for r_factor in (1.0, 2.0):
+        kw = {
+            "tedges": tedges,
+            "cout_tedges": tedges,
+            "aquifer_pore_volumes": apv,
+            "flow": flow,
+            "retardation_factor": r_factor,
+        }
+        _, contrib, _ = _infiltration_to_extraction_weights(**kw)
+        _, contrib_d, _ = _dense_weights_reference(**kw)
+        _, contrib_r = _exact_rational_advection(**kw)
+        np.testing.assert_array_equal(contrib, contrib_d)
+        np.testing.assert_array_equal(contrib, contrib_r)
+
+
+# Small-volume cases where float64 reproduces the exact Fraction truth to a few
+# ULP. atol=1e-14 is the machine-precision floor at these volume scales
+# (ulp of a ~10 m3 cumulative volume is ~1.8e-15); it is NOT a loosened
+# tolerance -- a real overlap/drop bug produces O(0.01-1) errors.
+_RATIONAL_CASES = {
+    "bimodal_const": {"flow": np.full(8, 1.0), "apv": np.array([2.0, 3.0, 5.0]), "R": 1.0, "cout": "same"},
+    "single_noninteger_rt": {"flow": np.full(10, 1.0), "apv": np.array([2.7]), "R": 1.0, "cout": "same"},
+    # general fringe: variable flow, irregular cout, non-integer residence time
+    "variable_flow_fringe": {
+        "flow": 1.0 + 0.4 * np.sin(np.arange(10)),
+        "apv": np.array([1.3, 2.7, 4.1]),
+        "R": 1.4,
+        "cout": "fine",
+    },
+    "retardation": {"flow": np.full(9, 2.0), "apv": np.array([1.5, 4.0]), "R": 2.3, "cout": "coarse"},
+}
+
+
+@pytest.mark.parametrize("case_name", list(_RATIONAL_CASES))
+def test_banded_builder_exact_vs_rational(case_name):
+    """Banded accumulated_weights equals the exact Fraction truth to machine
+    precision (incl. a general fringe case: variable flow + irregular cout +
+    non-integer residence time). Weights are cin-independent, so exactness of
+    the operator implies exactness of every cout = W @ cin."""
+    case = _RATIONAL_CASES[case_name]
+    flow = np.asarray(case["flow"], dtype=float)
+    n = len(flow)
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    if case["cout"] == "same":
+        cout = tedges
+    elif case["cout"] == "coarse":
+        cout = tedges[::2]
+    else:
+        days = np.sort(np.unique(np.concatenate([np.linspace(0.0, n, 3 * n), [0.0, float(n)]])))
+        cout = tedges[0] + pd.to_timedelta(days, unit="D")
+    kw = {
+        "tedges": tedges,
+        "cout_tedges": cout,
+        "aquifer_pore_volumes": case["apv"],
+        "flow": flow,
+        "retardation_factor": case["R"],
+    }
+    acc, contrib, _ = _infiltration_to_extraction_weights(**kw)
+    acc_r, contrib_r = _exact_rational_advection(**kw)
+    np.testing.assert_array_equal(contrib, contrib_r)
+    np.testing.assert_allclose(acc, acc_r, atol=1e-14, rtol=0)
+
+
+def test_banded_builder_degenerate_zero_width_broken_through_bin():
+    """A near-zero-width (w ~ 0.01 m3) but fully broken-through cout bin is exact.
+
+    The weight is overlap/w with overlap ~ w, so the division is well
+    conditioned and the row still sums to the contributing count. Exercises the
+    w != 0 path with a pathological width against the exact rational oracle."""
+    n = 20
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)  # 100 m3 per daily bin
+    apv = np.array([300.0, 700.0])  # RTs 3 d and 7 d -> broken through by day 7
+    # cout: one ordinary bin then a 0.0001-day (=0.01 m3) sliver, deep in the
+    # broken-through interior (day ~12).
+    cout_days = np.array([10.0, 12.0, 12.0001, 15.0])
+    cout = tedges[0] + pd.to_timedelta(cout_days, unit="D")
+    kw = {
+        "tedges": tedges,
+        "cout_tedges": cout,
+        "aquifer_pore_volumes": apv,
+        "flow": flow,
+        "retardation_factor": 1.0,
+    }
+    acc, contrib, zf = _infiltration_to_extraction_weights(**kw)
+    acc_r, contrib_r = _exact_rational_advection(**kw)
+    assert contrib[1] == len(apv)  # sliver bin fully broken through
+    assert not zf[1]
+    np.testing.assert_array_equal(contrib, contrib_r)
+    np.testing.assert_allclose(acc, acc_r, atol=1e-14, rtol=0)
+    # The sliver row, normalized by its contributing count, sums to 1.
+    np.testing.assert_allclose(acc[1].sum() / contrib[1], 1.0, atol=1e-13)
+
+
+@pytest.mark.parametrize("spinup", [None, "constant", 0.5])
+def test_banded_builder_public_forward_parity_spinup_modes(spinup):
+    """Public forward output matches the dense-oracle-driven forward for all
+    three spin-up modes, including bit-identical NaN masks. For spinup=0.5 the
+    fringe (0 < contributing < n_pv on surviving bins) is asserted non-empty, so
+    a broken fringe path would change the float-mode output and fail here."""
+    n = 50
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = 100.0 + 20.0 * np.sin(np.arange(n) * 2 * np.pi / 11)
+    cin = 2.0 + np.cos(np.arange(n) * 2 * np.pi / 9)
+    apv = np.array([100.0, 500.0, 1500.0])  # widely separated RTs => real fringe
+
+    real_out = infiltration_to_extraction(
+        cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, spinup=spinup
+    )
+    dense_out, contrib = _forward_via(
+        _dense_weights_reference,
+        cin=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        aquifer_pore_volumes=apv,
+        retardation_factor=1.0,
+        spinup=spinup,
+    )
+    np.testing.assert_array_equal(np.isnan(real_out), np.isnan(dense_out))
+    valid = ~np.isnan(real_out)
+    np.testing.assert_allclose(real_out[valid], dense_out[valid], atol=1e-12, rtol=0)
+    if spinup == 0.5:
+        assert np.any(valid & (contrib < len(apv))), "fringe path not exercised"
+
+
+def test_banded_builder_fringe_decircularized_vs_rational():
+    """De-circularize the fringe: a surviving fringe bin's spinup=0.5 public
+    value equals the exact rational count-mean (W_rational @ cin / contributing),
+    not just the relocated dense build."""
+    n = 24
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = 1.0 + 0.3 * np.sin(np.arange(n) * 2 * np.pi / 7)  # small-volume, variable
+    cin = 3.0 + np.cos(np.arange(n) * 2 * np.pi / 5)
+    apv = np.array([1.3, 2.7, 4.1])  # non-integer residence times
+
+    out = infiltration_to_extraction(
+        cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, spinup=0.5
+    )
+    acc_r, contrib_r = _exact_rational_advection(
+        tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, flow=flow, retardation_factor=1.0
+    )
+    # Exact count-mean reference for the threshold mode (contributing >= 0.5*n_pv).
+    n_pv = len(apv)
+    fringe = (contrib_r > 0) & (contrib_r < n_pv) & (contrib_r >= 0.5 * n_pv)
+    assert np.any(fringe), "no surviving fringe bin in this setup"
+    expected = (acc_r[fringe] @ cin) / contrib_r[fringe]
+    np.testing.assert_allclose(out[fringe], expected, atol=1e-13, rtol=0)
+
+
+def test_banded_builder_sharp_step_and_pulse_exact_vs_rational():
+    """Sharp step and pulse cin produce the exact W @ cin in the broken-through
+    region (W is cin-independent; this checks the cin-contraction too)."""
+    n = 40
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    apv = np.array([200.0, 400.0])  # RTs 2 d, 4 d
+    acc_r, contrib_r = _exact_rational_advection(
+        tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, flow=flow, retardation_factor=1.0
+    )
+    n_pv = len(apv)
+    broken = contrib_r == n_pv
+    step = np.where(np.arange(n) >= 15, 7.0, 1.0)
+    pulse = np.zeros(n)
+    pulse[20:22] = 5.0
+    for cin in (step, pulse):
+        out = infiltration_to_extraction(
+            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, spinup=None
+        )
+        expected = acc_r[broken] @ cin / n_pv
+        np.testing.assert_allclose(out[broken], expected, atol=1e-13, rtol=0)
+
+
+def test_banded_builder_cout_outside_range_masked_like_dense():
+    """cout bins straddling or outside the cin time range are dropped exactly as
+    the dense build drops them (NaN residence-time edge), not clipped."""
+    n = 20
+    tedges = pd.date_range("2020-01-10", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    apv = np.array([150.0, 350.0])
+    # cout extends 5 days before and after the cin range -> straddling + outside.
+    cout = pd.date_range("2020-01-05", periods=n + 11, freq="D")
+    kw = {
+        "tedges": tedges,
+        "cout_tedges": cout,
+        "aquifer_pore_volumes": apv,
+        "flow": flow,
+        "retardation_factor": 1.0,
+    }
+    acc, contrib, zf = _infiltration_to_extraction_weights(**kw)
+    acc_d, contrib_d, zf_d = _dense_weights_reference(**kw)
+    np.testing.assert_array_equal(contrib, contrib_d)
+    np.testing.assert_array_equal(zf, zf_d)
+    np.testing.assert_allclose(acc, acc_d, atol=1e-12, rtol=0)
+
+
+def test_banded_builder_zero_and_tiny_flow_match_dense():
+    """Zero-flow series gives an all-zero operator; tiny flow (band spanning the
+    whole series) still matches the dense oracle."""
+    n = 25
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    apv = np.array([100.0, 300.0])
+
+    zero_kw = {
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "aquifer_pore_volumes": apv,
+        "flow": np.zeros(n),
+        "retardation_factor": 1.0,
+    }
+    acc0, contrib0, zf0 = _infiltration_to_extraction_weights(**zero_kw)
+    assert np.count_nonzero(acc0) == 0
+    assert np.all(contrib0 == 0)
+    assert np.all(zf0)
+
+    # Tiny flow: residence volumes dwarf the per-bin volume, so the band spans
+    # (nearly) the whole series -- the builder degrades gracefully to dense.
+    tiny_kw = {**zero_kw, "flow": np.full(n, 0.5)}
+    acc_t, contrib_t, zf_t = _infiltration_to_extraction_weights(**tiny_kw)
+    acc_d, contrib_d, zf_d = _dense_weights_reference(**tiny_kw)
+    np.testing.assert_array_equal(contrib_t, contrib_d)
+    np.testing.assert_array_equal(zf_t, zf_d)
+    np.testing.assert_allclose(acc_t, acc_d, atol=1e-12, rtol=0)
+
+
+def test_banded_builder_structurally_banded_large_n():
+    """The weight operator is structurally banded at large N: nonzeros per cout
+    row are bounded by the APVD volume span / per-bin volume, independent of N.
+    This is an invariant of the advection operator -- each cout bin draws from
+    one narrow source window -- so it guards against a band/gather bug that
+    smears weights across too many cin bins, not against the build cost itself."""
+    n = 1500
+    tedges = pd.date_range("2018-01-01", periods=n + 1, freq="D")
+    flow = 100.0 + 30.0 * np.sin(np.arange(n) * 2 * np.pi / 365)
+    apv = gamma.bins(mean=250.0, std=90.0, n_bins=60)["expected_values"]
+    acc, _, _ = _infiltration_to_extraction_weights(
+        tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, flow=flow, retardation_factor=1.0
+    )
+    # Per-row band bound: source-volume span / smallest per-bin volume + margin
+    # for the cout bin width and searchsorted rounding.
+    band_bound = int(np.ceil((apv.max() - apv.min()) / flow.min())) + 5
+    nnz = np.count_nonzero(acc)
+    assert nnz <= n * band_bound, f"nnz={nnz} exceeds banded bound {n * band_bound}"
+    assert nnz < 0.05 * n * n, "operator is not sub-dense -- banding failed"
+
+
+def test_banded_builder_reverse_and_gamma_match_dense_driven():
+    """Reverse (extraction_to_infiltration) and gamma wrappers inherit the banded
+    builder: their outputs match the same pipeline driven by the dense oracle."""
+    n = 60
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = 100.0 + 15.0 * np.sin(np.arange(n) * 2 * np.pi / 13)
+    apv = np.array([150.0, 400.0, 700.0])
+    cin_true = 5.0 + 2.0 * np.sin(2 * np.pi * np.arange(n) / 21.0)
+
+    # Forward with the package builder, then invert with both pipelines.
+    cout = infiltration_to_extraction(
+        cin=cin_true, flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv
+    )
+    cin_real = extraction_to_infiltration(
+        cout=cout, flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv
+    )
+
+    # Dense-driven reverse: rebuild W_forward with the dense oracle and solve the
+    # same Tikhonov system the package uses.
+    weight_tedges, weight_flow, _, threshold, n_pad = _resolve_spinup_inputs(
+        "constant", tedges=tedges, flow=flow, aquifer_pore_volumes=apv, retardation_factor=1.0
+    )
+    acc_d, contrib_d, zf_d = _dense_weights_reference(
+        tedges=weight_tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, flow=weight_flow, retardation_factor=1.0
+    )
+    w_d, _ = _resolve_spinup_mask(
+        accumulated_weights=acc_d, contributing_bins=contrib_d, zero_flow_cout=zf_d, n_pv=len(apv), spinup=threshold
+    )
+    cin_dense = solve_inverse_transport(
+        w_forward=w_d, observed=cout, n_output=len(weight_tedges) - 1, regularization_strength=1e-10
+    )[n_pad:]
+    np.testing.assert_allclose(cin_real, cin_dense, atol=1e-9, rtol=0)
+
+    # Gamma wrapper parity: gamma_* delegates to the same forward builder.
+    cout_gamma_real = gamma_infiltration_to_extraction(
+        cin=cin_true, flow=flow, tedges=tedges, cout_tedges=tedges, mean=300.0, std=120.0, n_bins=12
+    )
+    apv_gamma = gamma.bins(mean=300.0, std=120.0, n_bins=12)["expected_values"]
+    cout_gamma_dense, _ = _forward_via(
+        _dense_weights_reference,
+        cin=cin_true,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        aquifer_pore_volumes=apv_gamma,
+        retardation_factor=1.0,
+        spinup="constant",
+    )
+    np.testing.assert_array_equal(np.isnan(cout_gamma_real), np.isnan(cout_gamma_dense))
+    g_valid = ~np.isnan(cout_gamma_real)
+    np.testing.assert_allclose(cout_gamma_real[g_valid], cout_gamma_dense[g_valid], atol=1e-12, rtol=0)


### PR DESCRIPTION
## Summary

The infiltration-to-extraction weight builder (`advection_utils._infiltration_to_extraction_weights`) previously built a dense `O(n_pv · n_cout · n_cin)` overlap matrix (`residence_time` + `partial_isin`, looped over pore volumes). This replaces it with a **banded per-streamtube** build that runs the same time-domain overlap arithmetic only on the nonzero band — each back-projected source window spans one cout bin's worth of cumulative volume, so it overlaps only a few cin bins — giving `O(n_pv · n_cout · band)`.

- **Exact, not approximate:** machine-precision identical to the dense build (2.6e-15 vs an exact `fractions.Fraction` oracle on every grid, including sub-bin cout); ~150× faster (33 ms vs 5.2 s at N=2920, n_pv=100).
- **Drop-in:** returns the same `(accumulated_weights, contributing_bins, zero_flow_cout)` triple, so the forward/reverse/gamma wrappers and every spin-up mode are byte-identical and unchanged.
- `zero_flow_cout` is now `np.diff(vc) == 0` (`O(n_cout)`), bit-identical to the old `partial_isin(cout, cin) @ flow == 0` but without the `O(N²)` dense matrix.
- Removes the now-unused `residence_time`/`partial_isin` imports from `advection_utils` (the `*_series` functions keep their own `residence_time`).
- Docstring cleanups: rewrote the stale dense/closed-form algorithm prose in `infiltration_to_extraction`; changed algorithmic "convolution" → "flow-weighted averaging".

## Test plan

- `pytest tests/src -n auto` → **1456 passed, 2 skipped**.
- New `test_banded_builder_*` suite adds two independent oracles (a relocated dense build and an exact `fractions.Fraction` build) and validates: triple parity vs dense across {APVD shape × flow CV × regular/irregular tedges × cout same/coarse/fine × R}, exactness vs the rational oracle (`atol=1e-14`), drop-not-clip fringe, boundary-touch containment, sharp step/pulse, reverse + gamma inheritance, banded structure at large N, and all three spin-up modes (incl. the issue-161 over-attribution literals).
- The existing regression net (`test_advection.py` / `test_advection_roundtrip.py`) passes unchanged.
- `ruff format` / `ruff check` clean; `ty check` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
