### PR TITLE
fix: handle cout_tedges/tedges datetime-unit mismatch in diffusion

### DIFF
--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -504,8 +504,15 @@ def _infiltration_to_extraction_coeff_matrix(
     # Compute the cumulative flow at tedges
     cumulative_volume_at_cin_tedges = cumulative_flow_volume(flow, dt_to_days(tedges))  # m3
 
-    # Compute the cumulative flow at cout_tedges
-    cumulative_volume_at_cout_tedges = np.interp(cout_tedges, tedges, cumulative_volume_at_cin_tedges).astype(float)
+    # Compute the cumulative flow at cout_tedges. Both edge arrays are first reduced to a shared
+    # day axis: np.interp coerces each datetime64 operand to int64 in its own resolution, so a
+    # cout_tedges / tedges unit mismatch (e.g. ns vs us) would send every query out of range and
+    # silently return all-NaN.
+    tedges_days_arr = tedges_to_days(tedges)
+    cout_tedges_days = tedges_to_days(cout_tedges, ref=tedges[0])
+    cumulative_volume_at_cout_tedges = np.interp(
+        cout_tedges_days, tedges_days_arr, cumulative_volume_at_cin_tedges
+    ).astype(float)
 
     # Compute residence time at cout_tedges to identify valid output bins
     # RT is NaN for cout_tedges beyond the input data range
@@ -527,9 +534,6 @@ def _infiltration_to_extraction_coeff_matrix(
 
     # Determine when infiltration has occurred: cout_tedge must be >= tedge (infiltration time)
     isactive = cout_tedges.to_numpy()[:, None] >= tedges.to_numpy()[None, :]
-
-    # Convert tedges to days for volume→time interpolation
-    tedges_days_arr = tedges_to_days(tedges)
 
     # Loop over each pore volume
     for i_pv in range(len(aquifer_pore_volumes)):

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -2415,3 +2415,30 @@ def test_validate_diffusion_inputs_raises_on_bad_input(path, mutate, match_regex
     bad = mutate(_good_diffusion_inputs())
     with pytest.raises(ValueError, match=match_regex):
         _validate_diffusion_inputs(**bad)
+
+
+def test_cout_tedges_unit_mismatch_matches_aligned():
+    """cout_tedges in a different datetime64 resolution than tedges gives the same result.
+
+    The cumulative-volume interpolation reduces both edge arrays to a shared day axis; a
+    regression where np.interp received the raw datetime64 arrays silently returned all-NaN
+    when cout_tedges and tedges carried different units (e.g. ns vs us).
+    """
+    n = 60
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D").as_unit("us")
+    # Same instants, nanosecond resolution.
+    cout_tedges_ns = pd.DatetimeIndex(pd.to_datetime(tedges.values).as_unit("ns"))
+    kwargs = {
+        "cin": np.full(n, 5.0),
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "aquifer_pore_volumes": np.array([300.0]),
+        "streamline_length": 50.0,
+        "molecular_diffusivity": 1e-3,
+        "longitudinal_dispersivity": 0.5,
+    }
+    aligned = infiltration_to_extraction(cout_tedges=tedges, **kwargs)
+    mismatched = infiltration_to_extraction(cout_tedges=cout_tedges_ns, **kwargs)
+
+    assert np.isfinite(mismatched).sum() == np.isfinite(aligned).sum() > 0
+    np.testing.assert_array_equal(mismatched, aligned)


### PR DESCRIPTION
## Summary

`diffusion._compute_coefficient_matrix` interpolated the cumulative through-flow volume onto `cout_tedges` by passing the **raw `datetime64` arrays** to `np.interp`. `np.interp` reduces each operand to `int64` in its *own* resolution, so when `cout_tedges` and `tedges` carried different units (e.g. `ns` vs `us`) every query fell outside the reference range and the output was **silently all-NaN**.

Fix: reduce both edge arrays to a shared day axis (`tedges_to_days` with a common `ref`) before interpolating — the same pattern the advection builder already uses. The now-duplicate `tedges_to_days(tedges)` call further down is dropped.

This was found while auditing the diffusion modules for banded-operator opportunities; it is independent of that work.

## Test plan

- New regression test `test_cout_tedges_unit_mismatch_matches_aligned`: same instants with `cout_tedges` in `ns` and `tedges` in `us` now produce output **bit-identical** to the aligned-unit case (`assert_array_equal`), where before the mismatched case was all-NaN.
- `pytest tests/src/test_diffusion.py` — **93 passed**.
- `ruff format` + `ruff check` clean; `ty check` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.