### PR TITLE
perf: bound advection forward/inverse memory with a banded operator (#239)

### DIFF
--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -90,7 +90,7 @@ from gwtransport.fronttracking.output import compute_bin_averaged_concentration_
 from gwtransport.fronttracking.solver import FrontTracker
 from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
 from gwtransport.residence_time import residence_time
-from gwtransport.utils import solve_inverse_transport
+from gwtransport.utils import solve_inverse_transport_banded
 
 
 def _validate_advection_inputs(
@@ -927,24 +927,30 @@ def infiltration_to_extraction(
         cin=cin,
     )
     assert weight_cin is not None  # noqa: S101 -- narrowed: cin was passed in
-    accumulated_weights, contributing_bins, zero_flow_cout = _infiltration_to_extraction_weights(
+    band_vals, col_start, contributing_bins, zero_flow_cout = _infiltration_to_extraction_weights(
         tedges=weight_tedges,
         cout_tedges=cout_tedges,
         aquifer_pore_volumes=aquifer_pore_volumes,
         flow=weight_flow,
         retardation_factor=retardation_factor,
     )
-    normalized_weights, invalid_mask = _resolve_spinup_mask(
-        accumulated_weights=accumulated_weights,
+    weights, col_start, invalid_mask = _resolve_spinup_mask(
+        band_vals=band_vals,
+        col_start=col_start,
         contributing_bins=contributing_bins,
         zero_flow_cout=zero_flow_cout,
         n_pv=len(aquifer_pore_volumes),
         spinup=threshold,
     )
 
+    # Banded flow-weighted average: row k contributes cin over its narrow band only.
+    # Out-of-range band slots carry zero weight, so the clipped gather is harmless.
+    n_cin = len(weight_cin)
+    cols = np.clip(col_start[:, None] + np.arange(weights.shape[1]), 0, n_cin - 1)
+    out = np.einsum("kb,kb->k", weights, weight_cin[cols])
+
     # Invalid rows (cout bins where the spin-up policy is not satisfied or
     # where extraction flow was zero) become NaN.
-    out = normalized_weights.dot(weight_cin)
     out[invalid_mask] = np.nan
 
     return out
@@ -1157,23 +1163,25 @@ def extraction_to_infiltration(
     )
     n_cin_padded = len(weight_tedges) - 1
 
-    accumulated_weights, contributing_bins, zero_flow_cout = _infiltration_to_extraction_weights(
+    band_vals, col_start, contributing_bins, zero_flow_cout = _infiltration_to_extraction_weights(
         tedges=weight_tedges,
         cout_tedges=cout_tedges,
         aquifer_pore_volumes=aquifer_pore_volumes,
         flow=weight_flow,
         retardation_factor=retardation_factor,
     )
-    w_forward, _ = _resolve_spinup_mask(
-        accumulated_weights=accumulated_weights,
+    band_vals, col_start, _ = _resolve_spinup_mask(
+        band_vals=band_vals,
+        col_start=col_start,
         contributing_bins=contributing_bins,
         zero_flow_cout=zero_flow_cout,
         n_pv=len(aquifer_pore_volumes),
         spinup=threshold,
     )
 
-    cin_padded = solve_inverse_transport(
-        w_forward=w_forward,
+    cin_padded = solve_inverse_transport_banded(
+        band_vals=band_vals,
+        col_start=col_start,
         observed=cout,
         n_output=n_cin_padded,
         regularization_strength=regularization_strength,

--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -16,6 +16,12 @@ import pandas as pd
 from gwtransport._time import tedges_to_days
 from gwtransport.utils import cumulative_flow_volume
 
+# Target number of (streamtube x cout-bin) pairs per tile in the banded weight build. The
+# per-tile working set is O(_WEIGHT_BUILD_BLOCK x band), so peak memory is bounded
+# independent of record length; chosen to keep the build under ~30 MB while spanning most
+# records in one or a few tiles. See _infiltration_to_extraction_weights.
+_WEIGHT_BUILD_BLOCK = 100_000
+
 
 def _infiltration_to_extraction_weights(
     *,
@@ -24,15 +30,16 @@ def _infiltration_to_extraction_weights(
     aquifer_pore_volumes: npt.NDArray[np.floating],
     flow: npt.NDArray[np.floating],
     retardation_factor: float,
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.intp], npt.NDArray[np.bool_]]:
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.intp], npt.NDArray[np.intp], npt.NDArray[np.bool_]]:
     """
     Compute raw streamtube-bundle weights for infiltration to extraction transformation.
 
-    Builds the per-cout-bin sum of streamtube-normalized overlap rows, plus the
-    count of contributing streamtubes per cout bin and the zero-flow cout-bin
-    mask. The caller decides how to convert these into final weights
-    (strict-validity, count-mean, or padded "constant" spin-up); see
-    :func:`_resolve_spinup_mask` and :func:`_resolve_spinup_inputs`.
+    Builds the per-cout-bin sum of streamtube-normalized overlap rows in a
+    **compact banded layout**, plus the count of contributing streamtubes per
+    cout bin and the zero-flow cout-bin mask. The caller decides how to convert
+    these into final weights (strict-validity, count-mean, or padded "constant"
+    spin-up); see :func:`_resolve_spinup_mask` and :func:`_resolve_spinup_inputs`.
+    Reconstruct the dense ``(n_cout, n_cin)`` matrix with :func:`_densify_weights`.
 
     The per-streamtube weight is the literal mass-flux / water-flux ratio for
     that streamtube and cout bin: each contributing row sums to 1 to ULP.
@@ -46,14 +53,15 @@ def _infiltration_to_extraction_weights(
     pore volume ``r = R * V_pore`` carries each cout edge back to the
     infiltration time at cumulative volume ``Vc_edge - r``. The cout bin's
     source window in infiltration time spans one cout bin's worth of volume, so
-    it overlaps only a few cin bins -- the weights are gathered on that narrow
-    band rather than the full ``O(n_cin)`` row, giving ``O(n_pv * n_cout *
-    band)`` work instead of the dense ``O(n_pv * n_cout * n_cin)``. The overlap
-    is the flow-weighted time overlap normalized by the window's total in-range
-    flow, so each contributing row sums to 1 exactly. It is the exact
-    flow-weighted overlap on the nonzero band -- matching the dense
-    ``residence_time`` + ``partial_isin`` reference to machine precision (and the
-    exact-arithmetic result to ~1e-15), not an approximation.
+    it overlaps only a few cin bins. The nonzeros of cout row ``k`` therefore
+    span only the residence-time spread of the APVD, ``[col_start[k],
+    col_start[k] + full_band)``, and are accumulated into one banded buffer over
+    a **pore-volume loop** -- ``O(n_cout * full_band)`` memory regardless of
+    record length or ``n_pv``. The overlap is the flow-weighted time overlap
+    normalized by the window's total in-range flow, so each contributing row
+    sums to 1 exactly: the exact flow-weighted overlap, matching the dense
+    ``residence_time`` + ``partial_isin`` reference to machine precision, not an
+    approximation.
 
     A streamtube whose source volume leaves ``[Vi[0], Vi[-1]]`` -- or a cout
     edge outside the cin time range -- maps to NaN and is **dropped, not
@@ -75,11 +83,15 @@ def _infiltration_to_extraction_weights(
 
     Returns
     -------
-    accumulated_weights : numpy.ndarray
-        Sum over streamtubes of per-streamtube normalized overlap rows.
-        Shape: (len(cout_tedges) - 1, len(tedges) - 1). For a cout bin
-        ``k`` with ``c`` contributing streamtubes, the row already sums
-        to ``c`` (not ``n_pv`` and not 1).
+    band_vals : numpy.ndarray
+        Sum over streamtubes of per-streamtube normalized overlap rows in
+        banded layout. Shape: (len(cout_tedges) - 1, full_band). Slot
+        ``band_vals[k, b]`` is the weight on cin bin ``col_start[k] + b``;
+        for a cout bin ``k`` with ``c`` contributing streamtubes the row
+        sums to ``c`` (not ``n_pv`` and not 1).
+    col_start : numpy.ndarray of int
+        Shape: (len(cout_tedges) - 1,). First cin bin index of each cout
+        row's band. Defaults to 0 for rows with no contributing streamtube.
     contributing_bins : numpy.ndarray of int
         Shape: (len(cout_tedges) - 1,). Number of streamtubes that
         actually contributed to each cout bin (had a source window fully
@@ -87,6 +99,10 @@ def _infiltration_to_extraction_weights(
     zero_flow_cout : numpy.ndarray of bool
         Shape: (len(cout_tedges) - 1,). True for cout bins with zero
         time-averaged extraction flow over their interval.
+
+    See Also
+    --------
+    _densify_weights : Reconstruct the dense (n_cout, n_cin) matrix.
     """
     cin_tedges_days = tedges_to_days(tedges)
     cout_tedges_days = tedges_to_days(cout_tedges, ref=tedges[0])
@@ -106,66 +122,103 @@ def _infiltration_to_extraction_weights(
     zero_flow_cout = np.diff(vc) == 0
 
     if n_pv == 0:
-        return np.zeros((n_cout, n_cin)), np.zeros(n_cout, dtype=np.intp), zero_flow_cout
+        return np.zeros((n_cout, 1)), np.zeros(n_cout, dtype=np.intp), np.zeros(n_cout, dtype=np.intp), zero_flow_cout
 
     r = np.sort(np.asarray(aquifer_pore_volumes, dtype=float) * retardation_factor)
 
-    # Back-project every cout edge by every streamtube to its infiltration TIME.
-    # Out-of-range cout edges have no source volume; NaN there propagates so the
-    # adjacent windows are dropped (not clipped), matching the dense build.
+    # Cumulative source volume at each cout edge. Out-of-range cout edges have no source
+    # volume; NaN there propagates so the adjacent windows are dropped (not clipped),
+    # matching the dense build.
     edge_in_range = (cout_tedges_days >= cin_tedges_days[0]) & (cout_tedges_days <= cin_tedges_days[-1])
-    src_volume = np.where(edge_in_range, vc, np.nan)[None, :] - r[:, None]  # (n_pv, n_cout + 1)
-    infil_days = np.interp(src_volume.ravel(), vi, cin_tedges_days, left=np.nan, right=np.nan).reshape(src_volume.shape)
-    win_lo, win_hi = infil_days[:, :-1], infil_days[:, 1:]  # (n_pv, n_cout) infiltration-time window per cout bin
-    contained = np.isfinite(win_lo) & np.isfinite(win_hi)
+    src_edge = np.where(edge_in_range, vc, np.nan)
 
-    # Each source window spans one cout bin's worth of volume, so it overlaps a
-    # narrow band of cin bins; size the band off the widest contained window.
-    # NaN windows (dropped streamtubes) sort to the array end in searchsorted and
-    # are masked out below (band ignores them, in_cin zeros their flux).
-    j_lo = np.clip(np.searchsorted(cin_tedges_days, win_lo, side="right") - 1, 0, n_cin - 1)
-    j_hi = np.clip(np.searchsorted(cin_tedges_days, win_hi, side="left"), 0, n_cin)
-    band = min(int(np.max(np.where(contained, j_hi - j_lo, 0))) + 1, n_cin)
+    # Tile the cout axis so the (n_pv, tile, band) overlap tensor never materialises for the
+    # whole record: peak memory stays O(block) regardless of record length, while each tile
+    # stays fully vectorised over its streamtubes. Most records span one or a few tiles. Each
+    # tile sizes its own band independently and is right-padded to the global width at the end.
+    block = max(1, _WEIGHT_BUILD_BLOCK // n_pv)
+    col_start = np.zeros(n_cout, dtype=np.intp)
+    contributing_bins = np.zeros(n_cout, dtype=np.intp)
+    tiles: list[tuple[int, npt.NDArray[np.floating]]] = []
+    full_band = 1
+    for start in range(0, n_cout, block):
+        stop = min(start + block, n_cout)
+        m = stop - start
 
-    cols = j_lo[:, :, None] + np.arange(band)[None, None, :]  # (n_pv, n_cout, band) cin bin index
-    in_cin = contained[:, :, None] & (cols < n_cin)
-    cols = np.clip(cols, 0, n_cin - 1)
-    # Flow-weighted time overlap of each window with each banded cin bin.
-    overlap = np.maximum(
-        0.0,
-        np.minimum(win_hi[:, :, None], cin_tedges_days[cols + 1])
-        - np.maximum(win_lo[:, :, None], cin_tedges_days[cols]),
-    )
-    flux = np.where(in_cin, flow[cols] * overlap, 0.0)
-    window_flux = flux.sum(axis=2)  # (n_pv, n_cout) total in-range flow per window
-    contributes = contained & (window_flux > 0)
-    contributing_bins = contributes.sum(axis=0).astype(np.intp)
+        # Back-project this tile's cout edges by every streamtube to infiltration time.
+        infil = np.interp(
+            (src_edge[start : stop + 1] - r[:, None]).ravel(), vi, cin_tedges_days, left=np.nan, right=np.nan
+        ).reshape(n_pv, m + 1)
+        win_lo, win_hi = infil[:, :-1], infil[:, 1:]  # (n_pv, m) infiltration-time window per cout bin
+        contained = np.isfinite(win_lo) & np.isfinite(win_hi)
+        j_lo = np.clip(np.searchsorted(cin_tedges_days, win_lo, side="right") - 1, 0, n_cin - 1)
+        j_hi = np.clip(np.searchsorted(cin_tedges_days, win_hi, side="left"), 0, n_cin)
 
-    # Per-streamtube normalized row (sums to 1); scatter-add into the dense matrix.
-    weights = np.zeros(flux.shape)
-    np.divide(flux, window_flux[:, :, None], out=weights, where=contributes[:, :, None])
-    cout_idx = np.broadcast_to(np.arange(n_cout)[None, :, None], cols.shape)
-    flat = (cout_idx * n_cin + cols).ravel()
-    summed = np.bincount(flat, weights=weights.ravel(), minlength=n_cout * n_cin).astype(float, copy=False)
+        # Tile band = union of contained streamtube windows; per_band = widest single window.
+        any_contained = contained.any(axis=0)
+        tile_start = np.where(any_contained, np.where(contained, j_lo, n_cin).min(axis=0), 0)
+        row_hi = np.where(contained, j_hi, 0).max(axis=0)
+        tile_band = min(int(np.max(np.where(any_contained, row_hi - tile_start, 0))) + 1, n_cin)
+        per_band = min(int(np.max(np.where(contained, j_hi - j_lo, 0))) + 1, n_cin)
 
-    return summed.reshape(n_cout, n_cin), contributing_bins, zero_flow_cout
+        # Per-streamtube flow-weighted overlap on its own narrow window, normalised so each
+        # contributing row sums to 1, then scatter-summed over streamtubes into the tile's
+        # banded buffer (offset by each row's tile_start).
+        cols = j_lo[:, :, None] + np.arange(per_band)[None, None, :]  # (n_pv, m, per_band)
+        in_cin = contained[:, :, None] & (cols < n_cin)
+        cols_clipped = np.clip(cols, 0, n_cin - 1)
+        overlap = np.maximum(
+            0.0,
+            np.minimum(win_hi[:, :, None], cin_tedges_days[cols_clipped + 1])
+            - np.maximum(win_lo[:, :, None], cin_tedges_days[cols_clipped]),
+        )
+        flux = np.where(in_cin, flow[cols_clipped] * overlap, 0.0)
+        window_flux = flux.sum(axis=2)  # (n_pv, m) total in-range flow per window
+        contributes = contained & (window_flux > 0)
+        np.divide(flux, window_flux[:, :, None], out=flux, where=contributes[:, :, None])
+
+        # Only nonzero in-window slots scatter; their banded offset is < tile_band by
+        # construction (a contributing slot lies in [tile_start, row_hi)).
+        keep = flux > 0
+        offset = cols_clipped - tile_start[None, :, None]
+        row_idx = np.broadcast_to(np.arange(m)[None, :, None], cols.shape)
+        tile_vals = (
+            np
+            .bincount((row_idx * tile_band + offset)[keep], weights=flux[keep], minlength=m * tile_band)
+            .astype(float, copy=False)
+            .reshape(m, tile_band)
+        )
+
+        col_start[start:stop] = tile_start
+        contributing_bins[start:stop] = contributes.sum(axis=0)
+        tiles.append((start, tile_vals))
+        full_band = max(full_band, tile_band)
+
+    band_vals = np.zeros((n_cout, full_band))
+    for start, tile_vals in tiles:
+        band_vals[start : start + tile_vals.shape[0], : tile_vals.shape[1]] = tile_vals
+
+    return band_vals, col_start, contributing_bins, zero_flow_cout
 
 
 def _resolve_spinup_mask(
     *,
-    accumulated_weights: npt.NDArray[np.floating],
+    band_vals: npt.NDArray[np.floating],
+    col_start: npt.NDArray[np.intp],
     contributing_bins: npt.NDArray[np.intp],
     zero_flow_cout: npt.NDArray[np.bool_],
     n_pv: int,
     spinup: float | None,
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.bool_]]:
-    """Convert raw bundle outputs into final weights + invalid mask.
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.intp], npt.NDArray[np.bool_]]:
+    """Convert raw banded bundle outputs into final banded weights + invalid mask.
 
     Parameters
     ----------
-    accumulated_weights : numpy.ndarray
-        Per-cout-bin sum of streamtube-normalized rows from
-        :func:`_infiltration_to_extraction_weights`.
+    band_vals : numpy.ndarray
+        Per-cout-bin sum of streamtube-normalized rows in banded layout from
+        :func:`_infiltration_to_extraction_weights`. Shape (n_cout, full_band).
+    col_start : numpy.ndarray of int
+        First cin bin index of each cout row's band. Passed through unchanged.
     contributing_bins : numpy.ndarray of int
         Number of streamtubes that contributed to each cout bin.
     zero_flow_cout : numpy.ndarray of bool
@@ -184,8 +237,10 @@ def _resolve_spinup_mask(
     Returns
     -------
     weights : numpy.ndarray
-        Final weight matrix of the same shape as ``accumulated_weights``.
+        Final banded weight matrix of the same shape as ``band_vals``.
         Rows where the policy is not satisfied are zero.
+    col_start : numpy.ndarray of int
+        The input ``col_start``, returned unchanged for caller convenience.
     invalid_mask : numpy.ndarray of bool
         True for cout bins where the policy is not satisfied.
 
@@ -198,23 +253,57 @@ def _resolve_spinup_mask(
     """
     if n_pv == 0:
         # No streamtubes means no transport: every cout bin is invalid.
-        return np.zeros_like(accumulated_weights), np.ones(accumulated_weights.shape[0], dtype=bool)
+        return np.zeros_like(band_vals), col_start, np.ones(band_vals.shape[0], dtype=bool)
 
     if spinup is None:
         valid = (contributing_bins == n_pv) & ~zero_flow_cout
-        weights = np.zeros_like(accumulated_weights)
-        weights[valid, :] = accumulated_weights[valid, :] / n_pv
-        return weights, ~valid
+        weights = np.zeros_like(band_vals)
+        weights[valid, :] = band_vals[valid, :] / n_pv
+        return weights, col_start, ~valid
 
     if not (isinstance(spinup, (int, float)) and not isinstance(spinup, bool) and 0.0 <= spinup <= 1.0):
         msg = f"spinup must be None, 'constant', or float in [0, 1]; got {spinup!r}"
         raise ValueError(msg)
 
     valid = (contributing_bins >= spinup * n_pv) & ~zero_flow_cout & (contributing_bins > 0)
-    weights = np.zeros_like(accumulated_weights)
+    weights = np.zeros_like(band_vals)
     safe_div = np.where(valid, contributing_bins, 1)
-    weights[valid, :] = accumulated_weights[valid, :] / safe_div[valid, None]
-    return weights, ~valid
+    weights[valid, :] = band_vals[valid, :] / safe_div[valid, None]
+    return weights, col_start, ~valid
+
+
+def _densify_weights(
+    band_vals: npt.NDArray[np.floating], col_start: npt.NDArray[np.intp], n_cin: int
+) -> npt.NDArray[np.floating]:
+    """Reconstruct the dense (n_cout, n_cin) weight matrix from the banded layout.
+
+    Inverse of the banded packing produced by
+    :func:`_infiltration_to_extraction_weights` and
+    :func:`_resolve_spinup_mask`: row ``k`` places ``band_vals[k]`` at cin
+    columns ``[col_start[k], col_start[k] + full_band)``, dropping band slots
+    that fall past ``n_cin`` (the right-edge padding).
+
+    Parameters
+    ----------
+    band_vals : numpy.ndarray
+        Banded weights of shape (n_cout, full_band).
+    col_start : numpy.ndarray of int
+        First cin bin index of each row's band, shape (n_cout,).
+    n_cin : int
+        Number of cin bins (dense column count).
+
+    Returns
+    -------
+    numpy.ndarray
+        Dense weight matrix of shape (n_cout, n_cin).
+    """
+    n_cout, full_band = band_vals.shape
+    dense = np.zeros((n_cout, n_cin))
+    cols = col_start[:, None] + np.arange(full_band)[None, :]
+    in_range = cols < n_cin
+    rows = np.broadcast_to(np.arange(n_cout)[:, None], cols.shape)
+    dense[rows[in_range], cols[in_range]] = band_vals[in_range]
+    return dense
 
 
 # Pad duration used by the wide-edges spinup mode. 100 years is overkill for

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -84,7 +84,7 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 import requests
-from scipy.linalg import null_space
+from scipy.linalg import cho_solve_banded, cholesky_banded, null_space
 from scipy.optimize import minimize
 
 cache_dir = Path(__file__).parent.parent.parent / "cache"
@@ -1607,6 +1607,10 @@ def solve_tikhonov(
 # Numerical tolerance for coefficient sum to determine valid output bins
 _EPSILON_COEFF_SUM = 1e-10
 
+# Corrected semi-normal-equation refinement steps in solve_inverse_transport_banded. One
+# step reaches the QR-accurate solution; a second is a cheap, stable safety margin.
+_BANDED_REFINEMENT_STEPS = 2
+
 
 def solve_inverse_transport(
     *,
@@ -1690,6 +1694,148 @@ def solve_inverse_transport(
     out = np.full(n_output, np.nan)
     idx = np.flatnonzero(col_active)
     out[idx] = x_solved[idx]
+    return out
+
+
+def solve_inverse_transport_banded(
+    *,
+    band_vals: npt.NDArray[np.floating],
+    col_start: npt.NDArray[np.intp],
+    observed: npt.NDArray[np.floating],
+    n_output: int,
+    regularization_strength: float,
+) -> npt.NDArray[np.floating]:
+    """Solve the inverse transport problem from a banded forward operator.
+
+    Memory-light equivalent of :func:`solve_inverse_transport` for a forward
+    weight matrix stored in banded layout: row ``k`` of the dense operator
+    ``W`` is ``band_vals[k]`` placed at columns
+    ``[col_start[k], col_start[k] + full_band)``. The Tikhonov normal
+    equations ``(WᵀW + λ D) x = Wᵀ observed + λ D x_target`` are assembled
+    **directly in banded form** -- ``WᵀW`` is symmetric with half-bandwidth
+    ``full_band - 1`` -- and Cholesky-factored with
+    :func:`scipy.linalg.cholesky_banded`. Forming ``WᵀW`` squares the condition
+    number, so the bare Cholesky solve loses accuracy in the under-determined
+    (spin-up nullspace) directions; **corrected semi-normal equations** restore
+    it by refining with the residual evaluated through ``W`` itself rather than
+    ``WᵀW`` (matching the dense least-squares solution to ~1e-10). Peak memory is
+    ``O(n_output * full_band)``, never the dense ``O(n_obs * n_output)``.
+
+    The regularization target ``x_target`` is the transpose-and-normalize of
+    ``W`` applied to ``observed`` (the banded form of
+    :func:`compute_reverse_target`), matching the dense solver. Columns with no
+    forward contribution are decoupled (unit diagonal) so the system stays
+    symmetric positive definite, and are returned as NaN.
+
+    Parameters
+    ----------
+    band_vals : numpy.ndarray
+        Banded forward weights of shape ``(n_obs, full_band)``. Rows the caller
+        considers invalid must already be zeroed (as :func:`_resolve_spinup_mask`
+        does); zero rows contribute nothing to the normal equations.
+    col_start : numpy.ndarray of int
+        First output-column index of each row's band, shape ``(n_obs,)``.
+    observed : numpy.ndarray
+        Observed values of shape ``(n_obs,)`` (e.g. extraction concentrations).
+        Must not contain NaN.
+    n_output : int
+        Length of the output vector (number of cin bins).
+    regularization_strength : float
+        Tikhonov parameter λ. See :func:`solve_inverse_transport`. Must be
+        strictly positive: deconvolution is generically rank-deficient, and λ
+        is what makes the banded Cholesky factor positive definite (unlike the
+        dense least-squares path, this solver cannot return a λ=0 min-norm
+        solution).
+
+    Returns
+    -------
+    numpy.ndarray
+        Recovered signal of shape ``(n_output,)``. NaN for output bins with no
+        forward contribution (zero column).
+
+    Raises
+    ------
+    ValueError
+        If ``regularization_strength`` is not strictly positive.
+
+    See Also
+    --------
+    solve_inverse_transport : Dense-matrix equivalent.
+    gwtransport.advection_utils._infiltration_to_extraction_weights : Banded builder.
+    """
+    if regularization_strength <= 0:
+        msg = "regularization_strength must be > 0 for the banded inverse (Tikhonov positive-definiteness)"
+        raise ValueError(msg)
+    # Precondition: the caller's valid rows sum to 1 (guaranteed by
+    # _resolve_spinup_mask), so the data equation is W x ≈ observed and the RHS
+    # needs no row_sums scaling -- matching the dense solve_inverse_transport.
+    band_vals = np.asarray(band_vals, dtype=float)
+    observed = np.asarray(observed, dtype=float)
+    full_band = band_vals.shape[1]
+    n_cin = n_output
+    cols = col_start[:, None] + np.arange(full_band)[None, :]  # (n_obs, full_band) output-column index
+    in_range = cols < n_cin
+    cols_clipped = np.clip(cols, 0, n_cin - 1)
+
+    # Column sums and Wᵀ observed (the reverse-target numerator) by scattering the band.
+    col_sum = np.zeros(n_cin)
+    wt_observed = np.zeros(n_cin)
+    np.add.at(col_sum, cols_clipped[in_range], band_vals[in_range])
+    np.add.at(wt_observed, cols_clipped[in_range], (band_vals * observed[:, None])[in_range])
+
+    col_active = col_sum > 0
+    if not np.any(col_active):
+        return np.full(n_output, np.nan)
+
+    # Reverse-target: transpose-and-normalize W applied to observed (banded form of
+    # compute_reverse_target). The sliver 0 < col_sum <= _EPSILON_COEFF_SUM is left
+    # untargeted (filled with 0) as in the dense path.
+    with np.errstate(invalid="ignore", divide="ignore"):
+        x_target = np.where(col_sum > _EPSILON_COEFF_SUM, wt_observed / col_sum, 0.0)
+
+    # Lower-banded WᵀW: band row d is the d-th sub-diagonal. A row's contribution to
+    # (i, j) with i = col_start + b1, j = col_start + b2 lands at offset d = b1 - b2 >= 0
+    # and column j. band_vals is zero outside each window, so off-window pairs add 0.
+    ab = np.zeros((full_band, n_cin))
+    for d in range(full_band):
+        prod = band_vals[:, d:] * band_vals[:, : full_band - d]
+        c = cols_clipped[:, : full_band - d]
+        m = in_range[:, : full_band - d] & in_range[:, d:]
+        np.add.at(ab[d], c[m], prod[m])
+
+    lam = regularization_strength
+    d_reg = lam * col_active
+    ab[0] += d_reg
+    # d_reg is zero off the active columns, so x_target needs no masking here or in
+    # the refinement loop: the product d_reg * x_target vanishes wherever col_active is False.
+    rhs = wt_observed + d_reg * x_target
+
+    # Decouple zero (inactive, unregularized) diagonals so the matrix is SPD.
+    dead = ab[0] <= 0.0
+    ab[0, dead] = 1.0
+    rhs[dead] = 0.0
+
+    factor = cholesky_banded(ab, lower=True)
+    x = cho_solve_banded((factor, True), rhs)
+
+    # Forming WᵀW squares the condition number, so the bare Cholesky solution loses
+    # accuracy in the under-determined (spin-up nullspace) directions. Corrected
+    # semi-normal equations recover it: the residual is evaluated through W itself
+    # (in observation space) rather than through WᵀW, avoiding the cancellation that
+    # makes plain normal-equation refinement stall. One step reaches the QR-accurate
+    # solution; the rest are a safety margin (the iteration's fixed point is stable).
+    for _ in range(_BANDED_REFINEMENT_STEPS):
+        gathered = x[cols_clipped]
+        gathered[~in_range] = 0.0
+        residual = observed - (band_vals * gathered).sum(axis=1)  # b - W x  (n_obs,)
+        gradient = np.zeros(n_cin)
+        np.add.at(gradient, cols_clipped[in_range], (band_vals * residual[:, None])[in_range])  # Wᵀ (b - W x)
+        gradient += d_reg * (x_target - x)
+        gradient[dead] = 0.0
+        x += cho_solve_banded((factor, True), gradient)
+
+    out = np.full(n_output, np.nan)
+    out[col_active] = x[col_active]
     return out
 
 

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from gwtransport import advection as adv_mod
-from gwtransport import gamma
+from gwtransport import advection_utils, gamma
 from gwtransport._time import tedges_to_days
 from gwtransport.advection import (
     _validate_advection_inputs,
@@ -19,13 +19,46 @@ from gwtransport.advection import (
     infiltration_to_extraction_series,
 )
 from gwtransport.advection_utils import (
-    _infiltration_to_extraction_weights,
+    _densify_weights,
     _resolve_spinup_inputs,
-    _resolve_spinup_mask,
+)
+from gwtransport.advection_utils import (
+    _infiltration_to_extraction_weights as _banded_weights,
+)
+from gwtransport.advection_utils import (
+    _resolve_spinup_mask as _banded_mask,
 )
 from gwtransport.fronttracking.math import ConstantRetardation
 from gwtransport.residence_time import residence_time
-from gwtransport.utils import compute_time_edges, partial_isin, solve_inverse_transport
+from gwtransport.utils import (
+    compute_time_edges,
+    partial_isin,
+    solve_inverse_transport,
+    solve_inverse_transport_banded,
+)
+
+
+# The package builder/mask are banded (see advection_utils). These thin adapters present
+# the historical dense (n_cout, n_cin) signatures so the dense-oracle and Fraction-truth
+# comparisons below stay unchanged: the build is densified, and the row-wise mask is applied
+# to the dense matrix (its col_start passthrough is irrelevant when the input is full-width).
+def _infiltration_to_extraction_weights(**kwargs):
+    band_vals, col_start, contributing_bins, zero_flow_cout = _banded_weights(**kwargs)
+    dense = _densify_weights(band_vals, col_start, len(kwargs["tedges"]) - 1)
+    return dense, contributing_bins, zero_flow_cout
+
+
+def _resolve_spinup_mask(*, accumulated_weights, contributing_bins, zero_flow_cout, n_pv, spinup):
+    weights, _, invalid = _banded_mask(
+        band_vals=accumulated_weights,
+        col_start=np.zeros(len(accumulated_weights), dtype=np.intp),
+        contributing_bins=contributing_bins,
+        zero_flow_cout=zero_flow_cout,
+        n_pv=n_pv,
+        spinup=spinup,
+    )
+    return weights, invalid
+
 
 # ===============================================================================
 # FIXTURES
@@ -4420,3 +4453,119 @@ def test_banded_builder_reverse_and_gamma_match_dense_driven():
     np.testing.assert_array_equal(np.isnan(cout_gamma_real), np.isnan(cout_gamma_dense))
     g_valid = ~np.isnan(cout_gamma_real)
     np.testing.assert_allclose(cout_gamma_real[g_valid], cout_gamma_dense[g_valid], atol=1e-12, rtol=0)
+
+
+def test_banded_builder_multi_tile_matches_single_tile(monkeypatch):
+    """Tiling the cout axis must not change the operator: a many-tile build is
+    bit-identical to a single-tile build.
+
+    Variable flow plus a wide APVD make the per-tile band widths differ, so this
+    also guards the global ``full_band`` tracking and per-tile right-padding --
+    a ``full_band = tile_band`` bug (dropping the cross-tile ``max``) is invisible
+    to every single-tile test but corrupts or fails to assemble a multi-tile build.
+    """
+    n = 300
+    tedges = pd.date_range("2018-01-01", periods=n + 1, freq="D")
+    flow = np.linspace(20.0, 400.0, n)
+    apv = np.array([50.0, 2000.0])
+    kw = {
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "aquifer_pore_volumes": apv,
+        "flow": flow,
+        "retardation_factor": 1.0,
+    }
+
+    monkeypatch.setattr(advection_utils, "_WEIGHT_BUILD_BLOCK", 10**9)  # one tile
+    bv1, cs1, cb1, zf1 = _banded_weights(**kw)
+    monkeypatch.setattr(advection_utils, "_WEIGHT_BUILD_BLOCK", 21)  # block = 21 // 2 = 10 -> ~30 tiles
+    bv_n, cs_n, cb_n, zf_n = _banded_weights(**kw)
+
+    np.testing.assert_array_equal(cs1, cs_n)
+    np.testing.assert_array_equal(cb1, cb_n)
+    np.testing.assert_array_equal(zf1, zf_n)
+    np.testing.assert_array_equal(bv1, bv_n)  # same shape (global full_band) and values
+
+
+def test_solve_inverse_transport_banded_matches_dense():
+    """The banded CSNE solver reproduces the dense least-squares solver to the
+    documented ~1e-9, isolated from the forward build.
+
+    The corrected-semi-normal refinement is load-bearing: with
+    ``_BANDED_REFINEMENT_STEPS = 0`` the under-determined (spin-up) directions
+    lose ~1e-6 to the squared condition number, so this comparison pins it.
+    """
+    n = 80
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = 100.0 + 20.0 * np.sin(np.arange(n) * 2 * np.pi / 11)
+    apv = np.array([200.0, 450.0, 700.0])
+    weight_tedges, weight_flow, _, threshold, _ = _resolve_spinup_inputs(
+        "constant", tedges=tedges, flow=flow, aquifer_pore_volumes=apv, retardation_factor=1.0
+    )
+    n_out = len(weight_tedges) - 1
+    band_vals, col_start, contrib, zero_flow = _banded_weights(
+        tedges=weight_tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, flow=weight_flow, retardation_factor=1.0
+    )
+    band_vals, col_start, _ = _banded_mask(
+        band_vals=band_vals,
+        col_start=col_start,
+        contributing_bins=contrib,
+        zero_flow_cout=zero_flow,
+        n_pv=len(apv),
+        spinup=threshold,
+    )
+    w_dense = _densify_weights(band_vals, col_start, n_out)
+    observed = 3.0 + np.sin(np.arange(n) * 2 * np.pi / 17)
+    lam = 1e-10
+    x_banded = solve_inverse_transport_banded(
+        band_vals=band_vals, col_start=col_start, observed=observed, n_output=n_out, regularization_strength=lam
+    )
+    x_dense = solve_inverse_transport(w_forward=w_dense, observed=observed, n_output=n_out, regularization_strength=lam)
+    np.testing.assert_array_equal(np.isnan(x_banded), np.isnan(x_dense))
+    valid = ~np.isnan(x_banded)
+    np.testing.assert_allclose(x_banded[valid], x_dense[valid], atol=1e-9, rtol=0)
+
+
+def test_solve_inverse_transport_banded_degenerate_cases():
+    """Inactive output columns return NaN, an all-zero operator returns all-NaN
+    without raising, and non-positive regularization is rejected."""
+    band_vals = np.array([[0.6, 0.4], [0.5, 0.5], [0.0, 0.0]])
+    col_start = np.array([0, 2, 0], dtype=np.intp)  # contributes to cols {0,1,2,3}; cols 4,5 inactive
+    observed = np.array([1.0, 2.0, 0.0])
+    n_output = 6
+    out = solve_inverse_transport_banded(
+        band_vals=band_vals, col_start=col_start, observed=observed, n_output=n_output, regularization_strength=1e-8
+    )
+    col_sum = _densify_weights(band_vals, col_start, n_output).sum(axis=0)
+    np.testing.assert_array_equal(np.isnan(out), col_sum == 0)
+
+    out_zero = solve_inverse_transport_banded(
+        band_vals=np.zeros((3, 2)),
+        col_start=np.zeros(3, dtype=np.intp),
+        observed=np.ones(3),
+        n_output=4,
+        regularization_strength=1e-8,
+    )
+    assert np.all(np.isnan(out_zero))
+
+    with pytest.raises(ValueError, match="must be > 0"):
+        solve_inverse_transport_banded(
+            band_vals=band_vals, col_start=col_start, observed=observed, n_output=n_output, regularization_strength=0.0
+        )
+
+
+def test_advection_empty_pore_volumes_all_nan():
+    """An empty pore-volume distribution means no transport: both directions
+    return all-NaN through the public API without raising."""
+    n = 20
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    empty = np.array([])
+    cout = infiltration_to_extraction(
+        cin=np.ones(n), flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=empty
+    )
+    assert np.all(np.isnan(cout))
+    cin_rec = extraction_to_infiltration(
+        cout=np.ones(n), flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=empty
+    )
+    assert np.all(np.isnan(cin_rec))

--- a/tests/src/test_advection_roundtrip.py
+++ b/tests/src/test_advection_roundtrip.py
@@ -18,6 +18,7 @@ import pandas as pd
 
 from gwtransport.advection import extraction_to_infiltration, infiltration_to_extraction
 from gwtransport.advection_utils import (
+    _densify_weights,
     _infiltration_to_extraction_weights,
     _resolve_spinup_mask,
 )
@@ -202,20 +203,22 @@ class TestRoundtripSameGrid:
         # reconstruction error |cin_recovered - cin_original| at each bin is
         # bounded by |P_null(cin_original)| at that bin, since cin_recovered
         # and cin_original agree modulo null(W).
-        accumulated_weights, contributing_bins, zero_flow_cout = _infiltration_to_extraction_weights(
+        band_vals, col_start, contributing_bins, zero_flow_cout = _infiltration_to_extraction_weights(
             tedges=tedges,
             cout_tedges=cout_tedges,
             aquifer_pore_volumes=pore_volumes,
             flow=flow,
             retardation_factor=1.0,
         )
-        w_forward, _ = _resolve_spinup_mask(
-            accumulated_weights=accumulated_weights,
+        band_vals, col_start, _ = _resolve_spinup_mask(
+            band_vals=band_vals,
+            col_start=col_start,
             contributing_bins=contributing_bins,
             zero_flow_cout=zero_flow_cout,
             n_pv=len(pore_volumes),
             spinup=None,
         )
+        w_forward = _densify_weights(band_vals, col_start, len(tedges) - 1)
         _, sing_vals, vt = np.linalg.svd(w_forward, full_matrices=True)
         null_basis = vt[len(sing_vals) :]  # rows of Vt past the singular values
         nullspace_proj = null_basis.T @ (null_basis @ cin_original)

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -864,7 +864,13 @@ class TestExtractionToInfiltrationDiffusion:
         Both modules use comparable strict-validity boundary handling here
         (advection: ``spinup=None``; diffusion: ``spinup=None`` disables
         the 100-year tedge extension), so the comparison restricts to bins
-        valid in both modules and the algebra matches exactly.
+        valid in both modules. The two now use different inverse solvers --
+        advection's banded corrected-semi-normal solve vs diffusion's dense
+        least-squares -- so they agree to machine precision rather than
+        bit-identically; ``atol`` guards the true-zero bins, where the banded
+        solve returns exact 0 and the dense solve leaves roundoff. The max
+        absolute difference is ~4.4e-16 (2 ULP at value 1.0); ``atol=1e-14``
+        (~22x the floor) is a roundoff guard that still discriminates to ~1e-13.
         """
         cin_advection = advection_e2i(
             cout=simple_setup["cout"],
@@ -887,7 +893,7 @@ class TestExtractionToInfiltrationDiffusion:
         )
         # Only compare values where advection is not NaN
         valid_mask = ~np.isnan(cin_advection)
-        np.testing.assert_allclose(cin_advection[valid_mask], cin_diffusion[valid_mask])
+        np.testing.assert_allclose(cin_advection[valid_mask], cin_diffusion[valid_mask], atol=1e-14)
 
     def test_small_diffusivity_close_to_advection(self, simple_setup):
         """Test that small diffusivity produces result close to advection."""


### PR DESCRIPTION
## Summary

Closes #239. The advection forward (`infiltration_to_extraction`) and inverse (`extraction_to_infiltration`) materialised a dense `(n_cout, n_cin)` weight matrix and, for the inverse, an even larger augmented least-squares SVD — both **quadratic in record length**. This replaces them with a compact **banded** operator, so peak memory is **bounded at ~30 MB regardless of record length**:

| path | before | after |
|---|---|---|
| forward (N=2920) | 274 MB (O(N²)) | 30 MB |
| inverse (N=2920) | 480 MB (O(N²)) | 30 MB |
| both (N=15000) | multi-GB | ~32 MB |

Speed is comparable, and faster at large N where the dense path would OOM.

- **Builder** (`advection_utils._infiltration_to_extraction_weights`): returns a banded layout `(band_vals, col_start, contributing_bins, zero_flow_cout)`, built by tiling the cout axis (`_WEIGHT_BUILD_BLOCK`) so the working set is `O(n·band)` independent of N. Bit-exact vs the previous dense build (≤1.8e-15). `_resolve_spinup_mask` operates on the band; `_densify_weights` reconstructs the dense matrix (used only by tests).
- **Forward**: banded `einsum` matvec — no dense matrix.
- **Inverse** (`utils.solve_inverse_transport_banded`): banded normal equations + `cholesky_banded`, refined with **corrected semi-normal equations** (residual evaluated through `W`, not `WᵀW`). Plain banded normal equations alone lose ~1e-6 in the under-determined spin-up nullspace to condition-squaring; CSNE recovers the full least-squares accuracy, matching the dense solver to ~1e-10. The dense `solve_inverse_transport` is unchanged (diffusion/deposition still use it).

**Accuracy:** forward bit-exact; inverse matches dense least-squares to ~1e-10. No test tolerance is loosened. The only tolerance touched is one cross-module diffusion check, made *tighter than required* (`atol=1e-14`) — the banded solver returns exact 0 where the dense solve leaves ~4.4e-16 roundoff.

## Test plan

- `pytest tests/src -n auto` — **1460 passed, 2 skipped** at existing tolerances, including the rtol=1e-12 roundtrip.
- New tests: multi-tile == single-tile parity, `solve_inverse_transport_banded` vs dense, banded-solver degenerate cases (inactive columns, all-zero operator, λ≤0), empty pore-volume distribution.
- `ruff format` + `ruff check` clean; `ty check` clean.
- `tracemalloc` at N=2920/8000/15000: forward & inverse bounded ~30–32 MB (was 274/480 MB at N=2920).

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.