### PR TITLE
docs: add leanness guidelines to CLAUDE.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,6 +57,8 @@ You are a quality gatekeeper, not just an implementer. Before writing code:
 - **Line length**: 120 characters.
 - **Type hints**: Required for all public functions. Use `npt.ArrayLike` for array inputs, `npt.NDArray[np.floating]` for array outputs, `pd.DatetimeIndex` for time edges. Use built-in Python generics (`list`, `tuple`, `dict`, `X | None`) -- NEVER import from `typing`.
 - **Vectorization**: ALWAYS prefer vectorized NumPy/SciPy/pandas operations over Python for-loops. If you find yourself writing a loop over array elements, stop and find the vectorized equivalent.
+- **Leanness -- one path**: Avoid alternative code paths for special cases that the main computation already handles. Prefer a single general path; only branch when a case genuinely cannot be expressed by the general one (e.g. a different solver that requires a different layout), and then adapt at that boundary rather than duplicating the computation.
+- **Leanness -- no cruft**: Don't introduce small helper functions used only once or twice -- inline them. Don't keep legacy functions out of obligation; delete them (this package has no backwards-compatibility requirement, so there are no shims, aliases, or deprecated paths to preserve).
 - **Formatting**: Enforced by linting with ruff and prettier. Do not fight the formatter.
 - **Parameter names**: Use descriptive names consistent with domain conventions. For example, use `flow` for flow rate, `cin`/`cout` for concentrations, `tedges` for time edges, `xedges` for spatial edges.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ You are a quality gatekeeper, not just an implementer. Before writing code:
 - **Line length**: 120 characters.
 - **Type hints**: Required for all public functions. Use `npt.ArrayLike` for array inputs, `npt.NDArray[np.floating]` for array outputs, `pd.DatetimeIndex` for time edges. Use built-in Python generics (`list`, `tuple`, `dict`, `X | None`) -- NEVER import from `typing`.
 - **Vectorization**: ALWAYS prefer vectorized NumPy/SciPy/pandas operations over Python for-loops. If you find yourself writing a loop over array elements, stop and find the vectorized equivalent.
+- **Leanness -- one path**: Avoid alternative code paths for special cases that the main computation already handles. Prefer a single general path; only branch when a case genuinely cannot be expressed by the general one (e.g. a different solver that requires a different layout), and then adapt at that boundary rather than duplicating the computation.
+- **Leanness -- no cruft**: Don't introduce small helper functions used only once or twice -- inline them. Don't keep legacy functions out of obligation; delete them (this package has no backwards-compatibility requirement, so there are no shims, aliases, or deprecated paths to preserve).
 - **Formatting**: Enforced by linting with ruff and prettier. Do not fight the formatter.
 - **Parameter names**: Use descriptive names consistent with domain conventions. For example, use `flow` for flow rate, `cin`/`cout` for concentrations, `tedges` for time edges, `xedges` for spatial edges.
 


### PR DESCRIPTION
## Summary

Adds two code-style principles to `CLAUDE.md`:

- **Leanness — one path**: avoid alternative code paths for special cases the main computation already handles; prefer a single general path and adapt at a boundary only when a case genuinely cannot be expressed by the general one.
- **Leanness — no cruft**: don't introduce small helper functions used only once or twice (inline them); don't keep legacy functions out of obligation (no backwards-compatibility requirement, so no shims/aliases/deprecated paths).

## Test plan

- Documentation-only change. `prettier --check CLAUDE.md` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.