### PR TITLE
feat(residence_time): exact closed-form gamma-APVD mean residence time

### DIFF
--- a/docs/source/user_guide/assumptions.rst
+++ b/docs/source/user_guide/assumptions.rst
@@ -21,7 +21,7 @@ Module Reference
    * - ``advection``
      - :py:func:`~gwtransport.advection.gamma_infiltration_to_extraction`, :py:func:`~gwtransport.advection.infiltration_to_extraction`, :py:func:`~gwtransport.advection.infiltration_to_extraction_nonlinear_sorption`
    * - ``residence_time``
-     - :py:func:`~gwtransport.residence_time.residence_time_full`, :py:func:`~gwtransport.residence_time.residence_time_series`, :py:func:`~gwtransport.residence_time.freundlich_retardation`
+     - :py:func:`~gwtransport.residence_time.residence_time_full`, :py:func:`~gwtransport.residence_time.residence_time_series`, :py:func:`~gwtransport.residence_time.gamma_residence_time`, :py:func:`~gwtransport.residence_time.freundlich_retardation`
    * - ``deposition``
      - :py:func:`~gwtransport.deposition.deposition_to_extraction`, :py:func:`~gwtransport.deposition.extraction_to_deposition`
    * - ``logremoval``
@@ -301,7 +301,7 @@ Model Parameterization Assumptions
 
 - :py:func:`~gwtransport.advection.gamma_infiltration_to_extraction`, :py:func:`~gwtransport.advection.infiltration_to_extraction`
 - :py:func:`~gwtransport.advection.gamma_extraction_to_infiltration`, :py:func:`~gwtransport.advection.extraction_to_infiltration`
-- :py:func:`~gwtransport.residence_time.residence_time_full`, :py:func:`~gwtransport.residence_time.residence_time_series`
+- :py:func:`~gwtransport.residence_time.residence_time_full`, :py:func:`~gwtransport.residence_time.residence_time_series`, :py:func:`~gwtransport.residence_time.gamma_residence_time`
 - :py:func:`~gwtransport.deposition.deposition_to_extraction`, :py:func:`~gwtransport.deposition.extraction_to_deposition`
 - :py:func:`~gwtransport.diffusion_fast.infiltration_to_extraction`
 

--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -20,6 +20,10 @@ Available functions:
   volume. Sampling at arbitrary instants departs from the bin-edge convention, so it is kept
   separate from :func:`residence_time_full`. Same directional options.
 
+- :func:`gamma_residence_time` - Compute the mean residence time over output bins for a
+  (shifted) gamma aquifer pore-volume distribution, in closed form (no pore-volume binning).
+  Collapses the pore-volume axis to a single per-bin series.
+
 - :func:`fraction_explained` - Compute fraction of aquifer pore volumes with valid residence
   times. Indicates how many pore volumes have sufficient flow history to compute residence time.
   Returns values in [0, 1] where 1.0 means all volumes are fully informed. Useful for assessing
@@ -32,9 +36,15 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
+from scipy.stats import gamma as gamma_dist
 
 from gwtransport._time import tedges_to_days
+from gwtransport.gamma import parse_parameters
 from gwtransport.utils import cumulative_flow_volume, linear_average, linear_interpolate
+
+# Upper gamma quantile used as a finite support cap for the closed-form APVD integral;
+# the dropped tail mass (~1e-13) is far below the discretization error it replaces.
+_GAMMA_SUPPORT_TAIL = 1e-13
 
 
 def residence_time_series(
@@ -294,6 +304,218 @@ def residence_time_full(
     bins_within = (tedges_out_days[:-1] >= flow_tedges_days[0]) & (tedges_out_days[1:] <= flow_tedges_days[-1])
     if not np.all(bins_within):
         result = np.where(bins_within[None, :], result, np.nan)
+    return result
+
+
+def gamma_residence_time(
+    *,
+    flow: npt.ArrayLike,
+    flow_tedges: pd.DatetimeIndex | np.ndarray,
+    tedges_out: pd.DatetimeIndex | np.ndarray,
+    mean: float | None = None,
+    std: float | None = None,
+    loc: float = 0.0,
+    alpha: float | None = None,
+    beta: float | None = None,
+    direction: str = "extraction_to_infiltration",
+    retardation_factor: float = 1.0,
+) -> npt.NDArray[np.floating]:
+    r"""
+    Compute the mean residence time over output bins for a (shifted) gamma APVD.
+
+    The expectation over the aquifer pore-volume distribution (APVD) is taken in closed form,
+    so there is no discretization into pore-volume bins and no ``n_bins`` accuracy/cost knob.
+    The result is a single series -- the APVD-mean residence time per output bin -- not a
+    per-pore-volume array. The pore-volume distribution is a (shifted) gamma parameterized by
+    either ``(mean, std, loc)`` or ``(alpha, beta, loc)``.
+
+    The bin mean is flow-weighted (uniform in cumulative volume), matching the bin-edge
+    convention of the package. The single-streamtube residence time is piecewise-linear in
+    the pore volume :math:`V_p`, so its per-bin time integral is piecewise-quadratic in
+    :math:`V_p`, and the bin mean is the ratio of two closed-form integrals against the gamma
+    density (its zeroth, first and second partial moments). Forming the ratio once, after
+    integrating, keeps the result exact in the spin-up zone where only part of the APVD has
+    sufficient flow history (the covered sub-mass renormalizes the mean, matching a
+    pore-volume-resolved ``nanmean`` in the limit of infinite resolution).
+
+    Parameters
+    ----------
+    flow : array-like
+        Flow rate of water in the aquifer [m3/day]. Length matches ``flow_tedges`` minus one.
+    flow_tedges : array-like
+        Time edges for the flow data, as datetime64 objects, defining the flow intervals.
+    tedges_out : array-like
+        Output time edges as datetime64 objects; ``n + 1`` edges define ``n`` output bins.
+    mean : float, optional
+        Mean of the gamma APVD [m3]. Must be strictly greater than ``loc``. Provide either
+        ``(mean, std)`` or ``(alpha, beta)``.
+    std : float, optional
+        Standard deviation of the gamma APVD [m3]. Must be positive.
+    loc : float, optional
+        Location (lower bound of support) of the gamma APVD [m3]; a guaranteed minimum pore
+        volume. Must satisfy ``0 <= loc < mean``. Default is 0.0.
+    alpha : float, optional
+        Shape parameter of the gamma APVD (must be > 0).
+    beta : float, optional
+        Scale parameter of the gamma APVD (must be > 0).
+    direction : {'extraction_to_infiltration', 'infiltration_to_extraction'}, optional
+        Direction of the flow calculation:
+        * 'extraction_to_infiltration': how many days ago was the extracted water infiltrated
+        * 'infiltration_to_extraction': how many days until the infiltrated water is extracted
+        Default is 'extraction_to_infiltration'.
+    retardation_factor : float, optional
+        Retardation factor of the compound in the aquifer [dimensionless]. Default is 1.0.
+
+    Returns
+    -------
+    numpy.ndarray
+        APVD-mean residence time [days], shape ``(n_output_bins,)``. Output bins outside the
+        flow record (or with no covered pore-volume sub-mass) are NaN.
+
+    Raises
+    ------
+    ValueError
+        If ``flow_tedges`` does not have exactly one more element than ``flow``. If
+        ``direction`` is not ``'extraction_to_infiltration'`` or
+        ``'infiltration_to_extraction'``. If gamma parameter validation in
+        :func:`gwtransport.gamma.parse_parameters` fails.
+
+    See Also
+    --------
+    residence_time_full : Per-pore-volume mean residence time over output bins
+    gwtransport.gamma.bins : Discretize a gamma APVD into pore-volume bins
+    :ref:`concept-residence-time` : Time in aquifer between infiltration and extraction
+    :ref:`concept-gamma-distribution` : Two-parameter pore volume model
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from gwtransport.residence_time import gamma_residence_time
+    >>> flow_dates = pd.date_range(start="2023-01-01", end="2023-02-10", freq="D")
+    >>> flow_values = np.full(len(flow_dates) - 1, 100.0)  # 100 m³/day
+    >>> tau_bar = gamma_residence_time(
+    ...     flow=flow_values,
+    ...     flow_tedges=flow_dates,
+    ...     tedges_out=flow_dates,
+    ...     mean=500.0,
+    ...     std=100.0,
+    ...     direction="extraction_to_infiltration",
+    ... )
+    >>> # Deep in the record the mean residence time approaches mean / flow = 5 days
+    >>> float(np.round(tau_bar[-1], 6))
+    5.0
+    """
+    if direction not in {"extraction_to_infiltration", "infiltration_to_extraction"}:
+        msg = "direction should be 'extraction_to_infiltration' or 'infiltration_to_extraction'"
+        raise ValueError(msg)
+
+    alpha, beta, loc = parse_parameters(mean=mean, std=std, loc=loc, alpha=alpha, beta=beta)
+    flow = np.asarray(flow, dtype=float)
+    flow_tedges = pd.DatetimeIndex(flow_tedges)
+    tedges_out = pd.DatetimeIndex(tedges_out)
+    n_out = len(tedges_out) - 1
+
+    if len(flow_tedges) != len(flow) + 1:
+        msg = "tedges must have one more element than flow"
+        raise ValueError(msg)
+    if np.any(flow < 0) or np.any(np.isnan(flow)):
+        return np.full(n_out, np.nan)
+
+    sign = -1.0 if direction == "extraction_to_infiltration" else 1.0
+    r = retardation_factor
+
+    td = tedges_to_days(flow_tedges)
+    flow_cum = cumulative_flow_volume(flow, np.diff(td), strictly_monotone=True)
+    flow_rate = (flow_cum[1:] - flow_cum[:-1]) / (td[1:] - td[:-1])
+    v_end = flow_cum[-1]
+    # Phi(v) = int_0^v T(w) dw with T the inverse cumulative-volume map (piecewise-linear);
+    # Phi is piecewise-quadratic with knots at flow_cum.
+    seg_integral = td[:-1] * (flow_cum[1:] - flow_cum[:-1]) + (flow_cum[1:] - flow_cum[:-1]) ** 2 / (2 * flow_rate)
+    phi_knot = np.concatenate([[0.0], np.cumsum(seg_integral)])
+
+    tedges_out_days = tedges_to_days(tedges_out, ref=flow_tedges[0])
+    vol_out = linear_interpolate(x_ref=td, y_ref=flow_cum, x_query=tedges_out_days, left=np.nan, right=np.nan)
+    support_hi = loc + gamma_dist.ppf(1 - _GAMMA_SUPPORT_TAIL, alpha, scale=beta)
+
+    def phi(v: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
+        v = np.clip(v, 0.0, v_end)
+        j = np.clip(np.searchsorted(flow_cum, v, side="right") - 1, 0, len(flow_rate) - 1)
+        dv = v - flow_cum[j]
+        return phi_knot[j] + td[j] * dv + dv * dv / (2 * flow_rate[j])
+
+    def partial_moments(lo: np.ndarray, hi: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        # zeroth/first/second partial moments of the shifted gamma over [lo, hi] in V_p
+        def cdf(shape: float, x: np.ndarray) -> np.ndarray:
+            return gamma_dist.cdf(np.maximum(x - loc, 0.0), shape, scale=beta)
+
+        m0 = cdf(alpha, hi) - cdf(alpha, lo)
+        d1 = cdf(alpha + 1, hi) - cdf(alpha + 1, lo)
+        m1 = alpha * beta * d1 + loc * m0
+        d2 = cdf(alpha + 2, hi) - cdf(alpha + 2, lo)
+        m2 = alpha * (alpha + 1) * beta**2 * d2 + 2 * loc * alpha * beta * d1 + loc * loc * m0
+        return m0, m1, m2
+
+    result = np.full(n_out, np.nan)
+    for b in range(n_out):
+        v_lo, v_hi = vol_out[b], vol_out[b + 1]
+        if not (np.isfinite(v_lo) and np.isfinite(v_hi)) or v_hi <= v_lo:
+            continue
+
+        # V_p breakpoints where a Phi argument (clipped look-back/forward limit) crosses a flow
+        # edge or a validity bound; a superset covering both directions is safe (an extra
+        # breakpoint merely splits one quadratic piece into two with the same integral).
+        candidates = np.concatenate([
+            (v_hi - flow_cum) / r,
+            (flow_cum - v_hi) / r,
+            (v_lo - flow_cum) / r,
+            (flow_cum - v_lo) / r,
+            flow_cum / r,
+            (v_end - flow_cum) / r,
+            [v_lo / r, v_hi / r, (v_end - v_lo) / r, (v_end - v_hi) / r],
+        ])
+        candidates = candidates[(candidates > 0.0) & (candidates < support_hi) & np.isfinite(candidates)]
+        edges_vp = np.unique(np.concatenate([[0.0], candidates, [support_hi]]))
+        lo, hi = edges_vp[:-1], edges_vp[1:]
+        mid = 0.5 * (lo + hi)
+        half = 0.5 * (hi - lo)
+
+        # Evaluate the per-V_p bin integral g(V_p) = int_bin tau dv and the valid length l(V_p)
+        # at the three quadrature nodes (piece lo / mid / hi) at once; g is quadratic and l
+        # linear per piece. tau integrals are differences of Phi (the antiderivative of T).
+        vp3 = np.concatenate([lo, mid, hi])
+        if sign < 0:  # extraction_to_infiltration: look back, valid where a = v - r*V_p >= 0
+            v_start = np.maximum(v_lo, r * vp3)
+            length3 = np.maximum(v_hi - v_start, 0.0)
+            g3 = (phi(np.full_like(vp3, v_hi)) - phi(v_start)) - (
+                phi(v_hi - r * vp3) - phi(np.maximum(v_lo - r * vp3, 0.0))
+            )
+        else:  # infiltration_to_extraction: look forward, valid where a = v + r*V_p <= v_end
+            v_stop = np.minimum(v_hi, v_end - r * vp3)
+            length3 = np.maximum(v_stop - v_lo, 0.0)
+            g3 = (phi(np.minimum(v_hi + r * vp3, v_end)) - phi(v_lo + r * vp3)) - (
+                phi(v_stop) - phi(np.full_like(vp3, v_lo))
+            )
+        g3 = np.where(length3 > 0, g3, 0.0)
+        length3 = np.where(length3 > 0, length3, 0.0)
+        n_piece = len(lo)
+        g_lo, g_mid, g_hi = g3[:n_piece], g3[n_piece : 2 * n_piece], g3[2 * n_piece :]
+        l_lo, l_mid, l_hi = length3[:n_piece], length3[n_piece : 2 * n_piece], length3[2 * n_piece :]
+        m0, m1, m2 = partial_moments(lo, hi)
+
+        # G is quadratic per piece, L linear; write both centred at mid and contract with the
+        # partial moments: int x^k f over [lo, hi] = m_k, so int (a(x-mid)^2 + b(x-mid) + c) f
+        # = a (m2 - 2 mid m1 + mid^2 m0) + b (m1 - mid m0) + c m0.
+        safe = half > 0
+        g_a = np.where(safe, (g_lo - 2 * g_mid + g_hi) / (2 * half**2), 0.0)
+        g_b = np.where(safe, (g_hi - g_lo) / (2 * half), 0.0)
+        int_g = g_a * (m2 - 2 * mid * m1 + mid**2 * m0) + g_b * (m1 - mid * m0) + g_mid * m0
+        l_b = np.where(safe, (l_hi - l_lo) / (2 * half), 0.0)
+        int_l = l_b * (m1 - mid * m0) + l_mid * m0
+
+        covered = np.sum(int_l)
+        if covered > 0:
+            result[b] = np.sum(int_g) / covered
     return result
 
 

--- a/tests/src/test_gamma_residence_time.py
+++ b/tests/src/test_gamma_residence_time.py
@@ -1,0 +1,132 @@
+import numpy as np
+import pandas as pd
+import pytest
+from scipy.integrate import quad
+from scipy.stats import gamma as gamma_dist
+
+from gwtransport.residence_time import gamma_residence_time, residence_time_full
+
+DIRECTIONS = ["extraction_to_infiltration", "infiltration_to_extraction"]
+
+
+def _constant_flow(n_days=40, q=100.0):
+    tedges = pd.date_range("2023-01-01", periods=n_days + 1, freq="D")
+    return np.full(n_days, q), tedges
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+@pytest.mark.parametrize(("mean", "std", "loc", "r"), [(300.0, 80.0, 0.0, 1.0), (250.0, 60.0, 90.0, 2.0)])
+def test_constant_flow_deep_bin_equals_analytic(direction, mean, std, loc, r):
+    """Fully-informed bins under constant flow: tau_bar = R * mean / Q to machine precision.
+
+    With constant flow the residence time of every streamtube is ``R * V_p / Q`` regardless of
+    time, so the APVD mean collapses to ``R * E[V_p] / Q = R * mean / Q``. The tiny residual is
+    the gamma tail truncated at a high quantile, far below any discretization error.
+    """
+    q = 100.0
+    flow, tedges = _constant_flow(q=q)
+    tau = gamma_residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        mean=mean,
+        std=std,
+        loc=loc,
+        direction=direction,
+        retardation_factor=r,
+    )
+    deep = tau[-1] if direction == "extraction_to_infiltration" else tau[0]
+    np.testing.assert_allclose(deep, r * mean / q, atol=0, rtol=1e-11)
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_spinup_partial_bin_matches_direct_integral(direction):
+    """In the spin-up zone the covered-sub-mass renormalization equals a direct 2-D integral.
+
+    Only streamtubes with enough flow history contribute; the mean is the flow-and-coverage
+    weighted ratio of two integrals, not an average of the per-instant ratio. The reference
+    integrates ``tau(V_p) = R * V_p / Q`` (constant flow) over the covered length per V_p.
+    """
+    q, mean, std, r, n = 100.0, 600.0, 200.0, 2.0, 40  # r != 1 exercises the coverage clamp
+    flow, tedges = _constant_flow(n_days=n, q=q)
+    tau = gamma_residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        mean=mean,
+        std=std,
+        direction=direction,
+        retardation_factor=r,
+    )
+    alpha, beta = (mean / std) ** 2, std**2 / mean
+    v_end = q * n
+    b = 4 if direction == "extraction_to_infiltration" else n - 5  # a partially-covered bin
+    v_lo, v_hi = q * b, q * (b + 1)
+
+    def covered_length(vp):
+        if direction == "extraction_to_infiltration":
+            return max(v_hi - max(v_lo, r * vp), 0.0)
+        return max(min(v_hi, v_end - r * vp) - v_lo, 0.0)
+
+    hi = gamma_dist.ppf(1 - 1e-12, alpha, scale=beta)
+    num, _ = quad(
+        lambda vp: (r * vp / q) * covered_length(vp) * gamma_dist.pdf(vp, alpha, scale=beta), 0, hi, limit=200
+    )
+    den, _ = quad(lambda vp: covered_length(vp) * gamma_dist.pdf(vp, alpha, scale=beta), 0, hi, limit=200)
+    np.testing.assert_allclose(tau[b], num / den, rtol=1e-9)
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_narrow_gamma_reduces_to_single_pore_volume(direction):
+    """A near-degenerate gamma (std -> 0) reduces to the single-pore-volume bin mean.
+
+    Because the residence time is piecewise-linear in V_p, the mean over a narrow distribution
+    centred at ``mean`` equals the residence time at ``mean`` -- i.e. ``residence_time_full`` for
+    a single pore volume. This cross-checks the closed form against the per-pore-volume path.
+    """
+    rng = np.random.default_rng(0)
+    n = 40
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.clip(100 * (1 + 0.3 * np.sin(np.arange(n) / 9)) + rng.normal(0, 4, n), 5, None)
+    mean = 433.0  # generic value, not on a flow-edge breakpoint
+    # std small enough that the std -> 0 limit is reached to ~3e-9 (residual scales with std^2);
+    # loc != 0 exercises the loc shift in the partial moments.
+    tau = gamma_residence_time(
+        flow=flow, flow_tedges=tedges, tedges_out=tedges, mean=mean, std=0.05, loc=120.0, direction=direction
+    )
+    ref = residence_time_full(
+        flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=mean, direction=direction
+    )[0]
+    mask = np.isfinite(tau) & np.isfinite(ref)
+    assert mask.sum() > n // 2
+    np.testing.assert_allclose(tau[mask], ref[mask], atol=1e-7, rtol=1e-7)
+
+
+def test_alpha_beta_matches_mean_std():
+    """The (alpha, beta) parameterization matches the equivalent (mean, std) one exactly."""
+    flow, tedges = _constant_flow()
+    mean, std = 350.0, 90.0
+    alpha, beta = (mean / std) ** 2, std**2 / mean
+    by_moments = gamma_residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, mean=mean, std=std)
+    by_shape = gamma_residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, alpha=alpha, beta=beta)
+    np.testing.assert_allclose(by_moments, by_shape, atol=0, rtol=1e-12, equal_nan=True)
+
+
+def test_invalid_direction_raises():
+    flow, tedges = _constant_flow()
+    with pytest.raises(ValueError, match="direction"):
+        gamma_residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, mean=300.0, std=80.0, direction="bad")
+
+
+def test_requires_gamma_parameters():
+    flow, tedges = _constant_flow()
+    with pytest.raises(ValueError):
+        gamma_residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges)
+
+
+def test_bins_outside_record_are_nan():
+    """Output bins extending beyond the flow record are NaN, like residence_time_full."""
+    flow, tedges = _constant_flow(n_days=20)
+    tedges_out = pd.date_range("2023-01-01", periods=31, freq="D")  # 10 days past the record
+    tau = gamma_residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges_out, mean=300.0, std=80.0)
+    assert np.isnan(tau[-1])


### PR DESCRIPTION
## Summary

Adds `gamma_residence_time`: the **exact** mean residence time per output bin over a (shifted) gamma aquifer pore-volume distribution, in closed form — no discretization into pore-volume bins and no `n_bins` accuracy/cost knob (Example 02 currently uses `n_bins=1000` "for accuracy" then `np.nanmean`).

The single-streamtube residence time is piecewise-linear in the pore volume `V_p`, so its per-bin time integral is piecewise-quadratic in `V_p`. The flow-weighted bin mean is the ratio of two closed-form integrals against the gamma density (its 0th/1st/2nd partial moments via the regularized incomplete gamma). Numerator and denominator are integrated separately and divided **once**, which keeps the result exact in the spin-up zone where only part of the distribution has sufficient flow history (the covered sub-mass renormalizes the mean). Both directions, retardation, and `loc` are supported. Returns a 1-D series (the pore-volume axis is collapsed analytically).

Builds on the renamed API from #245.

## Test plan

`tests/src/test_gamma_residence_time.py` (12 tests, ~3 s) with independent exact oracles:
- constant flow → `tau_bar = R·mean/Q` (both directions, with `loc` and `R`), machine precision;
- spin-up partial bin vs a direct `scipy.quad` 2-D integral (both directions, `R=2`);
- near-degenerate gamma (`std→0`, `loc≠0`) reduces to `residence_time_full` for a single pore volume;
- `(alpha,beta)` vs `(mean,std)` parameterizations agree; parameter/edge validation; out-of-record bins are NaN.

The closed form matches a per-bin prototype to 6.7e-14 and a dense 2-D reference converges to it. Full suite: `pytest tests/src` — 1506 passed, 2 skipped. `ruff`, `ty` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.