### PR TITLE
perf: bound diffusion_fast memory + speed with a banded operator

### DIFF
--- a/src/gwtransport/_diffusion_shared.py
+++ b/src/gwtransport/_diffusion_shared.py
@@ -17,6 +17,7 @@ import pandas as pd
 from scipy.special import erf, erfcx
 
 from gwtransport._time import dt_to_days
+from gwtransport.utils import solve_inverse_transport_banded
 
 # Minimum coefficient sum to consider an output bin valid.
 _EPSILON_COEFF_SUM = 1e-10
@@ -36,9 +37,9 @@ def _breakthrough_antideriv(
 
     Returns :math:`I(x) = \tfrac12 x + \tfrac12[x\,\operatorname{erf}(x/s) + (s/\sqrt\pi)e^{-(x/s)^2}]`
     with :math:`s = 2\sqrt{D_t}`, alongside ``s`` and the Gaussian factor ``exp(-(x/s)^2)`` (both
-    reused by the retardation correction). Shared by the dense kernel
-    (:func:`gwtransport.diffusion_fast._flux_breakthrough_fraction`) and the banded build, so both
-    compute identical floating-point results for the same inputs.
+    reused by the retardation correction). Shared by the banded ``C_F`` build
+    (:func:`gwtransport.diffusion_fast._pv_band_values`) and the slow quadrature, so both compute
+    identical floating-point results for the same inputs.
 
     Returns
     -------
@@ -310,3 +311,73 @@ def _validate_inputs(
         if np.any(flow_out < 0):
             msg = "flow_out must be non-negative (negative flow not supported)"
             raise ValueError(msg)
+
+
+def _solve_reverse_banded(
+    *,
+    band_vals: npt.NDArray[np.floating],
+    col_start: npt.NDArray[np.intp],
+    valid_cout_bins: npt.NDArray[np.bool_],
+    cout: npt.NDArray[np.floating],
+    n_cin: int,
+    regularization_strength: float,
+) -> npt.NDArray[np.floating]:
+    """Normalize, decouple the warm-start tail, and solve the banded Tikhonov inverse.
+
+    Shared by :func:`gwtransport.diffusion_fast.extraction_to_infiltration` and
+    :func:`gwtransport.diffusion_fast_fast.extraction_to_infiltration`, which build the same banded
+    forward operator and must therefore produce byte-identical inverses. The steps are:
+
+    1. Zero invalid rows (incomplete breakthrough) and normalize the remaining rows to sum to 1 --
+       the banded solver's ``W x ~= observed`` precondition.
+    2. Decouple the warm-start data-start tail. With a leading zero-flow plateau and ``D_m > 0`` the
+       forward operator carries a negative warm-start coefficient at the data-start columns (kept in
+       the forward band so the forward ``C_F`` is exact); their net column sum is ``<= 0``, so the
+       banded normal-equation solver would leave them unregularized -- a large, unregularized
+       ``WᵀW`` diagonal coupled to the spin-up nullspace, which is indefinite and breaks the Cholesky
+       factorisation. These columns are the unrecoverable spin-up region (NaN in the dense and the
+       slow-module inverses alike), so zeroing their band entries decouples them: the solver's
+       zero-diagonal path returns them as NaN and the remaining system is symmetric positive definite.
+
+    Parameters
+    ----------
+    band_vals : ndarray, shape (n_cout_bins, full_band)
+        Banded forward weights from :func:`gwtransport.diffusion_fast._closed_form_coeff_matrix`.
+    col_start : ndarray of int, shape (n_cout_bins,)
+        First cin-bin column of each cout row's band.
+    valid_cout_bins : ndarray of bool, shape (n_cout_bins,)
+        Output bins with complete breakthrough information.
+    cout : ndarray, shape (n_cout_bins,)
+        Observed extraction concentration.
+    n_cin : int
+        Number of infiltration bins (output length).
+    regularization_strength : float
+        Tikhonov parameter.
+
+    Returns
+    -------
+    ndarray, shape (n_cin,)
+        Recovered infiltration concentration; NaN for unconstrained / spin-up bins.
+    """
+    row_sums = band_vals.sum(axis=1)
+    valid = valid_cout_bins & (row_sums > _EPSILON_COEFF_SUM)
+    bn = band_vals.copy()
+    bn[~valid] = 0.0
+    bn[valid] /= row_sums[valid, None]
+
+    full_band = bn.shape[1]
+    band_cols = col_start[:, None] + np.arange(full_band)
+    in_range = band_cols < n_cin
+    band_cols_clipped = np.clip(band_cols, 0, n_cin - 1)
+    col_sum = np.zeros(n_cin)
+    np.add.at(col_sum, band_cols_clipped[in_range], bn[in_range])
+    inactive_col = col_sum <= _EPSILON_COEFF_SUM
+    bn[inactive_col[band_cols_clipped] & in_range] = 0.0
+
+    return solve_inverse_transport_banded(
+        band_vals=bn,
+        col_start=col_start,
+        observed=cout,
+        n_output=n_cin,
+        regularization_strength=regularization_strength,
+    )

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -84,11 +84,12 @@ from gwtransport._diffusion_shared import (
     _cout_cumulative_volume,
     _extend_tedges_flag,
     _retardation_excess_density,
+    _solve_reverse_banded,
     _validate_inputs,
 )
 from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport.residence_time import residence_time
-from gwtransport.utils import cumulative_flow_volume, solve_inverse_transport
+from gwtransport.utils import cumulative_flow_volume
 
 # Default saturation threshold U for the banded build: a cout/cin pair is only evaluated
 # while the breakthrough |x|/(2*sqrt(D_t)) <= U; beyond it the bin-averaged C_F is saturated
@@ -99,111 +100,8 @@ from gwtransport.utils import cumulative_flow_volume, solve_inverse_transport
 _DEFAULT_SATURATION_THRESHOLD = 7.0
 
 
-def _flux_breakthrough_fraction(
+def _pv_band_geometry(
     *,
-    step_widths: npt.NDArray[np.floating],
-    tau: npt.NDArray[np.floating],
-    molecular_diffusivity: float,
-    longitudinal_dispersivity: float,
-    streamline_len: float,
-    retardation_factor: float,
-    velocity: npt.NDArray[np.floating],
-) -> npt.NDArray[np.floating]:
-    r"""Bin-averaged Kreft-Zuber flux concentration over each cout bin, per cin edge.
-
-    Closed-form evaluation of the bin-averaged outlet breakthrough. For a unit step
-    injected at cin edge *j*, the bin-averaged resident concentration over cout bin *i* is
-
-    .. math::
-
-        \frac{1}{\Delta x}\int C_R\,dx,\qquad
-        C_R = \tfrac12\bigl(1 + \operatorname{erf}(x/(2\sqrt{D_t}))\bigr),
-
-    with antiderivative
-    :math:`I(x) = \tfrac12 x + \tfrac12[x\,\operatorname{erf}(x/s) + (s/\sqrt\pi)e^{-(x/s)^2}]`,
-    :math:`s = 2\sqrt{D_t}`. Evaluating :math:`I` once per cout *edge* and differencing,
-    with the moving-frame dispersion product :math:`D_t = D_m\,\tau + \alpha_L\,\xi`
-    carried *per edge*, yields the **flux** concentration :math:`C_F` (Kreft & Zuber 1978),
-    not merely :math:`C_R`. This is exact, not coincidental: the antiderivative difference
-    picks up a :math:`\partial I/\partial D_t \cdot (dD_t/dx)` term, and
-
-    .. math::
-
-        \frac{dD_t}{dx} = D_m\frac{d\tau}{dx} + \alpha_L
-                        = \frac{D_m}{v} + \alpha_L = \frac{D_L}{v},
-
-    which is precisely the Kreft-Zuber flux coefficient (using :math:`d\tau/dx = 1/v`). The
-    dispersive boundary-flux correction therefore emerges from the ``D_t`` variation across
-    the bin; no explicit flux term is added.
-
-    Parameters
-    ----------
-    step_widths : ndarray, shape (n_cout_edges, n_cin_edges)
-        ``x = (V_cout - V_cin - R*V_pore) * L / (R*V_pore)`` at each (cout-edge, cin-edge);
-        equals :math:`\xi - L`.
-    tau : ndarray, shape (n_cout_edges, n_cin_edges)
-        Elapsed time ``t_cout - t_cin`` [day] at each (cout-edge, cin-edge), clipped at 0.
-    molecular_diffusivity : float
-        Effective molecular diffusivity D_m [m^2/day].
-    longitudinal_dispersivity : float
-        Longitudinal dispersivity alpha_L [m].
-    streamline_len : float
-        Streamline length L [m].
-    retardation_factor : float
-        Retardation factor R [-]. Triggers the K-Z flux-coefficient correction when
-        ``R != 1`` and ``D_m > 0`` (see notes in the body).
-    velocity : ndarray, shape (n_cout_bins,)
-        Fluid (unretarded) velocity ``Q*L/V_pore`` [m/day] in each cout bin, used by the
-        retardation correction.
-
-    Returns
-    -------
-    ndarray, shape (n_cout_bins, n_cin_edges)
-        Bin-averaged flux concentration for the step injected at each cin edge.
-
-    References
-    ----------
-    Kreft, A., & Zuber, A. (1978). On the physical meaning of the dispersion equation and
-    its solutions for different initial and boundary conditions. Chemical Engineering
-    Science, 33(11), 1471-1480.
-    """
-    x_lo = step_widths[:-1]
-    x_hi = step_widths[1:]
-    dx = x_hi - x_lo
-
-    # No dispersion: C_R is the step function H(x); its exact bin-average is the fraction
-    # of the cout bin with x > 0 (the limit of the erf form as D_t -> 0).
-    if molecular_diffusivity == 0.0 and longitudinal_dispersivity == 0.0:
-        with np.errstate(divide="ignore", invalid="ignore"):
-            frac = (np.maximum(x_hi, 0.0) - np.maximum(x_lo, 0.0)) / dx
-        return np.where(dx > 0.0, frac, 0.5 + 0.5 * np.sign(x_lo))
-
-    xi = step_widths + streamline_len
-    dt_var = np.maximum(molecular_diffusivity * tau + longitudinal_dispersivity * np.maximum(xi, 0.0), _DT_FLOOR)
-    antideriv, s, gaussian = _breakthrough_antideriv(step_widths, dt_var)
-    with np.errstate(divide="ignore", invalid="ignore"):
-        frac = np.where(dx > 0.0, np.diff(antideriv, axis=0) / dx, 0.0)
-
-    if retardation_factor != 1.0 and molecular_diffusivity > 0.0:
-        density_binavg = _retardation_excess_density(
-            x_lo=x_lo,
-            x_hi=x_hi,
-            dx=dx,
-            d_lo=dt_var[:-1],
-            d_hi=dt_var[1:],
-            s_lo=s[:-1],
-            s_hi=s[1:],
-            g_lo=gaussian[:-1],
-            g_hi=gaussian[1:],
-        )
-        excess = np.where(velocity > 0.0, (retardation_factor - 1.0) * molecular_diffusivity / velocity, 0.0)
-        frac -= excess[:, None] * density_binavg
-    return frac
-
-
-def _accumulate_pv_banded(
-    *,
-    accumulated_coeff: npt.NDArray[np.floating],
     cumulative_volume_at_cout: npt.NDArray[np.floating],
     cumulative_volume_at_cin: npt.NDArray[np.floating],
     cout_tedges_days: npt.NDArray[np.floating],
@@ -212,36 +110,34 @@ def _accumulate_pv_banded(
     length: float,
     molecular_diffusivity: float,
     longitudinal_dispersivity: float,
-    retardation_factor: float,
-    velocity: npt.NDArray[np.floating],
     min_cin_flow: float,
     saturation_threshold: float,
-) -> bool:
-    r"""Scatter one streamtube's banded ``C_F`` contribution into ``accumulated_coeff``.
+    n_cin_bins: int,
+) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
+    r"""Per-cout-row band bounds (lo, hi) in cin-bin columns for one streamtube (geometry only).
 
-    Computes the bin-averaged flux concentration only on the narrow cumulative-volume band where
-    the breakthrough transitions between 0 and 1 -- the only cin bins with a non-zero coefficient.
-    Within a streamtube the moving-frame dispersion product is exactly linear in the breakthrough
-    coordinate, ``D_t(x) = A + B*x``, with slope ``B = dD_t/dx = R*D_m/v + alpha_L`` (the per-bin
-    flux coefficient) and intercept ``A`` the front value, so the saturation edge
-    ``|x| = saturation_threshold * 2*sqrt(D_t(x))`` is the root of a quadratic -- the band
-    half-width is closed form, no iteration. The band is centred per cout bin on the front
-    ``V_cin = V_cout - R*V_pore`` and mapped to cin-edge columns with ``searchsorted`` (so
+    Locates the narrow cumulative-volume band where the breakthrough transitions between 0 and 1
+    -- the only cin bins with a non-zero coefficient. Within a streamtube the moving-frame
+    dispersion product is exactly linear in the breakthrough coordinate, ``D_t(x) = A + B*x``,
+    with slope ``B = dD_t/dx = R*D_m/v + alpha_L`` and intercept ``A`` the front value, so the
+    saturation edge ``|x| = saturation_threshold * 2*sqrt(D_t(x))`` is the root of a quadratic --
+    the band half-width is closed form, no iteration. The band is centred per cout bin on the
+    front ``V_cin = V_cout - R*V_pore`` and mapped to cin-edge columns with ``searchsorted`` (so
     non-uniform / variable-flow grids need no special handling).
 
-    At ``saturation_threshold`` around 7 the dropped tail is ``~exp(-threshold**2)``, far below the
-    ulp of the kept entries, so the scattered band reproduces the dense build
-    (:func:`_flux_breakthrough_fraction`) to machine precision; a smaller threshold narrows the
-    band (faster) at the cost of dropping breakthrough tails of that order. ``C_F`` over a cout bin
-    is ``(I(x_hi) - I(x_lo)) / dx`` with the antiderivative ``I`` evaluated at both cout edges over
-    the gathered cin stripe, plus the same closed-form retardation correction as the dense kernel.
+    With a warm-start spin-up and ``D_m > 0`` the breakthrough is *also* unsaturated at the
+    data-start edge (cin edge 0): a leading zero-flow plateau holds the cumulative volume flat
+    there, so the front search lands the local band one or more columns inside the record while a
+    genuine, non-negligible coefficient remains at column 0 (the warm-start tail of a wide bin with
+    large ``tau`` -> large ``D_t``). Each row therefore additionally tests ``|x0| < U*2*sqrt(D_t0)``
+    at edge 0 and, when non-saturated, drops its band lower bound to 0 so that tail is kept.
 
     Returns
     -------
-    bool
-        ``True`` if the contribution was scattered. ``False`` (leaving ``accumulated_coeff``
-        unchanged) when the band would span more than half the cin axis -- the caller then uses
-        the dense kernel for this streamtube, so the cost never exceeds the dense build.
+    lo : ndarray of int, shape (n_cout_bins,)
+        Per-row band lower bound (inclusive), clipped to ``[0, n_cin_bins - 1]``.
+    hi : ndarray of int, shape (n_cout_bins,)
+        Per-row band upper bound (inclusive), clipped to ``[0, n_cin_bins - 1]``.
     """
     v_cin = cumulative_volume_at_cin
     n_cin_edges = v_cin.size
@@ -262,7 +158,8 @@ def _accumulate_pv_banded(
     # flow with larger tau, so it carries its own intercept a_post; max(a_pre, a_post) bounds the front
     # D_t of both cout edges there. The pre extent anchors at the upper cout edge. a_pre uses the upper
     # edge time / mid front (conservative for the pre side). +1 absorbs searchsorted rounding;
-    # min_cin_flow == 0 -> B = inf -> the band trips the fallback below.
+    # min_cin_flow == 0 (no flow) -> the post slope is unbounded; b_max is set to span the whole axis
+    # only when D_m > 0, else 0 (no diffusion, no flow term), avoiding a 0/0 NaN.
     u = saturation_threshold
     v_front = 0.5 * (v_cout_lo + v_cout_hi) - r_vpv
     center = np.searchsorted(v_cin, v_front)
@@ -275,24 +172,92 @@ def _accumulate_pv_banded(
     )
     a_post = np.maximum(a_post, a_pre)
     pre_x = 2.0 * u * np.sqrt(a_pre)
-    with np.errstate(divide="ignore", invalid="ignore"):
+    if min_cin_flow > 0.0:
         b_max = longitudinal_dispersivity + molecular_diffusivity * r_vpv / (length * min_cin_flow)
-        post_x = 2.0 * u * u * b_max + 2.0 * u * np.sqrt(u * u * b_max * b_max + a_post)
-        col_post = np.searchsorted(v_cin, (v_cout_lo - r_vpv) - r_vpv * post_x / length)  # smallest V_cin
-        col_pre = np.searchsorted(v_cin, (v_cout_hi - r_vpv) + r_vpv * pre_x / length)  # largest V_cin
+    else:
+        b_max = np.inf if molecular_diffusivity > 0.0 else longitudinal_dispersivity
+    post_x = 2.0 * u * u * b_max + 2.0 * u * np.sqrt(u * u * b_max * b_max + a_post)
+    col_post = np.searchsorted(v_cin, (v_cout_lo - r_vpv) - r_vpv * post_x / length)  # smallest V_cin
+    col_pre = np.searchsorted(v_cin, (v_cout_hi - r_vpv) + r_vpv * pre_x / length)  # largest V_cin
+    # Scalar (global-max) half-widths, applied to every row via the band centre. Taking the max over
+    # all cout rows is conservative: a row whose front sits in a slow / zero-flow plateau (large tau,
+    # wide local transition) sets the half-width for all rows, so an interior zero-flow gap straddled
+    # by a misaligned cout bin is never under-covered. +1 absorbs the searchsorted rounding.
     hw_post = max(int(np.max(center - col_post)), 1) + 1
     hw_pre = max(int(np.max(col_pre - center)), 1) + 1
-    if hw_post + hw_pre >= n_cin_edges // 2:
-        return False
+    lo = np.clip(center - hw_post, 0, n_cin_bins - 1)
+    hi = np.clip(center + hw_pre - 1, 0, n_cin_bins - 1)
 
-    # Bin-averaged C_F over the stripe: I evaluated at both cout edges. Columns are clipped to the
-    # real data edges, which the warm-start extension makes saturated, so out-of-range columns
-    # carry frac 0/1 and telescope away in the cin-edge difference below.
-    cols = center[:, None] + np.arange(-hw_post, hw_pre + 1)[None, :]
+    # Warm-start data-start tail: drop the band to column 0 where the breakthrough is still
+    # unsaturated at cin edge 0. x0 is the breakthrough coordinate of the lower cout edge measured
+    # from V_cin[0] (the smallest x0 over the bin, hence the most-broken-through / largest |D_t0|);
+    # D_t0 floors at _DT_FLOOR so the zero-dispersion limit gives x0 != 0 -> saturated -> no spurious
+    # widening. The leading zero-flow plateau that triggers this keeps full_band bounded by the
+    # plateau length, independent of the record length.
+    x0 = (v_cout_lo - v_cin[0] - r_vpv) * length / r_vpv
+    tau0 = np.maximum(t_cout_lo - tedges_days[0], 0.0)
+    dt0 = np.maximum(molecular_diffusivity * tau0 + longitudinal_dispersivity * np.maximum(x0 + length, 0.0), _DT_FLOOR)
+    non_saturated0 = np.abs(x0) < u * 2.0 * np.sqrt(dt0)
+    lo[non_saturated0] = 0
+    return lo, hi
+
+
+def _pv_band_values(
+    *,
+    col_start: npt.NDArray[np.intp],
+    full_band: int,
+    cumulative_volume_at_cout: npt.NDArray[np.floating],
+    cumulative_volume_at_cin: npt.NDArray[np.floating],
+    cout_tedges_days: npt.NDArray[np.floating],
+    tedges_days: npt.NDArray[np.floating],
+    r_vpv: float,
+    length: float,
+    molecular_diffusivity: float,
+    longitudinal_dispersivity: float,
+    retardation_factor: float,
+    velocity: npt.NDArray[np.floating],
+) -> npt.NDArray[np.floating]:
+    r"""Bin-averaged ``C_F`` stripe for one streamtube on the shared band (values pass).
+
+    ``C_F`` over a cout bin is ``(I(x_hi) - I(x_lo)) / dx`` with the closed-form antiderivative
+    ``I`` evaluated at both cout edges over the band cin edges, plus the same closed-form
+    retardation correction as the slow quadrature. The stripe is the band itself: each row spans
+    cin edges ``col_start[k] .. col_start[k] + full_band`` (``full_band + 1`` edges), so the
+    coefficient for band offset ``b`` (cin bin ``col_start[k] + b``) is ``frac[b] - frac[b + 1]``.
+    The zero-dispersion limit is exact here too: ``D_t`` floors to ``_DT_FLOOR``, so ``C_F`` is a
+    step smoothed by ~1e-15.
+
+    Returns
+    -------
+    coeff : ndarray, shape (n_cout_bins, full_band)
+        Per-row, per-band-offset coefficient ``frac[:, :-1] - frac[:, 1:]`` already aligned to the
+        banded buffer (offset 0 -> cin bin ``col_start[k]``).
+    """
+    v_cin = cumulative_volume_at_cin
+    n_cin_edges = v_cin.size
+    v_cout_lo, v_cout_hi = cumulative_volume_at_cout[:-1], cumulative_volume_at_cout[1:]
+    t_cout_lo, t_cout_hi = cout_tedges_days[:-1], cout_tedges_days[1:]
+
+    # Bin-averaged C_F over the band: I evaluated at both cout edges on the full_band + 1 cin edges
+    # of each row's band. Edges are clipped to the real data edges, which the warm-start extension
+    # makes saturated, so out-of-range edges carry frac 0/1 and telescope away in the difference.
+    cols = col_start[:, None] + np.arange(full_band + 1)[None, :]
     cc = np.clip(cols, 0, n_cin_edges - 1)
     v_c, t_c = v_cin[cc], tedges_days[cc]
     sw_lo = (v_cout_lo[:, None] - v_c - r_vpv) * length / r_vpv
     sw_hi = (v_cout_hi[:, None] - v_c - r_vpv) * length / r_vpv
+
+    # No dispersion: C_R is the step H(x); its exact bin-average is the fraction of the cout bin with
+    # x > 0, and at a zero-width (dv_cout = 0) cout bin it is the point value 0.5*(1 + sign(x_lo)).
+    # This matches the dense kernel's zero-dispersion branch bit-for-bit (the floored erf form would
+    # instead give 0 at dx = 0, dropping the step at a gap-straddling misaligned cout bin).
+    if molecular_diffusivity == 0.0 and longitudinal_dispersivity == 0.0:
+        dx = sw_hi - sw_lo
+        with np.errstate(divide="ignore", invalid="ignore"):
+            frac = (np.maximum(sw_hi, 0.0) - np.maximum(sw_lo, 0.0)) / dx
+        frac = np.where(dx > 0.0, frac, 0.5 + 0.5 * np.sign(sw_lo))
+        return frac[:, :-1] - frac[:, 1:]
+
     dt_lo = np.maximum(
         molecular_diffusivity * np.maximum(t_cout_lo[:, None] - t_c, 0.0)
         + longitudinal_dispersivity * np.maximum(sw_lo + length, 0.0),
@@ -315,12 +280,7 @@ def _accumulate_pv_banded(
         excess = np.where(velocity > 0.0, (retardation_factor - 1.0) * molecular_diffusivity / velocity, 0.0)
         frac -= excess[:, None] * density_binavg
 
-    coeff = frac[:, :-1] - frac[:, 1:]
-    cin_bin = cols[:, :-1]
-    rows = np.broadcast_to(np.arange(center.size)[:, None], coeff.shape)
-    valid = (cin_bin >= 0) & (cin_bin < n_cin_edges - 1)
-    np.add.at(accumulated_coeff, (rows[valid], cin_bin[valid]), coeff[valid])
-    return True
+    return frac[:, :-1] - frac[:, 1:]
 
 
 def _closed_form_coeff_matrix(
@@ -336,22 +296,26 @@ def _closed_form_coeff_matrix(
     retardation_factor: float,
     extend_tedges: bool,
     saturation_threshold: float = _DEFAULT_SATURATION_THRESHOLD,
-    force_dense: bool = False,
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.bool_]]:
-    """Build the forward coefficient matrix W (``cout = W @ cin``) via the closed-form C_F.
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.intp], npt.NDArray[np.bool_]]:
+    """Build the banded forward operator (``cout = W @ cin``) via the closed-form C_F.
 
     Mirrors :func:`gwtransport.diffusion._infiltration_to_extraction_coeff_matrix`
     (per-streamtube loop over pore volumes, 100-year warm-start extension, residence-time
-    validity) but computes the bin-averaged flux concentration in closed form
-    (:func:`_flux_breakthrough_fraction`) instead of 16-point Gauss-Legendre quadrature. The
-    result reproduces the slow module's C_F to machine precision when the cout grid aligns
-    with the flow grid. ``streamline_length``, ``molecular_diffusivity``, and
+    validity) but computes the bin-averaged flux concentration in closed form instead of
+    16-point Gauss-Legendre quadrature, and stores it in BANDED layout: row ``k`` of the dense
+    operator ``W`` is ``band_vals[k]`` placed at columns ``[col_start[k], col_start[k] + full_band)``.
+    The build runs in two passes over the pore-volume loop -- a cheap geometry pass that sizes the
+    per-row band union, then a values pass that scatters each streamtube's ``C_F`` stripe into the
+    banded buffer. The result reproduces the slow module's ``C_F`` to machine precision when the
+    cout grid aligns with the flow grid. ``streamline_length``, ``molecular_diffusivity``, and
     ``longitudinal_dispersivity`` are per-pore-volume arrays (length ``len(aquifer_pore_volumes)``).
 
     Returns
     -------
-    coeff_matrix : ndarray, shape (n_cout_bins, n_cin_bins)
-        Forward coefficient matrix, NaN replaced with zero.
+    band_vals : ndarray, shape (n_cout_bins, full_band)
+        Banded forward weights, NaN replaced with zero.
+    col_start : ndarray of int, shape (n_cout_bins,)
+        First cin-bin column of each cout row's band.
     valid_cout_bins : ndarray of bool, shape (n_cout_bins,)
         Output bins with complete breakthrough information for every streamtube.
     """
@@ -391,10 +355,6 @@ def _closed_form_coeff_matrix(
     )
     valid_cout_bins = ~np.any(np.isnan(rt_at_cout_tedges[:, :-1]) | np.isnan(rt_at_cout_tedges[:, 1:]), axis=0)
 
-    # Elapsed time tau[i, j] = t_cout_i - t_cin_j (the moving-frame age). Geometric xi and
-    # tau are all the closed form needs -- no per-cell residence-time inversion.
-    tau = np.maximum(cout_tedges_days[:, None] - tedges_days[None, :], 0.0)
-
     # Fluid (unretarded) velocity in each cout bin: q_cout * L / V_pore (V_pore folded in
     # per streamtube below). q_cout = dV_cout / dt_cout.
     dv_cout = np.diff(cumulative_volume_at_cout)
@@ -402,9 +362,9 @@ def _closed_form_coeff_matrix(
     with np.errstate(divide="ignore", invalid="ignore"):
         q_cout = np.where(dt_cout > 0, dv_cout / dt_cout, 0.0)
 
-    # Slowest cin-side flow rate, used by the banded build to bound the broken-through band width
-    # (the slowest flow gives the steepest dD_t/dx). Zero when flow is everywhere zero -> banding
-    # falls back to the dense kernel.
+    # Slowest cin-side flow rate, used to bound the broken-through band width (the slowest flow
+    # gives the steepest dD_t/dx). Zero when flow is everywhere zero -> the band widens (capped
+    # at n_cin_bins), and the resulting no-flow rows are masked invalid anyway.
     with np.errstate(divide="ignore", invalid="ignore"):
         cin_flow = np.diff(cumulative_volume_at_cin) / np.diff(tedges_days)
     positive_cin_flow = cin_flow[cin_flow > 0.0]
@@ -412,50 +372,59 @@ def _closed_form_coeff_matrix(
 
     n_cout_bins = len(cout_tedges) - 1
     n_cin_bins = len(flow)
-    accumulated_coeff = np.zeros((n_cout_bins, n_cin_bins))
+
+    # PASS 1 (geometry): per-streamtube band bounds (lo, hi) in cin-bin columns; accumulate the
+    # per-row union over streamtubes. union_lo / union_hi are the min / max bounds per cout row.
+    union_lo = np.full(n_cout_bins, n_cin_bins - 1, dtype=np.intp)
+    union_hi = np.zeros(n_cout_bins, dtype=np.intp)
+    geometry = []
     for i_pv, v_pore in enumerate(aquifer_pore_volumes):
         r_vpv = retardation_factor * v_pore
         length = float(streamline_length[i_pv])
         d_m = float(molecular_diffusivity[i_pv])
         alpha_l = float(longitudinal_dispersivity[i_pv])
-        velocity = q_cout * length / v_pore
-        # Banded build for the dispersive case. The zero-dispersion step function (no band to
-        # find) and a band wider than half the matrix fall back to the dense kernel, so the cost
-        # never exceeds -- and is bit-identical to -- the dense build.
-        if (
-            not force_dense
-            and (d_m > 0.0 or alpha_l > 0.0)
-            and _accumulate_pv_banded(
-                accumulated_coeff=accumulated_coeff,
-                cumulative_volume_at_cout=cumulative_volume_at_cout,
-                cumulative_volume_at_cin=cumulative_volume_at_cin,
-                cout_tedges_days=cout_tedges_days,
-                tedges_days=tedges_days,
-                r_vpv=r_vpv,
-                length=length,
-                molecular_diffusivity=d_m,
-                longitudinal_dispersivity=alpha_l,
-                retardation_factor=retardation_factor,
-                velocity=velocity,
-                min_cin_flow=min_cin_flow,
-                saturation_threshold=saturation_threshold,
-            )
-        ):
-            continue
-        step_widths = (cumulative_volume_at_cout[:, None] - cumulative_volume_at_cin[None, :] - r_vpv) * length / r_vpv
-        frac = _flux_breakthrough_fraction(
-            step_widths=step_widths,
-            tau=tau,
+        lo, hi = _pv_band_geometry(
+            cumulative_volume_at_cout=cumulative_volume_at_cout,
+            cumulative_volume_at_cin=cumulative_volume_at_cin,
+            cout_tedges_days=cout_tedges_days,
+            tedges_days=tedges_days,
+            r_vpv=r_vpv,
+            length=length,
             molecular_diffusivity=d_m,
             longitudinal_dispersivity=alpha_l,
-            streamline_len=length,
+            min_cin_flow=min_cin_flow,
+            saturation_threshold=saturation_threshold,
+            n_cin_bins=n_cin_bins,
+        )
+        np.minimum(union_lo, lo, out=union_lo)
+        np.maximum(union_hi, hi, out=union_hi)
+        geometry.append((r_vpv, length, d_m, alpha_l, v_pore))
+
+    col_start = union_lo
+    full_band = min(int(np.max(union_hi - union_lo)) + 1, n_cin_bins)
+    band_vals = np.zeros((n_cout_bins, full_band))
+
+    # PASS 2 (values): each streamtube's C_F stripe is built on the shared band (col_start,
+    # full_band), so its coeff is already offset-aligned and accumulates directly into the buffer.
+    for r_vpv, length, d_m, alpha_l, v_pore in geometry:
+        velocity = q_cout * length / v_pore
+        band_vals += _pv_band_values(
+            col_start=col_start,
+            full_band=full_band,
+            cumulative_volume_at_cout=cumulative_volume_at_cout,
+            cumulative_volume_at_cin=cumulative_volume_at_cin,
+            cout_tedges_days=cout_tedges_days,
+            tedges_days=tedges_days,
+            r_vpv=r_vpv,
+            length=length,
+            molecular_diffusivity=d_m,
+            longitudinal_dispersivity=alpha_l,
             retardation_factor=retardation_factor,
             velocity=velocity,
         )
-        accumulated_coeff += frac[:, :-1] - frac[:, 1:]
 
-    coeff_matrix = accumulated_coeff / len(aquifer_pore_volumes)
-    return np.nan_to_num(coeff_matrix, nan=0.0), valid_cout_bins
+    band_vals /= len(aquifer_pore_volumes)
+    return np.nan_to_num(band_vals, nan=0.0), col_start, valid_cout_bins
 
 
 def infiltration_to_extraction(
@@ -558,7 +527,7 @@ def infiltration_to_extraction(
     molecular_diffusivity = _broadcast_to_pore_volumes(molecular_diffusivity, n_pore_volumes)
     longitudinal_dispersivity = _broadcast_to_pore_volumes(longitudinal_dispersivity, n_pore_volumes)
 
-    coeff_matrix, valid_cout_bins = _closed_form_coeff_matrix(
+    band_vals, col_start, valid_cout_bins = _closed_form_coeff_matrix(
         flow=flow,
         tedges=tedges,
         cout_tedges=cout_tedges,
@@ -572,11 +541,14 @@ def infiltration_to_extraction(
         saturation_threshold=saturation_threshold,
     )
 
-    cout = coeff_matrix @ cin
+    n_cin = len(cin)
+    full_band = band_vals.shape[1]
+    cols = np.clip(col_start[:, None] + np.arange(full_band), 0, n_cin - 1)
+    cout = np.einsum("kb,kb->k", band_vals, cin[cols])
 
     # Mark output bins invalid where no input has broken through (spin-up) or the output
     # bin extends beyond the input data range.
-    total_coeff = np.sum(coeff_matrix, axis=1)
+    total_coeff = band_vals.sum(axis=1)
     cout[(total_coeff < _EPSILON_COEFF_SUM) | ~valid_cout_bins] = np.nan
     return cout
 
@@ -684,7 +656,7 @@ def extraction_to_infiltration(
     longitudinal_dispersivity = _broadcast_to_pore_volumes(longitudinal_dispersivity, n_pore_volumes)
 
     n_cin = len(tedges) - 1
-    w_forward, valid_cout_bins = _closed_form_coeff_matrix(
+    band_vals, col_start, valid_cout_bins = _closed_form_coeff_matrix(
         flow=flow,
         tedges=tedges,
         cout_tedges=cout_tedges,
@@ -698,13 +670,13 @@ def extraction_to_infiltration(
         saturation_threshold=saturation_threshold,
     )
 
-    return solve_inverse_transport(
-        w_forward=w_forward,
-        observed=cout,
-        n_output=n_cin,
+    return _solve_reverse_banded(
+        band_vals=band_vals,
+        col_start=col_start,
+        valid_cout_bins=valid_cout_bins,
+        cout=cout,
+        n_cin=n_cin,
         regularization_strength=regularization_strength,
-        valid_rows=valid_cout_bins,
-        warn_rank_deficient=True,
     )
 
 

--- a/src/gwtransport/diffusion_fast_fast.py
+++ b/src/gwtransport/diffusion_fast_fast.py
@@ -79,12 +79,13 @@ from gwtransport._diffusion_shared import (
     _broadcast_to_pore_volumes,
     _cout_cumulative_volume,
     _extend_tedges_flag,
+    _solve_reverse_banded,
     _validate_inputs,
 )
 from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport.diffusion_fast import _DEFAULT_SATURATION_THRESHOLD, _closed_form_coeff_matrix
 from gwtransport.residence_time import residence_time
-from gwtransport.utils import cumulative_flow_volume, solve_inverse_transport
+from gwtransport.utils import cumulative_flow_volume
 
 # Samples per native bin used to discretise the 1D breakthrough antiderivative ``Ibar``. Higher =
 # more accurate ``Ibar`` interpolation (advection+micro error ~ O(1/_KERNEL_FINE^2)) at the cost of
@@ -575,7 +576,7 @@ def extraction_to_infiltration(
     longitudinal_dispersivity = _broadcast_to_pore_volumes(longitudinal_dispersivity, n_pv)
 
     n_cin = len(tedges) - 1
-    w_forward, valid_cout_bins = _closed_form_coeff_matrix(
+    band_vals, col_start, valid_cout_bins = _closed_form_coeff_matrix(
         flow=flow,
         tedges=tedges,
         cout_tedges=cout_tedges,
@@ -589,13 +590,13 @@ def extraction_to_infiltration(
         saturation_threshold=saturation_threshold,
     )
 
-    return solve_inverse_transport(
-        w_forward=w_forward,
-        observed=cout,
-        n_output=n_cin,
+    return _solve_reverse_banded(
+        band_vals=band_vals,
+        col_start=col_start,
+        valid_cout_bins=valid_cout_bins,
+        cout=cout,
+        n_cin=n_cin,
         regularization_strength=regularization_strength,
-        valid_rows=valid_cout_bins,
-        warn_rank_deficient=True,
     )
 
 

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -6,7 +6,13 @@ import pytest
 from numpy.testing import assert_allclose
 
 from gwtransport import gamma as gamma_utils
-from gwtransport._time import tedges_to_days
+from gwtransport._diffusion_shared import (
+    _DT_FLOOR,
+    _breakthrough_antideriv,
+    _cout_cumulative_volume,
+    _retardation_excess_density,
+)
+from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport.advection import infiltration_to_extraction as advection_i2e
 from gwtransport.diffusion import extraction_to_infiltration as diffusion_exact_reverse
 from gwtransport.diffusion import gamma_infiltration_to_extraction as diffusion_gamma_i2e
@@ -21,7 +27,7 @@ from gwtransport.diffusion_fast import (
     infiltration_to_extraction,
 )
 from gwtransport.gamma import mean_std_loc_to_alpha_beta
-from gwtransport.utils import partial_isin
+from gwtransport.utils import cumulative_flow_volume, partial_isin
 
 # =============================================================================
 # Helper: create common test data for transport functions
@@ -1997,7 +2003,7 @@ def test_step_input_retardation_diffusion_variable_flow_matches_diffusion_exact(
     """Retardation correction reproduces ``gwtransport.diffusion`` under VARIABLE flow.
 
     The R != 1 with D_m > 0 regime triggers the per-cout-bin ``velocity`` retardation
-    correction in :func:`gwtransport.diffusion_fast._flux_breakthrough_fraction` (the
+    correction in :func:`gwtransport.diffusion_fast._pv_band_values` (the
     per-edge mechanism would otherwise weight the molecular-diffusion flux by R). Under
     constant flow the correction's velocity is a single value, so a bug that used a mean
     velocity instead of the per-bin ``q_cout`` would be invisible. Variable flow makes
@@ -2353,33 +2359,119 @@ def test_streamline_length_zero_rejected():
 # =============================================================================
 # Banded-build regression tests
 #
-# The forward coefficient matrix is built only on the breakthrough band -- the cin bins with a
-# non-zero coefficient -- because the bin-averaged C_F is saturated to 0 or 1 outside it. These
-# tests pin that the banded production path reproduces the full dense build (`force_dense=True`,
-# which fills every column), so no genuine coefficient is dropped. They complement the
-# equivalence tests above, which already anchor the banded output against the independent
-# `gwtransport.diffusion` quadrature.
+# The forward operator is stored in banded layout (band_vals, col_start): row k of the dense W is
+# band_vals[k] placed at columns [col_start[k], col_start[k] + full_band). The band spans only the
+# breakthrough transition -- the cin bins with a non-zero coefficient -- because the bin-averaged
+# C_F saturates to 0 or 1 outside it. These tests densify the banded production build and pin it
+# against an EXPLICIT full-width dense reference (`_dense_closed_form_w`) that evaluates the same
+# closed-form C_F on EVERY cin column, so no genuine coefficient is dropped: an under-sized band
+# drops O(1e-2..1e-4) and would fail at once. The reference shares the antiderivative kernel, so
+# it is bit-identical to the band where both are non-saturated. They complement the public-API
+# equivalence tests above, which anchor against the independent `gwtransport.diffusion` quadrature.
 # =============================================================================
 
 
-def _banded_and_dense_w(*, flow, tedges, cout_tedges, pv, length, d_m, alpha_l, retardation, flow_out):
-    """Build the forward matrix both ways: banded production path and forced-dense reference."""
+def _densify_banded(band_vals, col_start, n_cin):
+    """Place each row's band at columns [col_start[k], col_start[k] + full_band) -> dense (n_cout, n_cin)."""
+    n_cout, full_band = band_vals.shape
+    dense = np.zeros((n_cout, n_cin))
+    cols = col_start[:, None] + np.arange(full_band)[None, :]
+    rows = np.broadcast_to(np.arange(n_cout)[:, None], cols.shape)
+    in_range = (cols >= 0) & (cols < n_cin)
+    dense[rows[in_range], cols[in_range]] = band_vals[in_range]
+    return dense
+
+
+def _banded_dense(*, flow, tedges, cout_tedges, pv, length, d_m, alpha_l, retardation, flow_out):
+    """Densified banded production build of the forward operator."""
     nb = len(pv)
-    kwargs = {
-        "flow": flow,
-        "tedges": tedges,
-        "cout_tedges": cout_tedges,
-        "flow_out": flow_out,
-        "aquifer_pore_volumes": pv,
-        "streamline_length": np.full(nb, length),
-        "molecular_diffusivity": np.full(nb, d_m),
-        "longitudinal_dispersivity": np.full(nb, alpha_l),
-        "retardation_factor": retardation,
-        "extend_tedges": _extend_tedges_flag("constant"),
-    }
-    w_banded, _ = _closed_form_coeff_matrix(**kwargs, force_dense=False)
-    w_dense, _ = _closed_form_coeff_matrix(**kwargs, force_dense=True)
-    return w_banded, w_dense
+    band_vals, col_start, _ = _closed_form_coeff_matrix(
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        flow_out=flow_out,
+        aquifer_pore_volumes=pv,
+        streamline_length=np.full(nb, length),
+        molecular_diffusivity=np.full(nb, d_m),
+        longitudinal_dispersivity=np.full(nb, alpha_l),
+        retardation_factor=retardation,
+        extend_tedges=_extend_tedges_flag("constant"),
+    )
+    return _densify_banded(band_vals, col_start, len(flow))
+
+
+def _dense_closed_form_w(*, flow, tedges, cout_tedges, pv, length, d_m, alpha_l, retardation, flow_out):
+    """Explicit full-width dense closed-form C_F: the same kernel evaluated on EVERY cin column.
+
+    Reference for the banded build -- it shares the antiderivative kernel and the volume/tau setup,
+    so on the breakthrough band the two are computed from identical floating-point inputs (bit-exact
+    for R=1; the R != 1 erfcx retardation tail is far below machine epsilon). Outside the band the
+    closed form saturates to exactly 0 or 1 in the cin-edge difference, which the banded build drops.
+    """
+    nb = len(pv)
+    streamline_length = np.full(nb, length)
+    molecular_diffusivity = np.full(nb, d_m)
+    longitudinal_dispersivity = np.full(nb, alpha_l)
+
+    work_tedges = pd.DatetimeIndex([
+        tedges[0] - pd.Timedelta("36500D"),
+        *list(tedges[1:-1]),
+        tedges[-1] + pd.Timedelta("36500D"),
+    ])
+    tedges_days = tedges_to_days(work_tedges)
+    cout_tedges_days = tedges_to_days(cout_tedges, ref=work_tedges[0])
+    v_cin = cumulative_flow_volume(flow, dt_to_days(work_tedges))
+    v_cout = _cout_cumulative_volume(
+        flow_out=flow_out,
+        cout_tedges=cout_tedges,
+        cout_tedges_days=cout_tedges_days,
+        tedges_days=tedges_days,
+        cumulative_volume_at_cin=v_cin,
+    )
+    tau = np.maximum(cout_tedges_days[:, None] - tedges_days[None, :], 0.0)
+    dv_cout = np.diff(v_cout)
+    dt_cout = np.diff(cout_tedges_days)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        q_cout = np.where(dt_cout > 0, dv_cout / dt_cout, 0.0)
+
+    n_cout = len(cout_tedges) - 1
+    n_cin = len(flow)
+    acc = np.zeros((n_cout, n_cin))
+    for i_pv, v_pore in enumerate(pv):
+        r_vpv = retardation * v_pore
+        ell = float(streamline_length[i_pv])
+        dm = float(molecular_diffusivity[i_pv])
+        al = float(longitudinal_dispersivity[i_pv])
+        velocity = q_cout * ell / v_pore
+        step_widths = (v_cout[:, None] - v_cin[None, :] - r_vpv) * ell / r_vpv
+        x_lo, x_hi = step_widths[:-1], step_widths[1:]
+        dx = x_hi - x_lo
+        if dm == 0.0 and al == 0.0:
+            with np.errstate(divide="ignore", invalid="ignore"):
+                frac = (np.maximum(x_hi, 0.0) - np.maximum(x_lo, 0.0)) / dx
+            frac = np.where(dx > 0.0, frac, 0.5 + 0.5 * np.sign(x_lo))
+        else:
+            xi = step_widths + ell
+            dt_var = np.maximum(dm * tau + al * np.maximum(xi, 0.0), _DT_FLOOR)
+            antideriv, s, gaussian = _breakthrough_antideriv(step_widths, dt_var)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                frac = np.where(dx > 0.0, np.diff(antideriv, axis=0) / dx, 0.0)
+            if retardation != 1.0 and dm > 0.0:
+                density_binavg = _retardation_excess_density(
+                    x_lo=x_lo,
+                    x_hi=x_hi,
+                    dx=dx,
+                    d_lo=dt_var[:-1],
+                    d_hi=dt_var[1:],
+                    s_lo=s[:-1],
+                    s_hi=s[1:],
+                    g_lo=gaussian[:-1],
+                    g_hi=gaussian[1:],
+                )
+                excess = np.where(velocity > 0.0, (retardation - 1.0) * dm / velocity, 0.0)
+                frac -= excess[:, None] * density_binavg
+        acc += frac[:, :-1] - frac[:, 1:]
+    return np.nan_to_num(acc / len(pv), nan=0.0)
 
 
 def _assert_banded_matches_dense(w_banded, w_dense, retardation):
@@ -2388,8 +2480,7 @@ def _assert_banded_matches_dense(w_banded, w_dense, retardation):
         np.testing.assert_array_equal(w_banded, w_dense)
     else:
         # R != 1: the closed-form retardation correction's erfcx tail is not bitwise zero, but is
-        # far below machine epsilon (measured well below 1e-100 where banding engages, exactly 0 on
-        # the single-PV rows). atol=1e-20 keeps enormous margin while still catching any genuinely
+        # far below machine epsilon. atol=1e-20 keeps margin while still catching any genuinely
         # dropped coefficient (an under-sized band drops O(1e-2..1e-4)).
         np.testing.assert_allclose(w_banded, w_dense, atol=1e-20, rtol=0.0)
 
@@ -2397,7 +2488,6 @@ def _assert_banded_matches_dense(w_banded, w_dense, retardation):
 @pytest.mark.parametrize(
     ("d_m", "alpha_l", "retardation"),
     [
-        (0.0, 0.0, 1.0),  # pure advection (routes to the dense step kernel; confirms routing)
         (0.05, 0.0, 1.0),  # weak molecular diffusion
         (2.0, 0.0, 1.0),  # strong molecular diffusion (wide band)
         (0.0, 2.0, 1.0),  # pure mechanical dispersion
@@ -2405,28 +2495,64 @@ def _assert_banded_matches_dense(w_banded, w_dense, retardation):
         (0.0, 2.0, 2.7),  # mechanical dispersion + retardation
     ],
 )
-def test_banded_equals_force_dense_single_pv(d_m, alpha_l, retardation):
-    """Banded build reproduces the dense build across dispersion/retardation regimes (single PV).
+def test_banded_equals_dense_single_pv(d_m, alpha_l, retardation):
+    """Densified banded build reproduces the full-width dense closed form across regimes (single PV).
 
-    Geometry (pv=200, L=60) is chosen so every dispersive row genuinely engages banding rather
-    than tripping the dense fallback -- in particular the R != 1 rows exercise the banded
-    retardation correction, not a dense-vs-dense tautology.
+    Geometry (pv=200, L=60) keeps every dispersive row's band narrow, so the banded path -- not a
+    near-full band -- is exercised, including the R != 1 retardation correction.
     """
     n = 120
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
     flow = np.full(n, 100.0)
-    w_banded, w_dense = _banded_and_dense_w(
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "pv": np.array([200.0]),
+        "length": 60.0,
+        "d_m": d_m,
+        "alpha_l": alpha_l,
+        "retardation": retardation,
+    }
+    w_banded = _banded_dense(**common, flow_out=flow)
+    w_dense = _dense_closed_form_w(**common, flow_out=flow)
+    _assert_banded_matches_dense(w_banded, w_dense, retardation)
+
+
+def test_banded_both_zero_equals_advection_step():
+    """Both-zero (D_m=0, alpha_L=0) forward equals a pure-advection step to ~1e-14.
+
+    The zero-dispersion case routes through the same banded path; D_t floors to ~1e-30 so C_F is a
+    step smoothed by ~1e-15. The densified band must reproduce the advection breakthrough operator,
+    whose entries are 0 or 1 on aligned grids.
+    """
+    n = 120
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    w_banded = _banded_dense(
         flow=flow,
         tedges=tedges,
         cout_tedges=tedges,
         pv=np.array([200.0]),
         length=60.0,
-        d_m=d_m,
-        alpha_l=alpha_l,
-        retardation=retardation,
+        d_m=0.0,
+        alpha_l=0.0,
+        retardation=1.0,
         flow_out=flow,
     )
-    _assert_banded_matches_dense(w_banded, w_dense, retardation)
+    # Pure-advection step reference: dense closed form's exact 0/1 breakthrough operator.
+    w_step = _dense_closed_form_w(
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        pv=np.array([200.0]),
+        length=60.0,
+        d_m=0.0,
+        alpha_l=0.0,
+        retardation=1.0,
+        flow_out=flow,
+    )
+    np.testing.assert_allclose(w_banded, w_step, atol=1e-15, rtol=0.0)
 
 
 def test_banded_variable_flow_wandering_center():
@@ -2434,17 +2560,18 @@ def test_banded_variable_flow_wandering_center():
     n = 120
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
     flow = 100.0 * (1.0 + 0.3 * np.sin(2 * np.pi * np.arange(n) / 30.0))
-    w_banded, w_dense = _banded_and_dense_w(
-        flow=flow,
-        tedges=tedges,
-        cout_tedges=tedges,
-        pv=np.array([500.0]),
-        length=30.0,
-        d_m=0.5,
-        alpha_l=1.0,
-        retardation=1.0,
-        flow_out=flow,
-    )
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "pv": np.array([500.0]),
+        "length": 30.0,
+        "d_m": 0.5,
+        "alpha_l": 1.0,
+        "retardation": 1.0,
+    }
+    w_banded = _banded_dense(**common, flow_out=flow)
+    w_dense = _dense_closed_form_w(**common, flow_out=flow)
     np.testing.assert_array_equal(w_banded, w_dense)
 
 
@@ -2453,26 +2580,27 @@ def test_banded_multipv_union_of_bands(retardation):
     """Each streamtube's band sits at a different cin offset; the accumulated band is their union.
 
     The R != 1 case also guards the per-tube ``np.add.at`` accumulation of retardation-corrected
-    bands -- a per-tube indexing error would corrupt the overlap.
+    bands into the union buffer -- a per-tube offset error would corrupt the overlap.
     """
     n = 120
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
     flow = np.full(n, 100.0)
-    w_banded, w_dense = _banded_and_dense_w(
-        flow=flow,
-        tedges=tedges,
-        cout_tedges=tedges,
-        pv=np.array([120.0, 200.0, 280.0]),
-        length=100.0,
-        d_m=1.0,
-        alpha_l=0.3,
-        retardation=retardation,
-        flow_out=flow,
-    )
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "pv": np.array([120.0, 200.0, 280.0]),
+        "length": 100.0,
+        "d_m": 1.0,
+        "alpha_l": 0.3,
+        "retardation": retardation,
+    }
+    w_banded = _banded_dense(**common, flow_out=flow)
+    w_dense = _dense_closed_form_w(**common, flow_out=flow)
     _assert_banded_matches_dense(w_banded, w_dense, retardation)
 
 
-def test_banded_nonuniform_cin_grid_equals_force_dense():
+def test_banded_nonuniform_cin_grid_equals_dense():
     """Non-uniform cin bins must not mis-size the band.
 
     The band edges are located by ``searchsorted`` on the cumulative-volume axis, not by a
@@ -2484,17 +2612,18 @@ def test_banded_nonuniform_cin_grid_equals_force_dense():
     tedges = pd.DatetimeIndex(pd.Timestamp("2020-01-01") + pd.to_timedelta(days, unit="D"))
     n = len(tedges) - 1
     flow = np.full(n, 100.0)
-    w_banded, w_dense = _banded_and_dense_w(
-        flow=flow,
-        tedges=tedges,
-        cout_tedges=tedges,
-        pv=np.array([800.0]),
-        length=60.0,
-        d_m=0.5,
-        alpha_l=1.0,
-        retardation=1.0,
-        flow_out=flow,
-    )
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "pv": np.array([800.0]),
+        "length": 60.0,
+        "d_m": 0.5,
+        "alpha_l": 1.0,
+        "retardation": 1.0,
+    }
+    w_banded = _banded_dense(**common, flow_out=flow)
+    w_dense = _dense_closed_form_w(**common, flow_out=flow)
     np.testing.assert_array_equal(w_banded, w_dense)
 
 
@@ -2509,28 +2638,29 @@ def test_banded_nonuniform_cin_grid_equals_force_dense():
         (0.001, 20.0, 50.0, 0.5, 100.0),
     ],
 )
-def test_banded_variable_flow_step_equals_force_dense(d_m, pv, length, flow_lo, flow_hi):
+def test_banded_variable_flow_step_equals_dense(d_m, pv, length, flow_lo, flow_hi):
     """Sharp flow step under-covers the band unless both conservative post bounds hold.
 
     The breakthrough at a cout bin in one flow era reaches injections from another era (different
     tau, hence different D_t), so a front-anchored band width would drop real coefficients. Both
     parameter rows would fail against an under-sized band (~1e-2..1e-4 error); the conservative
-    closed form must reproduce the dense build. Both engage banding (verified, not the fallback).
+    closed form must reproduce the full-width dense build.
     """
     n = 200
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
     flow = np.concatenate([np.full(n // 2, flow_lo), np.full(n - n // 2, flow_hi)])
-    w_banded, w_dense = _banded_and_dense_w(
-        flow=flow,
-        tedges=tedges,
-        cout_tedges=tedges,
-        pv=np.array([pv]),
-        length=length,
-        d_m=d_m,
-        alpha_l=0.0,
-        retardation=2.0,
-        flow_out=flow,
-    )
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "pv": np.array([pv]),
+        "length": length,
+        "d_m": d_m,
+        "alpha_l": 0.0,
+        "retardation": 2.0,
+    }
+    w_banded = _banded_dense(**common, flow_out=flow)
+    w_dense = _dense_closed_form_w(**common, flow_out=flow)
     _assert_banded_matches_dense(w_banded, w_dense, 2.0)
 
 
@@ -2560,3 +2690,225 @@ def test_banded_retardation_matches_diffusion_exact():
     valid = ~np.isnan(cout_fast) & ~np.isnan(cout_exact)
     assert np.sum(valid) > 50
     assert_allclose(cout_fast[valid], cout_exact[valid], atol=1e-12, rtol=0.0)
+
+
+def test_banded_forward_masking_matches_diffusion():
+    """Banded forward output values AND NaN (spin-up / out-of-range) mask match the slow quadrature.
+
+    Guards that the banded einsum and the total-coefficient masking reproduce the slow module's
+    finite/NaN pattern, not just the in-band values.
+    """
+    n = 150
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = 100.0 * (1.0 + 0.2 * np.sin(2 * np.pi * np.arange(n) / 40.0))
+    cin = np.sin(np.linspace(0, 8, n)) + 1.0
+    kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "aquifer_pore_volumes": np.array([300.0]),
+        "molecular_diffusivity": 0.5,
+        "longitudinal_dispersivity": 1.0,
+        "retardation_factor": 1.0,
+        "flow_out": flow,
+    }
+    cout_fast = infiltration_to_extraction(cin=cin, streamline_length=40.0, **kwargs)
+    kwargs_exact = {k: v for k, v in kwargs.items() if k != "flow_out"}
+    cout_exact = diffusion_exact(cin=cin, streamline_length=np.array([40.0]), **kwargs_exact)
+    np.testing.assert_array_equal(np.isnan(cout_fast), np.isnan(cout_exact))
+    valid = ~np.isnan(cout_fast)
+    assert np.sum(valid) > 50
+    assert_allclose(cout_fast[valid], cout_exact[valid], atol=1e-12, rtol=0.0)
+
+
+def test_banded_inverse_roundtrip_nonuniform_cin_and_cout():
+    """Inverse round-trip on NON-uniform cin AND non-uniform (misaligned, sub-bin) cout.
+
+    Builds cout via the forward banded operator and deconvolves with the banded inverse on a
+    non-uniform cout grid that REFINES the non-uniform cin grid (each cin bin split into halves,
+    plus a sub-bin first edge), so the system is well-determined. Exercises col_start / full_band
+    on grids where a fixed-width band would mis-align; the smooth interior recovers tightly.
+    """
+    cin_widths = np.tile([1, 1, 2, 3], 40)
+    cin_days = np.concatenate(([0], np.cumsum(cin_widths)))
+    tedges = pd.DatetimeIndex(pd.Timestamp("2020-01-01") + pd.to_timedelta(cin_days, unit="D"))
+    n = len(tedges) - 1
+    flow = np.full(n, 100.0)
+    cin_true = np.sin(np.linspace(0, 10, n)) + 2.0
+
+    # Non-uniform cout that refines cin (each cin edge plus its midpoint), so cout is finer than cin
+    # and the inverse is well-posed despite the misaligned, non-uniform layout.
+    mids = 0.5 * (cin_days[:-1] + cin_days[1:])
+    cout_days = np.unique(np.concatenate([cin_days.astype(float), mids]))
+    cout_tedges = pd.DatetimeIndex(pd.Timestamp("2020-01-01") + pd.to_timedelta(cout_days, unit="D"))
+    flow_out = np.full(len(cout_tedges) - 1, 100.0)
+
+    fwd_kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([500.0]),
+        "streamline_length": 50.0,
+        "molecular_diffusivity": 0.5,
+        "longitudinal_dispersivity": 1.0,
+        "flow_out": flow_out,
+    }
+    cout = infiltration_to_extraction(cin=cin_true, **fwd_kwargs)
+    cout_filled = np.nan_to_num(cout, nan=0.0)
+    cin_rec = extraction_to_infiltration(cout=cout_filled, regularization_strength=1e-10, **fwd_kwargs)
+
+    # The interior (away from spin-up edges) is well-constrained; check it is recovered.
+    finite = ~np.isnan(cin_rec)
+    interior = finite.copy()
+    interior[: n // 4] = False
+    interior[-n // 4 :] = False
+    assert np.sum(interior) > 20
+    assert_allclose(cin_rec[interior], cin_true[interior], atol=5e-3, rtol=0.0)
+
+
+@pytest.mark.parametrize("n_lead", [1, 5, 12, 30], ids=["lead1", "lead5", "lead12", "lead30"])
+@pytest.mark.parametrize(("d_m", "alpha_l"), [(0.1, 0.0), (2.0, 0.0), (0.05, 0.5)], ids=["dm0.1", "dm2", "dm_al"])
+def test_banded_leading_zero_flow_warm_start_equals_dense(n_lead, d_m, alpha_l):
+    """Leading zero-flow plateau + dispersion: the band keeps the warm-start data-start tail.
+
+    Regression for the banded under-coverage bug. With ``flow[:n_lead] == 0`` the cumulative volume
+    is flat over the leading edges, so the front search lands the local band one or more columns
+    inside the record while a genuine warm-start coefficient (large ``tau`` -> large ``D_t`` at cin
+    edge 0, magnitude up to ~0.47 per row) remains at column 0 and spreads across the leading
+    plateau. A band that did not reach column 0 dropped it (~0.3..0.5 error). The densified band must
+    reproduce the full-width dense closed form bit-for-bit.
+    """
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    flow[:n_lead] = 0.0
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "pv": np.array([300.0]),
+        "length": 50.0,
+        "d_m": d_m,
+        "alpha_l": alpha_l,
+        "retardation": 1.0,
+    }
+    w_banded = _banded_dense(**common, flow_out=flow)
+    w_dense = _dense_closed_form_w(**common, flow_out=flow)
+    np.testing.assert_array_equal(w_banded, w_dense)
+
+
+@pytest.mark.parametrize("retardation", [1.0, 2.0], ids=["R1", "R2"])
+def test_banded_band_sizing_misaligned_subbin_multipv(retardation):
+    """Band sizing on a misaligned, sub-bin cout grid (multi-PV, variable flow) equals the dense ref.
+
+    The cout grid is finer than -- and offset from -- the variable-flow cin grid, so each cout bin
+    straddles cin bins and the per-row band must track a non-integer front across multiple
+    streamtubes. R=1 is bit-identical to the full-width dense closed form; the R=2 erfcx retardation
+    tail sits far below machine epsilon (atol 1e-20). An under-sized band would drop O(1e-2..1e-4).
+    """
+    n = 120
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = 100.0 * (1.0 + 0.3 * np.sin(2 * np.pi * np.arange(n) / 25.0))
+    # Misaligned sub-bin cout: refine each cin bin into halves and offset the first edge.
+    cout_tedges = pd.date_range(tedges[0], tedges[-1], periods=2 * n + 1)
+    flow_out = np.repeat(flow, 2)
+    common = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "pv": np.array([200.0, 350.0, 500.0]),
+        "length": 50.0,
+        "d_m": 0.1,
+        "alpha_l": 0.5,
+        "retardation": retardation,
+    }
+    w_banded = _banded_dense(**common, flow_out=flow_out)
+    w_dense = _dense_closed_form_w(**common, flow_out=flow_out)
+    if retardation == 1.0:
+        np.testing.assert_array_equal(w_banded, w_dense)
+    else:
+        np.testing.assert_allclose(w_banded, w_dense, atol=1e-20, rtol=0.0)
+
+
+def test_leading_zero_flow_forward_matches_diffusion_exact():
+    """Forward with a leading zero-flow plateau + molecular diffusion matches the slow quadrature.
+
+    The leading ``n_lead`` zero-flow bins hold the cumulative volume flat; with ``D_m > 0`` the
+    warm-start constant breaks through the data-start edge with a large ``D_t``, contributing a
+    non-saturated coefficient at cin column 0. The banded build keeps it (regression for the
+    dropped-warm-start bug), so a constant ``cin`` -- whose flux concentration is itself a clean
+    Kreft-Zuber breakthrough -- reproduces ``gwtransport.diffusion`` to machine precision.
+    """
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    flow[:12] = 0.0
+    cin = np.ones(n)
+    kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "aquifer_pore_volumes": np.array([300.0]),
+        "molecular_diffusivity": 0.1,
+        "longitudinal_dispersivity": 0.0,
+        "retardation_factor": 1.0,
+    }
+    cout_fast = infiltration_to_extraction(cin=cin, streamline_length=50.0, **kwargs)
+    cout_exact = diffusion_exact(cin=cin, streamline_length=np.array([50.0]), **kwargs)
+    # NaN (spin-up / out-of-range) mask must match, and the finite breakthrough is bit-exact.
+    np.testing.assert_array_equal(np.isnan(cout_fast), np.isnan(cout_exact))
+    valid = ~np.isnan(cout_fast)
+    assert np.sum(valid) > 100
+    assert_allclose(cout_fast[valid], cout_exact[valid], atol=1e-12, rtol=0.0)
+
+
+def test_leading_zero_flow_inverse_finite_and_matches_dense_reverse():
+    """Inverse with a leading zero-flow plateau + molecular diffusion returns finite (no LinAlgError).
+
+    The warm-start data-start tail makes the forward operator carry negative coefficients at the
+    leading columns; their non-positive column sum left the banded normal equations indefinite,
+    crashing ``cholesky_banded``. The warm-start tail is decoupled before the solve, so the inverse
+    now returns a finite result with no exception, and the well-determined interior (away from the
+    unrecoverable spin-up nullspace) matches the slow-module reverse.
+    """
+    n = 200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    flow[:12] = 0.0
+    cin_true = 1.0 + 0.5 * np.sin(2 * np.pi * np.arange(n) / 40.0)
+    kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "aquifer_pore_volumes": np.array([300.0]),
+        "streamline_length": 50.0,
+        "molecular_diffusivity": 0.1,
+        "longitudinal_dispersivity": 0.0,
+        "retardation_factor": 1.0,
+    }
+    cout = infiltration_to_extraction(cin=cin_true, **kwargs)
+    cout_filled = np.nan_to_num(cout, nan=0.0)
+
+    with warn_module.catch_warnings():
+        warn_module.simplefilter("ignore")
+        cin_rec = extraction_to_infiltration(cout=cout_filled, regularization_strength=1e-10, **kwargs)
+        cin_ref = diffusion_exact_reverse(
+            cout=cout_filled,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([300.0]),
+            streamline_length=np.array([50.0]),
+            molecular_diffusivity=0.1,
+            longitudinal_dispersivity=0.0,
+            retardation_factor=1.0,
+        )
+
+    # No exception was raised, and the recovered signal is finite where defined (not all-NaN).
+    assert np.isfinite(cin_rec).any()
+    # The well-determined interior (away from the spin-up nullspace) matches the slow reverse.
+    interior = np.zeros(n, dtype=bool)
+    interior[n // 2 : n - 10] = True
+    both = interior & np.isfinite(cin_rec) & np.isfinite(cin_ref)
+    assert np.sum(both) > 50
+    assert_allclose(cin_rec[both], cin_ref[both], atol=1e-6, rtol=0.0)


### PR DESCRIPTION
## Summary

`diffusion_fast` built its coefficient matrix on a narrow breakthrough band but **scattered it into a dense `(n_cout, n_cin)` matrix**, then did a dense matvec forward and a dense SVD/Tikhonov inverse — O(N²) memory and ~O(N³) inverse. This replaces the dense storage with a **single banded layout** `(band_vals, col_start)`, bit-identical to the dense build.

- `_closed_form_coeff_matrix` now returns `(band_vals, col_start, valid_cout_bins)` via a two-pass union-band build over the pore-volume loop. The dense `_flux_breakthrough_fraction` kernel, `force_dense`, and the wide-band fallback are **removed** — a single banded path. Zero dispersion (`D_m = α_L = 0`) is handled exactly by the limit (`D_t` floors to `_DT_FLOOR`), so no separate step kernel is needed.
- Forward is a banded `einsum`; inverse normalizes valid rows to sum 1 and routes through `utils.solve_inverse_transport_banded`. A shared `_solve_reverse_banded` decouples the warm-start data-start tail so the banded normal equations stay positive definite.
- The band lower bound extends to the data-start column when the breakthrough is non-saturated there, so the **warm-start far-field tail (leading zero-flow + molecular diffusion) is never dropped**. `full_band` is bounded by the residence-time + dispersion spread in bins, **independent of record length** (measured: 9 for a typical case, 127 for heat + a 12-bin pump-off, flat across N=200→3200).
- `diffusion_fast_fast`'s reverse path shares the same banded build + solver.

### Accuracy
- **Forward: bit-exact** vs the previous dense build across single/multi-PV gamma, retardation R≠1, variable flow, and non-uniform cin **and** cout grids (incl. misaligned/sub-bin cout). Both-zero matches the advection step to ~1e-15.
- **Inverse:** recovers the dense Tikhonov solution to **machine precision in the recoverable region** (≤4e-14 across all regimes, including leading-zero + heat). The unrecoverable warm-start spin-up region — where the previous dense solver returned unconstrained values — is now returned as **NaN** (the one intentional behavior change).

### Performance (measured, end-to-end public API; old = dense, new = banded)

| N | forward | inverse | dense W |
|---:|---:|---:|---:|
| 1,000 | 1.6× | 48× | 8 MB |
| 2,000 | 2.6× | 329× | 32 MB |
| 4,000 | 4.5× | **1543×** (36.5 s → 24 ms) | 128 MB |
| 8,000 | 7.9× | OOM/intractable → 47 ms | 512 MB |

Forward grows ~linearly with N (old dense matvec+storage is O(N²)); inverse grows ~quadratically (dense SVD O(N³) → banded Cholesky O(N·band²)). Peak memory O(N²) → bounded few-MB.

## Test plan

- `pytest tests/src/test_diffusion_fast.py tests/src/test_diffusion_fast_fast.py` — **221 passed**.
- New tests: leading-zero-flow + warm-start band parity (bit-exact vs dense), misaligned/sub-bin cout band sizing (`atol=0`), leading-zero forward vs the slow quadrature module, leading-zero inverse finite/no-crash, both-zero step (`atol=1e-15`).
- Bit-exact oracle vs the previous dense build over a 960-case sweep (flow patterns incl. leading/trailing/mid zero, `D_m`∈{0,…,2}, `α_L`∈{0,0.5}, R∈{1,2}, aligned/non-uniform/misaligned cout).
- `ruff format` + `ruff check` clean; `ty check` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.