### PR TITLE
feat(residence_time): vectorized gamma-APVD mean + discrete mean + spin-up policy

### DIFF
--- a/docs/source/user_guide/assumptions.rst
+++ b/docs/source/user_guide/assumptions.rst
@@ -21,7 +21,7 @@ Module Reference
    * - ``advection``
      - :py:func:`~gwtransport.advection.gamma_infiltration_to_extraction`, :py:func:`~gwtransport.advection.infiltration_to_extraction`, :py:func:`~gwtransport.advection.infiltration_to_extraction_nonlinear_sorption`
    * - ``residence_time``
-     - :py:func:`~gwtransport.residence_time.residence_time_full`, :py:func:`~gwtransport.residence_time.residence_time_series`, :py:func:`~gwtransport.residence_time.gamma_residence_time`, :py:func:`~gwtransport.residence_time.freundlich_retardation`
+     - :py:func:`~gwtransport.residence_time.residence_time`, :py:func:`~gwtransport.residence_time.gamma_residence_time`, :py:func:`~gwtransport.residence_time.residence_time_full`, :py:func:`~gwtransport.residence_time.residence_time_series`, :py:func:`~gwtransport.residence_time.freundlich_retardation`
    * - ``deposition``
      - :py:func:`~gwtransport.deposition.deposition_to_extraction`, :py:func:`~gwtransport.deposition.extraction_to_deposition`
    * - ``logremoval``
@@ -301,7 +301,7 @@ Model Parameterization Assumptions
 
 - :py:func:`~gwtransport.advection.gamma_infiltration_to_extraction`, :py:func:`~gwtransport.advection.infiltration_to_extraction`
 - :py:func:`~gwtransport.advection.gamma_extraction_to_infiltration`, :py:func:`~gwtransport.advection.extraction_to_infiltration`
-- :py:func:`~gwtransport.residence_time.residence_time_full`, :py:func:`~gwtransport.residence_time.residence_time_series`, :py:func:`~gwtransport.residence_time.gamma_residence_time`
+- :py:func:`~gwtransport.residence_time.residence_time`, :py:func:`~gwtransport.residence_time.gamma_residence_time`, :py:func:`~gwtransport.residence_time.residence_time_full`, :py:func:`~gwtransport.residence_time.residence_time_series`
 - :py:func:`~gwtransport.deposition.deposition_to_extraction`, :py:func:`~gwtransport.deposition.extraction_to_deposition`
 - :py:func:`~gwtransport.diffusion_fast.infiltration_to_extraction`
 

--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -20,20 +20,59 @@ Available functions:
   volume. Sampling at arbitrary instants departs from the bin-edge convention, so it is kept
   separate from :func:`residence_time_full`. Same directional options.
 
-- :func:`residence_time` - Compute the mass-weighted mean residence time over output bins for a
-  discrete aquifer pore-volume distribution (an array of pore volumes with optional probability
-  masses). Collapses the pore-volume axis to a single per-bin series. In the spin-up zone each
-  streamtube is included all-or-nothing; for the exact continuous spin-up result of a gamma
-  distribution use :func:`gamma_residence_time`.
+- :func:`residence_time` - Compute the mean residence time over output bins for a discrete
+  aquifer pore-volume distribution (an array of equally-weighted pore volumes). Collapses the
+  pore-volume axis to a single per-bin series. The ``spinup`` policy (default ``"constant"``)
+  warm-starts the spin-up by extrapolating the boundary flow.
 
-- :func:`gamma_residence_time` - Compute the exact closed-form mean residence time over output
-  bins for a (shifted) gamma aquifer pore-volume distribution, with no pore-volume
-  discretization. Exact in the spin-up zone via covered-sub-mass renormalization.
+- :func:`gamma_residence_time` - Compute the closed-form mean residence time over output bins for a
+  (shifted) gamma aquifer pore-volume distribution, with no pore-volume discretization. The
+  ``spinup`` policy (default ``"constant"``) warm-starts the spin-up; ``spinup=0.0`` instead
+  renormalizes over the covered sub-mass exactly.
 
 - :func:`fraction_explained` - Compute fraction of aquifer pore volumes with valid residence
   times. Indicates how many pore volumes have sufficient flow history to compute residence time.
   Returns values in [0, 1] where 1.0 means all volumes are fully informed. Useful for assessing
   spin-up periods and data coverage. NaN residence times indicate insufficient flow history.
+
+Spin-up period
+--------------
+The spin-up **region** is determined entirely by the supplied flow record (``flow_tedges``, which
+fixes the cumulative throughflow volume ``V`` from ``0`` at the record start to ``V_end`` at the
+record end) together with the retarded pore volume ``retardation_factor * V_p`` -- it is not a
+length you set. A residence time for an output time needs the corresponding parcel to stay inside
+the flow record:
+
+* ``direction='extraction_to_infiltration'`` looks **back** to the infiltration event, so the
+  spin-up sits at the **start** of the output record: the residence time of a pore volume ``V_p``
+  needs ``V(t) >= retardation_factor * V_p`` (the extracted water was infiltrated before the record
+  began otherwise).
+* ``direction='infiltration_to_extraction'`` looks **forward** to the extraction event, so the
+  spin-up sits at the **end** of the output record: it needs ``V_end - V(t) >= retardation_factor *
+  V_p`` (the infiltrated water is extracted after the record ends otherwise).
+
+The spin-up therefore lengthens with both the pore volume and the retardation factor, and is
+longest for the largest pore volumes of a distribution.
+
+What happens in that region is governed by a ``spinup`` policy, following the package convention
+(see :mod:`gwtransport.advection`); the default is ``"constant"`` everywhere:
+
+* :func:`residence_time_full` and :func:`residence_time` take ``spinup={'constant', None}``.
+  ``"constant"`` (default) **warm-starts** by extrapolating the boundary flow (flow held constant at
+  its first/last value), so no in-record output is ``NaN``; ``None`` is strict, marking a pore
+  volume ``NaN`` for any output bin its parcel leaves the record within (and :func:`residence_time`
+  then averages over the remaining informed streamtubes).
+* :func:`gamma_residence_time` takes ``spinup={'constant'} | float in [0, 1)``. ``"constant"``
+  (default) warm-starts identically; a ``float`` instead **renormalizes** over the covered
+  sub-mass, with ``0.0`` giving the exact covered-sub-mass conditional mean.
+* :func:`residence_time_series` (point samples) has no ``spinup`` policy: it always returns ``NaN``
+  in the spin-up. It is the primitive behind :func:`fraction_explained`.
+
+Output bins lying wholly outside ``flow_tedges`` are ``NaN`` under every policy.
+
+:func:`fraction_explained` reports, per output instant, the fraction of the pore-volume
+distribution that is out of spin-up (``1.0`` = fully informed, ``0.0`` = entirely in spin-up) and
+is the way to locate the spin-up region when the means warm-start over it.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
@@ -108,6 +147,14 @@ def residence_time_series(
     gwtransport.logremoval.residence_time_to_log_removal : Convert residence time to log removal
     :ref:`concept-residence-time` : Time in aquifer between infiltration and extraction
     :ref:`concept-retardation-factor` : Slower movement due to sorption
+
+    Notes
+    -----
+    Instants whose retarded look-back/forward parcel falls outside the supplied flow record -- the
+    spin-up period -- are returned as ``NaN`` rather than extrapolated. The spin-up is set by the
+    flow record and the retarded pore volume, not by any argument: for ``extraction_to_infiltration``
+    it occupies the start of the record, for ``infiltration_to_extraction`` the end. See the module
+    docstring (``Spin-up period``) for the full rule.
     """
     aquifer_pore_volumes = np.atleast_1d(aquifer_pore_volumes)
     flow_tedges = pd.DatetimeIndex(flow_tedges)
@@ -158,6 +205,7 @@ def residence_time_full(
     direction: str = "extraction_to_infiltration",
     retardation_factor: float = 1.0,
     weighting: str = "flow",
+    spinup: str | None = "constant",
 ) -> npt.NDArray[np.floating]:
     r"""
     Compute the mean residence time over output bins, per pore volume.
@@ -196,6 +244,18 @@ def residence_time_full(
           consume to compute a per-bin retarded velocity.
         * ``'time'``: time-weighted average -- uniform in clock time. Coincides with
           ``'flow'`` when flow is constant within an output bin.
+    spinup : {'constant'} or None, optional
+        How to treat the spin-up zone, where a pore volume's retarded look-back/forward parcel
+        leaves the flow record. Matches the package convention (see :mod:`gwtransport.advection`).
+
+        * ``'constant'`` (default): warm-start -- extrapolate the cumulative-volume-to-time map past
+          the record at the boundary flow rates (flow held constant at its first/last value), so
+          the residence time stays finite. No left-edge (extraction) or right-edge (infiltration)
+          spin-up ``NaN``.
+        * ``None``: strict -- a pore volume whose parcel leaves the record at any point within an
+          output bin is ``NaN`` for that bin (all-or-nothing per bin), with no extrapolation.
+
+        Output bins lying wholly outside ``flow_tedges`` are ``NaN`` under either policy.
 
     Returns
     -------
@@ -208,16 +268,23 @@ def residence_time_full(
     ValueError
         If ``flow_tedges`` does not have exactly one more element than ``flow``. If
         ``direction`` is not ``'extraction_to_infiltration'`` or
-        ``'infiltration_to_extraction'``. If ``weighting`` is not ``'flow'`` or ``'time'``.
+        ``'infiltration_to_extraction'``. If ``weighting`` is not ``'flow'`` or ``'time'``. If
+        ``spinup`` is not ``'constant'`` or ``None``.
 
     See Also
     --------
     residence_time_series : Residence time at specific time instants (per pore volume)
+    fraction_explained : Fraction of pore volumes out of spin-up at each instant
     :ref:`concept-residence-time` : Time in aquifer between infiltration and extraction
     :ref:`concept-transport-equation` : Flow-weighted averaging convention
 
     Notes
     -----
+    With the default ``spinup='constant'`` the spin-up zone is warm-started by extrapolating the
+    boundary flow, so no in-record bin is ``NaN``; use :func:`fraction_explained` (or
+    ``spinup=None``) to locate the spin-up region. See the module docstring (``Spin-up period``)
+    for the full rule.
+
     Exact-zero flow bins produce a plateau in cumulative volume that is bumped up by one
     float64 ulp per duplicate so the cumulative volume is strictly monotone; trapezoidal
     integration over the resulting one-ulp-wide ramp recovers the underlying step
@@ -248,15 +315,19 @@ def residence_time_full(
     ...     aquifer_pore_volumes=200.0,
     ...     direction="extraction_to_infiltration",
     ... )
-    >>> # 200 m³ / 100 m³/day = 2 days residence time
+    >>> # 200 m³ / 100 m³/day = 2 days residence time; the default constant warm-start
+    >>> # extrapolates the boundary flow, so the left-edge spin-up bins are also 2 days
     >>> print(mean_times)  # doctest: +NORMALIZE_WHITESPACE
-    [[nan nan  2.  2.  2.  2.  2.  2.  2.]]
+    [[2. 2. 2. 2. 2. 2. 2. 2. 2.]]
     """
     if direction not in {"extraction_to_infiltration", "infiltration_to_extraction"}:
         msg = "direction should be 'extraction_to_infiltration' or 'infiltration_to_extraction'"
         raise ValueError(msg)
     if weighting not in {"flow", "time"}:
         msg = "weighting should be 'flow' or 'time'"
+        raise ValueError(msg)
+    if spinup not in {"constant", None}:
+        msg = "spinup should be 'constant' or None"
         raise ValueError(msg)
 
     aquifer_pore_volumes = np.atleast_1d(aquifer_pore_volumes)
@@ -295,7 +366,29 @@ def residence_time_full(
 
     flow_cum_at_grid = linear_interpolate(x_ref=flow_tedges_days, y_ref=flow_cum, x_query=augmented_grid)
     a_grid = flow_cum_at_grid[None, :] + sign * retardation_factor * aquifer_pore_volumes[:, None]
-    days_grid = linear_interpolate(x_ref=flow_cum, y_ref=flow_tedges_days, x_query=a_grid, left=np.nan, right=np.nan)
+
+    # Spin-up handling. A parcel whose infiltration/extraction falls outside the flow record has an
+    # out-of-range look-back/forward target a_grid. With spinup="constant" the cumulative-volume ->
+    # time map is extrapolated past the record at the boundary flow rates (flow held constant at its
+    # first/last value), so the residence time stays finite (the package default warm-start). One
+    # anchor each end, padded by the largest reach R * max(V_p), is enough that a_grid never exceeds
+    # the extended map, so the interpolation is an exact linear extrapolation. With spinup=None the
+    # map is not extended and the out-of-record target yields NaN (strict, no extrapolation).
+    if spinup == "constant":
+        pad = retardation_factor * float(aquifer_pore_volumes.max())
+        inv_q_first = (flow_tedges_days[1] - flow_tedges_days[0]) / (flow_cum[1] - flow_cum[0])
+        inv_q_last = (flow_tedges_days[-1] - flow_tedges_days[-2]) / (flow_cum[-1] - flow_cum[-2])
+        flow_cum_map = np.concatenate([[flow_cum[0] - pad], flow_cum, [flow_cum[-1] + pad]])
+        days_map = np.concatenate([
+            [flow_tedges_days[0] - pad * inv_q_first],
+            flow_tedges_days,
+            [flow_tedges_days[-1] + pad * inv_q_last],
+        ])
+        days_grid = linear_interpolate(x_ref=flow_cum_map, y_ref=days_map, x_query=a_grid)
+    else:
+        days_grid = linear_interpolate(
+            x_ref=flow_cum, y_ref=flow_tedges_days, x_query=a_grid, left=np.nan, right=np.nan
+        )
     data_grid = sign * (days_grid - augmented_grid[None, :])
 
     if weighting == "time":
@@ -315,26 +408,30 @@ def residence_time(
     flow_tedges: pd.DatetimeIndex | np.ndarray,
     tedges_out: pd.DatetimeIndex | np.ndarray,
     aquifer_pore_volumes: npt.ArrayLike,
-    probability_mass: npt.ArrayLike | None = None,
     direction: str = "extraction_to_infiltration",
     retardation_factor: float = 1.0,
+    spinup: str | None = "constant",
 ) -> npt.NDArray[np.floating]:
     r"""
-    Compute the mass-weighted mean residence time over output bins for a discrete APVD.
+    Compute the mean residence time over output bins for a discrete APVD.
 
-    The mean is taken over a **discrete** set of aquifer pore volumes -- one streamtube per
-    entry in ``aquifer_pore_volumes`` -- weighted by ``probability_mass``. Each streamtube's
-    flow-weighted bin average is computed with :func:`residence_time_full` and the pore-volume
-    axis is then collapsed to a single per-output-bin series. For a continuous (shifted) gamma
-    pore-volume distribution evaluated in closed form, use :func:`gamma_residence_time`.
+    The mean is taken over a **discrete** set of equally-weighted aquifer pore volumes -- one
+    streamtube per entry in ``aquifer_pore_volumes``. Each streamtube's flow-weighted bin average
+    is computed with :func:`residence_time_full` and the pore-volume axis is then collapsed to a
+    single per-output-bin series by averaging over the streamtubes that are valid in each bin. For
+    a continuous (shifted) gamma pore-volume distribution evaluated in closed form, use
+    :func:`gamma_residence_time`.
 
-    The collapse renormalizes over the streamtubes that are valid in each output bin,
+    The mean is over the valid streamtubes,
 
     .. math::
 
-        \bar\tau_b = \frac{\sum_i w_i\,\tau_{i,b}}{\sum_{i\,:\,\tau_{i,b}\ \mathrm{finite}} w_i},
+        \bar\tau_b = \frac{1}{|V_b|}\sum_{i \in V_b} \tau_{i,b},
+        \qquad V_b = \{\, i : \tau_{i,b}\ \mathrm{finite} \,\}.
 
-    so the bin mean is exact for fully-informed bins under both constant and variable flow.
+    With the default ``spinup='constant'`` every streamtube is finite within the flow record
+    (the boundary flow is extrapolated), so this is simply the mean over all pore volumes; with
+    ``spinup=None`` it renormalizes over the streamtubes that have broken through.
 
     Parameters
     ----------
@@ -345,12 +442,8 @@ def residence_time(
     tedges_out : array-like
         Output time edges as datetime64 objects; ``n + 1`` edges define ``n`` output bins.
     aquifer_pore_volumes : array-like
-        Discrete pore volumes [m3], one per streamtube. A single value collapses to the
-        per-streamtube mean of :func:`residence_time_full`.
-    probability_mass : array-like, optional
-        Probability mass of each pore volume [dimensionless], same shape as
-        ``aquifer_pore_volumes``. Must be non-negative and sum to 1; it is not normalized
-        internally. Defaults to a uniform ``1 / n`` over the ``n`` pore volumes.
+        Discrete pore volumes [m3], one per (equally-weighted) streamtube. A single value
+        collapses to the per-streamtube mean of :func:`residence_time_full`.
     direction : {'extraction_to_infiltration', 'infiltration_to_extraction'}, optional
         Direction of the flow calculation:
         * 'extraction_to_infiltration': how many days ago was the extracted water infiltrated
@@ -358,36 +451,36 @@ def residence_time(
         Default is 'extraction_to_infiltration'.
     retardation_factor : float, optional
         Retardation factor of the compound in the aquifer [dimensionless]. Default is 1.0.
+    spinup : {'constant'} or None, optional
+        Spin-up policy, forwarded to :func:`residence_time_full`. ``'constant'`` (default)
+        warm-starts by extrapolating the boundary flow so no in-record bin is ``NaN``; ``None``
+        leaves spin-up streamtubes ``NaN`` and the mean renormalizes over those that have broken
+        through. Use :func:`fraction_explained` to locate the spin-up region.
 
     Returns
     -------
     numpy.ndarray
-        Mass-weighted mean residence time [days], shape ``(n_output_bins,)``. Output bins with
-        no valid streamtube (outside the flow record or fully in the spin-up zone) are NaN.
-
-    Raises
-    ------
-    ValueError
-        If ``flow_tedges`` does not have exactly one more element than ``flow``. If ``direction``
-        is not ``'extraction_to_infiltration'`` or ``'infiltration_to_extraction'``. If
-        ``probability_mass`` has a different shape than ``aquifer_pore_volumes``, is negative, or
-        does not sum to 1.
+        Mean residence time [days], shape ``(n_output_bins,)``. Output bins with no valid
+        streamtube (outside the flow record, or -- with ``spinup=None`` -- fully in the spin-up
+        zone) are NaN.
 
     See Also
     --------
     gamma_residence_time : Exact closed-form mean for a continuous (shifted) gamma APVD
     residence_time_full : Per-pore-volume mean residence time over output bins
+    fraction_explained : Fraction of pore volumes out of spin-up at each instant
     gwtransport.gamma.bins : Discretize a gamma APVD into pore-volume bins
     :ref:`concept-residence-time` : Time in aquifer between infiltration and extraction
 
     Notes
     -----
-    Spin-up is **all-or-nothing per streamtube**: a streamtube whose look-back/forward parcel
-    leaves the flow record part-way through an output bin has a NaN bin average (inherited from
-    :func:`residence_time_full`) and is dropped from that bin's mean entirely, rather than
-    contributing its partially-covered sub-mass. This differs from :func:`gamma_residence_time`,
-    which integrates the partial coverage exactly and is therefore the right choice when the
-    spin-up bins matter.
+    With ``spinup=None`` the spin-up is **all-or-nothing per streamtube**: a streamtube whose
+    look-back/forward parcel leaves the flow record part-way through an output bin has a ``NaN`` bin
+    average (inherited from :func:`residence_time_full`) and is dropped from that bin's mean
+    entirely, rather than contributing its partially-covered share; the bin is ``NaN`` only once
+    every streamtube is in spin-up. In that mode the discrete mean differs from
+    :func:`gamma_residence_time`, which renormalizes over the covered sub-mass exactly. See the
+    module docstring (``Spin-up period``) for the full rule.
 
     Examples
     --------
@@ -400,29 +493,12 @@ def residence_time(
     ...     flow=flow_values,
     ...     flow_tedges=flow_dates,
     ...     tedges_out=flow_dates,
-    ...     aquifer_pore_volumes=[400.0, 600.0],  # uniform mass over two streamtubes
+    ...     aquifer_pore_volumes=[400.0, 600.0],  # two equally-weighted streamtubes
     ... )
     >>> # Deep in the record: mean pore volume 500 / 100 m³/day = 5 days
     >>> float(np.round(tau_bar[-1], 6))
     5.0
     """
-    aquifer_pore_volumes = np.atleast_1d(np.asarray(aquifer_pore_volumes, dtype=float))
-    n_pore_volumes = len(aquifer_pore_volumes)
-
-    if probability_mass is None:
-        weights = np.full(n_pore_volumes, 1.0 / n_pore_volumes)
-    else:
-        weights = np.atleast_1d(np.asarray(probability_mass, dtype=float))
-        if weights.shape != aquifer_pore_volumes.shape:
-            msg = "probability_mass must have the same shape as aquifer_pore_volumes"
-            raise ValueError(msg)
-        if np.any(weights < 0):
-            msg = "probability_mass must be non-negative"
-            raise ValueError(msg)
-        if not np.isclose(weights.sum(), 1.0, rtol=0.0, atol=1e-8):
-            msg = "probability_mass must sum to 1"
-            raise ValueError(msg)
-
     rt = residence_time_full(
         flow=flow,
         flow_tedges=flow_tedges,
@@ -431,16 +507,15 @@ def residence_time(
         direction=direction,
         retardation_factor=retardation_factor,
         weighting="flow",
+        spinup=spinup,
     )
 
-    # Mass-weighted mean over the streamtubes that are valid (non-NaN) in each output bin.
-    weights = weights[:, None]
-    num = np.nansum(rt * weights, axis=0)
-    den = np.sum(np.where(np.isfinite(rt), weights, 0.0), axis=0)
-    result = np.full(rt.shape[1], np.nan)
-    covered = den > 0
-    result[covered] = num[covered] / den[covered]
-    return result
+    # Mean over the streamtubes that are valid (non-NaN) in each output bin; bins with no valid
+    # streamtube reduce to 0/0 and are NaN. With spinup='constant' every in-record streamtube is
+    # finite, so this is the plain mean; with spinup=None it renormalizes over the broken-through set.
+    valid_count = np.isfinite(rt).sum(axis=0)
+    with np.errstate(invalid="ignore"):
+        return np.nansum(rt, axis=0) / valid_count
 
 
 def gamma_residence_time(
@@ -455,10 +530,11 @@ def gamma_residence_time(
     beta: float | None = None,
     direction: str = "extraction_to_infiltration",
     retardation_factor: float = 1.0,
+    spinup: str | float = "constant",
     _max_tile_elements: int = 1_000_000,
 ) -> npt.NDArray[np.floating]:
     r"""
-    Compute the exact mean residence time over output bins for a (shifted) gamma APVD.
+    Compute the mean residence time over output bins for a (shifted) gamma APVD.
 
     The expectation over a (shifted) gamma aquifer pore-volume distribution (APVD),
     parameterized by either ``(mean, std, loc)`` or ``(alpha, beta, loc)``, is taken in closed
@@ -470,9 +546,11 @@ def gamma_residence_time(
     its per-bin time integral :math:`G_b(V_p) = \int_{\mathrm{bin}} \tau\,dV` is piecewise-
     quadratic in :math:`V_p` and the covered length :math:`L_b(V_p)` piecewise-linear. The bin
     mean is the ratio of two closed-form integrals against the gamma density -- its zeroth,
-    first and second partial moments (regularized incomplete gamma). Forming the ratio once,
-    after integrating, keeps the result **exact in the spin-up zone** where only part of the
-    APVD has sufficient flow history (the covered sub-mass renormalizes the mean).
+    first and second partial moments (regularized incomplete gamma) -- formed once after
+    integrating. The ``spinup`` policy sets what happens where part of the APVD lacks flow
+    history: ``'constant'`` (default) extrapolates the boundary flow over the full distribution
+    (the package default warm-start), while a ``float`` threshold renormalizes the mean over the
+    covered sub-mass (``0.0`` reproduces the exact covered-sub-mass conditional mean).
 
     Parameters
     ----------
@@ -501,27 +579,51 @@ def gamma_residence_time(
         Default is 'extraction_to_infiltration'.
     retardation_factor : float, optional
         Retardation factor of the compound in the aquifer [dimensionless]. Default is 1.0.
+    spinup : {'constant'} or float in [0, 1), optional
+        How to treat the spin-up zone, where part of the gamma APVD lacks flow history. Matches
+        the package convention (see :mod:`gwtransport.advection`); ``None`` is not offered because
+        a continuous distribution always has some covered sub-mass.
+
+        * ``'constant'`` (default): warm-start -- extrapolate the cumulative-volume-to-time map past
+          the record at the boundary flow rates (flow held constant at its first/last value) and
+          integrate the full distribution, so no in-record bin is ``NaN``.
+        * ``float`` in ``[0, 1)``: renormalize the mean over the covered sub-mass, emitting a bin
+          only where the covered fraction of the distribution is at least ``spinup``. ``0.0`` gives
+          the exact covered-sub-mass conditional mean (emit whenever any sub-mass is covered).
+
+        Output bins lying wholly outside ``flow_tedges`` are ``NaN`` under either policy.
 
     Returns
     -------
     numpy.ndarray
-        APVD-mean residence time [days], shape ``(n_output_bins,)``. Output bins outside the
-        flow record (or with no covered pore-volume sub-mass) are NaN.
+        APVD-mean residence time [days], shape ``(n_output_bins,)``. Output bins outside the flow
+        record are NaN; with a ``float`` ``spinup`` so are bins whose covered fraction is below the
+        threshold.
 
     Raises
     ------
     ValueError
         If ``flow_tedges`` does not have exactly one more element than ``flow``. If ``direction``
-        is not ``'extraction_to_infiltration'`` or ``'infiltration_to_extraction'``. Gamma
-        parameter validation is delegated to :func:`gwtransport.gamma.parse_parameters`.
+        is not ``'extraction_to_infiltration'`` or ``'infiltration_to_extraction'``. If ``spinup``
+        is not ``'constant'`` or a float in ``[0, 1)``. Gamma parameter validation is delegated to
+        :func:`gwtransport.gamma.parse_parameters`.
 
     See Also
     --------
-    residence_time : Mass-weighted mean for a discrete set of pore volumes
+    residence_time : Equally-weighted mean for a discrete set of pore volumes
     residence_time_full : Per-pore-volume mean residence time over output bins
+    fraction_explained : Fraction of pore volumes out of spin-up at each instant
     gwtransport.gamma.bins : Discretize a gamma APVD into pore-volume bins
     :ref:`concept-residence-time` : Time in aquifer between infiltration and extraction
     :ref:`concept-gamma-distribution` : Two-parameter pore volume model
+
+    Notes
+    -----
+    With the default ``spinup='constant'`` the spin-up is warm-started exactly as in
+    :func:`residence_time` (constant-boundary-flow extrapolation), so the two agree everywhere. With
+    ``spinup=0.0`` the spin-up is instead handled by exact covered-sub-mass renormalization: each
+    output bin integrates over only the pore-volume sub-range with sufficient flow history. See the
+    module docstring (``Spin-up period``) for the full rule.
 
     Examples
     --------
@@ -545,6 +647,14 @@ def gamma_residence_time(
     if direction not in {"extraction_to_infiltration", "infiltration_to_extraction"}:
         msg = "direction should be 'extraction_to_infiltration' or 'infiltration_to_extraction'"
         raise ValueError(msg)
+    extrapolate = spinup == "constant"
+    if extrapolate:
+        spinup_threshold = 0.0
+    elif isinstance(spinup, int | float) and not isinstance(spinup, bool) and 0.0 <= spinup < 1.0:
+        spinup_threshold = float(spinup)
+    else:
+        msg = "spinup should be 'constant' or a float in [0, 1)"
+        raise ValueError(msg)
 
     alpha, beta, loc = parse_parameters(mean=mean, std=std, loc=loc, alpha=alpha, beta=beta)
 
@@ -564,22 +674,44 @@ def gamma_residence_time(
 
     flow_tedges_days = tedges_to_days(flow_tedges)
     flow_cum = cumulative_flow_volume(flow, np.diff(flow_tedges_days), strictly_monotone=True)
-    dvol_seg = flow_cum[1:] - flow_cum[:-1]
-    flow_rate = dvol_seg / (flow_tedges_days[1:] - flow_tedges_days[:-1])
     v_end = flow_cum[-1]
     n_edges = len(flow_cum)
 
-    # phi(v) = int_0^v T(w) dw with T the inverse cumulative-volume map (piecewise-linear);
-    # phi is piecewise-quadratic with knots at flow_cum, so the per-bin time integral of tau is
-    # a difference of phi at the (validity-clipped) look-back/forward limits.
-    seg_integral = flow_tedges_days[:-1] * dvol_seg + dvol_seg**2 / (2 * flow_rate)
-    phi_knot = np.concatenate([[0.0], np.cumsum(seg_integral)])
+    # Finite support: drop the gamma tails (mass ~1e-13, far below the discretization error this
+    # closed form replaces). Restricting the integral to [support_lo, support_hi] is what keeps
+    # the per-bin flow-edge band -- and the gamma CDF evaluations -- bounded.
+    tail = 1e-13
+    support_lo = float(loc + gamma_dist.ppf(tail, alpha, scale=beta))
+    support_hi = float(loc + gamma_dist.ppf(1.0 - tail, alpha, scale=beta))
+
+    # phi(v) = int_0^v T(w) dw with T the inverse cumulative-volume map (piecewise-linear); phi is
+    # piecewise-quadratic with knots at the cumulative-volume edges, so the per-bin time integral of
+    # tau is a difference of phi at the look-back/forward limits. With spinup="constant" the map is
+    # extended past the record at the boundary flow rates (one anchor each end, padded by the largest
+    # reach r*support_hi) so phi extrapolates the spin-up; with a float spinup it stays clipped to
+    # [0, v_end] (the covered sub-mass only).
+    if extrapolate:
+        pad = r * support_hi
+        inv_q_first = (flow_tedges_days[1] - flow_tedges_days[0]) / (flow_cum[1] - flow_cum[0])
+        inv_q_last = (flow_tedges_days[-1] - flow_tedges_days[-2]) / (flow_cum[-1] - flow_cum[-2])
+        phi_v = np.concatenate([[flow_cum[0] - pad], flow_cum, [flow_cum[-1] + pad]])
+        phi_t = np.concatenate([
+            [flow_tedges_days[0] - pad * inv_q_first],
+            flow_tedges_days,
+            [flow_tedges_days[-1] + pad * inv_q_last],
+        ])
+    else:
+        phi_v = flow_cum
+        phi_t = flow_tedges_days
+    phi_dv = phi_v[1:] - phi_v[:-1]
+    phi_rate = phi_dv / (phi_t[1:] - phi_t[:-1])
+    phi_knot = np.concatenate([[0.0], np.cumsum(phi_t[:-1] * phi_dv + phi_dv**2 / (2 * phi_rate))])
 
     def phi(v: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
-        v = np.clip(v, 0.0, v_end)
-        j = np.clip(np.searchsorted(flow_cum, v, side="right") - 1, 0, len(flow_rate) - 1)
-        dv = v - flow_cum[j]
-        return phi_knot[j] + flow_tedges_days[j] * dv + dv * dv / (2 * flow_rate[j])
+        v = np.clip(v, phi_v[0], phi_v[-1])
+        j = np.clip(np.searchsorted(phi_v, v, side="right") - 1, 0, len(phi_rate) - 1)
+        dv = v - phi_v[j]
+        return phi_knot[j] + phi_t[j] * dv + dv * dv / (2 * phi_rate[j])
 
     tedges_out_days = tedges_to_days(tedges_out, ref=flow_tedges[0])
     vol_out = linear_interpolate(
@@ -590,13 +722,6 @@ def gamma_residence_time(
         return np.full(n_out, np.nan)
     v_lo_all = np.where(good_all, vol_out[:-1], 0.0)
     v_hi_all = np.where(good_all, vol_out[1:], 1.0)
-
-    # Finite support: drop the gamma tails (mass ~1e-13, far below the discretization error this
-    # closed form replaces). Restricting the integral to [support_lo, support_hi] is what keeps
-    # the per-bin flow-edge band -- and the gamma CDF evaluations -- bounded.
-    tail = 1e-13
-    support_lo = float(loc + gamma_dist.ppf(tail, alpha, scale=beta))
-    support_hi = float(loc + gamma_dist.ppf(1.0 - tail, alpha, scale=beta))
 
     # Fixed band of flow edges each bin's look-back/forward sweep can cross over the supported
     # pore volumes. band_width is the global maximum so every tile shares one column layout; a
@@ -644,22 +769,34 @@ def gamma_residence_time(
         half = 0.5 * (hi - lo)
         nodes = np.stack([lo, mid, hi], axis=0)  # (3, nt, n_pieces)
 
-        # G(V_p) at the three quadrature nodes (piece lo/mid/hi) as a difference of phi. The
-        # constant term phi(v_hi)/phi(v_lo) does not depend on V_p, so evaluate it once per bin
-        # and batch only the three V_p-dependent phi arguments.
+        # G(V_p) at the three quadrature nodes (piece lo/mid/hi) as a difference of phi. The constant
+        # term phi(v_hi)/phi(v_lo) does not depend on V_p, so evaluate it once per bin and batch only
+        # the three V_p-dependent phi arguments. With spinup="constant" the full bin is integrated
+        # against the extrapolated phi (length is the full bin width); with a float spinup the limits
+        # clamp to the streamtube's covered sub-interval and the covered length renormalizes.
         if sign < 0:
-            v_start = np.maximum(vlo[None], r * nodes)
-            a_lo = np.maximum(vlo[None] - r * nodes, 0.0)
             a_hi = vhi[None] - r * nodes
-            length = np.maximum(vhi[None] - v_start, 0.0)
+            if extrapolate:
+                v_start = np.broadcast_to(vlo[None], a_hi.shape)
+                a_lo = vlo[None] - r * nodes
+                length = np.broadcast_to(vhi[None] - vlo[None], a_hi.shape)
+            else:
+                v_start = np.maximum(vlo[None], r * nodes)
+                a_lo = np.maximum(vlo[None] - r * nodes, 0.0)
+                length = np.maximum(vhi[None] - v_start, 0.0)
             phi_const = phi(v_hi)
             phi_stack = phi(np.stack([v_start, a_hi, a_lo]))
             g = phi_const[None, :, None] - phi_stack[0] - phi_stack[1] + phi_stack[2]
         else:
-            v_stop = np.minimum(vhi[None], v_end - r * nodes)
-            a_hi = np.minimum(vhi[None] + r * nodes, v_end)
             a_lo = vlo[None] + r * nodes
-            length = np.maximum(v_stop - vlo[None], 0.0)
+            if extrapolate:
+                v_stop = np.broadcast_to(vhi[None], a_lo.shape)
+                a_hi = vhi[None] + r * nodes
+                length = np.broadcast_to(vhi[None] - vlo[None], a_lo.shape)
+            else:
+                v_stop = np.minimum(vhi[None], v_end - r * nodes)
+                a_hi = np.minimum(vhi[None] + r * nodes, v_end)
+                length = np.maximum(v_stop - vlo[None], 0.0)
             phi_const = phi(v_lo)
             phi_stack = phi(np.stack([a_hi, a_lo, v_stop]))
             g = phi_stack[0] - phi_stack[1] - phi_stack[2] + phi_const[None, :, None]
@@ -695,6 +832,10 @@ def gamma_residence_time(
         num = int_g.sum(axis=1)
         den = int_l.sum(axis=1)
         covered = good & (den > 0)
+        if spinup_threshold > 0.0:
+            # float spinup: emit only where the covered fraction of the APVD reaches the threshold.
+            # den is the covered sub-mass; (v_hi - v_lo) * m0.sum is the fully-covered sub-mass.
+            covered &= den >= spinup_threshold * (v_hi - v_lo) * m0.sum(axis=1)
         tile_result = np.full(nt, np.nan)
         tile_result[covered] = num[covered] / den[covered]
         result[t0:t1] = tile_result
@@ -713,6 +854,11 @@ def fraction_explained(
 ) -> npt.NDArray[np.floating]:
     """
     Compute the fraction of the aquifer that is informed with respect to the retarded flow.
+
+    For each output instant this is the fraction of the supplied pore volumes whose residence time
+    is finite, i.e. the complement of the spin-up coverage: ``1.0`` means every pore volume is out
+    of spin-up, ``0.0`` means all are still in it. The spin-up itself is set by the flow record and
+    the retarded pore volumes (see the module docstring, ``Spin-up period``), not by any argument.
 
     Parameters
     ----------

--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -20,9 +20,15 @@ Available functions:
   volume. Sampling at arbitrary instants departs from the bin-edge convention, so it is kept
   separate from :func:`residence_time_full`. Same directional options.
 
-- :func:`gamma_residence_time` - Compute the mean residence time over output bins for a
-  (shifted) gamma aquifer pore-volume distribution, in closed form (no pore-volume binning).
-  Collapses the pore-volume axis to a single per-bin series.
+- :func:`residence_time` - Compute the mass-weighted mean residence time over output bins for a
+  discrete aquifer pore-volume distribution (an array of pore volumes with optional probability
+  masses). Collapses the pore-volume axis to a single per-bin series. In the spin-up zone each
+  streamtube is included all-or-nothing; for the exact continuous spin-up result of a gamma
+  distribution use :func:`gamma_residence_time`.
+
+- :func:`gamma_residence_time` - Compute the exact closed-form mean residence time over output
+  bins for a (shifted) gamma aquifer pore-volume distribution, with no pore-volume
+  discretization. Exact in the spin-up zone via covered-sub-mass renormalization.
 
 - :func:`fraction_explained` - Compute fraction of aquifer pore volumes with valid residence
   times. Indicates how many pore volumes have sufficient flow history to compute residence time.
@@ -41,10 +47,6 @@ from scipy.stats import gamma as gamma_dist
 from gwtransport._time import tedges_to_days
 from gwtransport.gamma import parse_parameters
 from gwtransport.utils import cumulative_flow_volume, linear_average, linear_interpolate
-
-# Upper gamma quantile used as a finite support cap for the closed-form APVD integral;
-# the dropped tail mass (~1e-13) is far below the discretization error it replaces.
-_GAMMA_SUPPORT_TAIL = 1e-13
 
 
 def residence_time_series(
@@ -307,6 +309,140 @@ def residence_time_full(
     return result
 
 
+def residence_time(
+    *,
+    flow: npt.ArrayLike,
+    flow_tedges: pd.DatetimeIndex | np.ndarray,
+    tedges_out: pd.DatetimeIndex | np.ndarray,
+    aquifer_pore_volumes: npt.ArrayLike,
+    probability_mass: npt.ArrayLike | None = None,
+    direction: str = "extraction_to_infiltration",
+    retardation_factor: float = 1.0,
+) -> npt.NDArray[np.floating]:
+    r"""
+    Compute the mass-weighted mean residence time over output bins for a discrete APVD.
+
+    The mean is taken over a **discrete** set of aquifer pore volumes -- one streamtube per
+    entry in ``aquifer_pore_volumes`` -- weighted by ``probability_mass``. Each streamtube's
+    flow-weighted bin average is computed with :func:`residence_time_full` and the pore-volume
+    axis is then collapsed to a single per-output-bin series. For a continuous (shifted) gamma
+    pore-volume distribution evaluated in closed form, use :func:`gamma_residence_time`.
+
+    The collapse renormalizes over the streamtubes that are valid in each output bin,
+
+    .. math::
+
+        \bar\tau_b = \frac{\sum_i w_i\,\tau_{i,b}}{\sum_{i\,:\,\tau_{i,b}\ \mathrm{finite}} w_i},
+
+    so the bin mean is exact for fully-informed bins under both constant and variable flow.
+
+    Parameters
+    ----------
+    flow : array-like
+        Flow rate of water in the aquifer [m3/day]. Length matches ``flow_tedges`` minus one.
+    flow_tedges : array-like
+        Time edges for the flow data, as datetime64 objects, defining the flow intervals.
+    tedges_out : array-like
+        Output time edges as datetime64 objects; ``n + 1`` edges define ``n`` output bins.
+    aquifer_pore_volumes : array-like
+        Discrete pore volumes [m3], one per streamtube. A single value collapses to the
+        per-streamtube mean of :func:`residence_time_full`.
+    probability_mass : array-like, optional
+        Probability mass of each pore volume [dimensionless], same shape as
+        ``aquifer_pore_volumes``. Must be non-negative and sum to 1; it is not normalized
+        internally. Defaults to a uniform ``1 / n`` over the ``n`` pore volumes.
+    direction : {'extraction_to_infiltration', 'infiltration_to_extraction'}, optional
+        Direction of the flow calculation:
+        * 'extraction_to_infiltration': how many days ago was the extracted water infiltrated
+        * 'infiltration_to_extraction': how many days until the infiltrated water is extracted
+        Default is 'extraction_to_infiltration'.
+    retardation_factor : float, optional
+        Retardation factor of the compound in the aquifer [dimensionless]. Default is 1.0.
+
+    Returns
+    -------
+    numpy.ndarray
+        Mass-weighted mean residence time [days], shape ``(n_output_bins,)``. Output bins with
+        no valid streamtube (outside the flow record or fully in the spin-up zone) are NaN.
+
+    Raises
+    ------
+    ValueError
+        If ``flow_tedges`` does not have exactly one more element than ``flow``. If ``direction``
+        is not ``'extraction_to_infiltration'`` or ``'infiltration_to_extraction'``. If
+        ``probability_mass`` has a different shape than ``aquifer_pore_volumes``, is negative, or
+        does not sum to 1.
+
+    See Also
+    --------
+    gamma_residence_time : Exact closed-form mean for a continuous (shifted) gamma APVD
+    residence_time_full : Per-pore-volume mean residence time over output bins
+    gwtransport.gamma.bins : Discretize a gamma APVD into pore-volume bins
+    :ref:`concept-residence-time` : Time in aquifer between infiltration and extraction
+
+    Notes
+    -----
+    Spin-up is **all-or-nothing per streamtube**: a streamtube whose look-back/forward parcel
+    leaves the flow record part-way through an output bin has a NaN bin average (inherited from
+    :func:`residence_time_full`) and is dropped from that bin's mean entirely, rather than
+    contributing its partially-covered sub-mass. This differs from :func:`gamma_residence_time`,
+    which integrates the partial coverage exactly and is therefore the right choice when the
+    spin-up bins matter.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from gwtransport.residence_time import residence_time
+    >>> flow_dates = pd.date_range(start="2023-01-01", end="2023-02-10", freq="D")
+    >>> flow_values = np.full(len(flow_dates) - 1, 100.0)  # 100 m³/day
+    >>> tau_bar = residence_time(
+    ...     flow=flow_values,
+    ...     flow_tedges=flow_dates,
+    ...     tedges_out=flow_dates,
+    ...     aquifer_pore_volumes=[400.0, 600.0],  # uniform mass over two streamtubes
+    ... )
+    >>> # Deep in the record: mean pore volume 500 / 100 m³/day = 5 days
+    >>> float(np.round(tau_bar[-1], 6))
+    5.0
+    """
+    aquifer_pore_volumes = np.atleast_1d(np.asarray(aquifer_pore_volumes, dtype=float))
+    n_pore_volumes = len(aquifer_pore_volumes)
+
+    if probability_mass is None:
+        weights = np.full(n_pore_volumes, 1.0 / n_pore_volumes)
+    else:
+        weights = np.atleast_1d(np.asarray(probability_mass, dtype=float))
+        if weights.shape != aquifer_pore_volumes.shape:
+            msg = "probability_mass must have the same shape as aquifer_pore_volumes"
+            raise ValueError(msg)
+        if np.any(weights < 0):
+            msg = "probability_mass must be non-negative"
+            raise ValueError(msg)
+        if not np.isclose(weights.sum(), 1.0, rtol=0.0, atol=1e-8):
+            msg = "probability_mass must sum to 1"
+            raise ValueError(msg)
+
+    rt = residence_time_full(
+        flow=flow,
+        flow_tedges=flow_tedges,
+        tedges_out=tedges_out,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        direction=direction,
+        retardation_factor=retardation_factor,
+        weighting="flow",
+    )
+
+    # Mass-weighted mean over the streamtubes that are valid (non-NaN) in each output bin.
+    weights = weights[:, None]
+    num = np.nansum(rt * weights, axis=0)
+    den = np.sum(np.where(np.isfinite(rt), weights, 0.0), axis=0)
+    result = np.full(rt.shape[1], np.nan)
+    covered = den > 0
+    result[covered] = num[covered] / den[covered]
+    return result
+
+
 def gamma_residence_time(
     *,
     flow: npt.ArrayLike,
@@ -319,24 +455,24 @@ def gamma_residence_time(
     beta: float | None = None,
     direction: str = "extraction_to_infiltration",
     retardation_factor: float = 1.0,
+    _max_tile_elements: int = 1_000_000,
 ) -> npt.NDArray[np.floating]:
     r"""
-    Compute the mean residence time over output bins for a (shifted) gamma APVD.
+    Compute the exact mean residence time over output bins for a (shifted) gamma APVD.
 
-    The expectation over the aquifer pore-volume distribution (APVD) is taken in closed form,
-    so there is no discretization into pore-volume bins and no ``n_bins`` accuracy/cost knob.
-    The result is a single series -- the APVD-mean residence time per output bin -- not a
-    per-pore-volume array. The pore-volume distribution is a (shifted) gamma parameterized by
-    either ``(mean, std, loc)`` or ``(alpha, beta, loc)``.
+    The expectation over a (shifted) gamma aquifer pore-volume distribution (APVD),
+    parameterized by either ``(mean, std, loc)`` or ``(alpha, beta, loc)``, is taken in closed
+    form -- no pore-volume binning and no ``n_bins`` accuracy/cost knob. The bin mean is
+    flow-weighted (uniform in cumulative volume), matching the bin-edge convention of the
+    package, and a single per-output-bin series is returned.
 
-    The bin mean is flow-weighted (uniform in cumulative volume), matching the bin-edge
-    convention of the package. The single-streamtube residence time is piecewise-linear in
-    the pore volume :math:`V_p`, so its per-bin time integral is piecewise-quadratic in
-    :math:`V_p`, and the bin mean is the ratio of two closed-form integrals against the gamma
-    density (its zeroth, first and second partial moments). Forming the ratio once, after
-    integrating, keeps the result exact in the spin-up zone where only part of the APVD has
-    sufficient flow history (the covered sub-mass renormalizes the mean, matching a
-    pore-volume-resolved ``nanmean`` in the limit of infinite resolution).
+    The single-streamtube residence time is piecewise-linear in the pore volume :math:`V_p`, so
+    its per-bin time integral :math:`G_b(V_p) = \int_{\mathrm{bin}} \tau\,dV` is piecewise-
+    quadratic in :math:`V_p` and the covered length :math:`L_b(V_p)` piecewise-linear. The bin
+    mean is the ratio of two closed-form integrals against the gamma density -- its zeroth,
+    first and second partial moments (regularized incomplete gamma). Forming the ratio once,
+    after integrating, keeps the result **exact in the spin-up zone** where only part of the
+    APVD has sufficient flow history (the covered sub-mass renormalizes the mean).
 
     Parameters
     ----------
@@ -375,13 +511,13 @@ def gamma_residence_time(
     Raises
     ------
     ValueError
-        If ``flow_tedges`` does not have exactly one more element than ``flow``. If
-        ``direction`` is not ``'extraction_to_infiltration'`` or
-        ``'infiltration_to_extraction'``. If gamma parameter validation in
-        :func:`gwtransport.gamma.parse_parameters` fails.
+        If ``flow_tedges`` does not have exactly one more element than ``flow``. If ``direction``
+        is not ``'extraction_to_infiltration'`` or ``'infiltration_to_extraction'``. Gamma
+        parameter validation is delegated to :func:`gwtransport.gamma.parse_parameters`.
 
     See Also
     --------
+    residence_time : Mass-weighted mean for a discrete set of pore volumes
     residence_time_full : Per-pore-volume mean residence time over output bins
     gwtransport.gamma.bins : Discretize a gamma APVD into pore-volume bins
     :ref:`concept-residence-time` : Time in aquifer between infiltration and extraction
@@ -411,6 +547,7 @@ def gamma_residence_time(
         raise ValueError(msg)
 
     alpha, beta, loc = parse_parameters(mean=mean, std=std, loc=loc, alpha=alpha, beta=beta)
+
     flow = np.asarray(flow, dtype=float)
     flow_tedges = pd.DatetimeIndex(flow_tedges)
     tedges_out = pd.DatetimeIndex(tedges_out)
@@ -425,97 +562,142 @@ def gamma_residence_time(
     sign = -1.0 if direction == "extraction_to_infiltration" else 1.0
     r = retardation_factor
 
-    td = tedges_to_days(flow_tedges)
-    flow_cum = cumulative_flow_volume(flow, np.diff(td), strictly_monotone=True)
-    flow_rate = (flow_cum[1:] - flow_cum[:-1]) / (td[1:] - td[:-1])
+    flow_tedges_days = tedges_to_days(flow_tedges)
+    flow_cum = cumulative_flow_volume(flow, np.diff(flow_tedges_days), strictly_monotone=True)
+    dvol_seg = flow_cum[1:] - flow_cum[:-1]
+    flow_rate = dvol_seg / (flow_tedges_days[1:] - flow_tedges_days[:-1])
     v_end = flow_cum[-1]
-    # Phi(v) = int_0^v T(w) dw with T the inverse cumulative-volume map (piecewise-linear);
-    # Phi is piecewise-quadratic with knots at flow_cum.
-    seg_integral = td[:-1] * (flow_cum[1:] - flow_cum[:-1]) + (flow_cum[1:] - flow_cum[:-1]) ** 2 / (2 * flow_rate)
-    phi_knot = np.concatenate([[0.0], np.cumsum(seg_integral)])
+    n_edges = len(flow_cum)
 
-    tedges_out_days = tedges_to_days(tedges_out, ref=flow_tedges[0])
-    vol_out = linear_interpolate(x_ref=td, y_ref=flow_cum, x_query=tedges_out_days, left=np.nan, right=np.nan)
-    support_hi = loc + gamma_dist.ppf(1 - _GAMMA_SUPPORT_TAIL, alpha, scale=beta)
+    # phi(v) = int_0^v T(w) dw with T the inverse cumulative-volume map (piecewise-linear);
+    # phi is piecewise-quadratic with knots at flow_cum, so the per-bin time integral of tau is
+    # a difference of phi at the (validity-clipped) look-back/forward limits.
+    seg_integral = flow_tedges_days[:-1] * dvol_seg + dvol_seg**2 / (2 * flow_rate)
+    phi_knot = np.concatenate([[0.0], np.cumsum(seg_integral)])
 
     def phi(v: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
         v = np.clip(v, 0.0, v_end)
         j = np.clip(np.searchsorted(flow_cum, v, side="right") - 1, 0, len(flow_rate) - 1)
         dv = v - flow_cum[j]
-        return phi_knot[j] + td[j] * dv + dv * dv / (2 * flow_rate[j])
+        return phi_knot[j] + flow_tedges_days[j] * dv + dv * dv / (2 * flow_rate[j])
 
-    def partial_moments(lo: np.ndarray, hi: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        # zeroth/first/second partial moments of the shifted gamma over [lo, hi] in V_p
-        def cdf(shape: float, x: np.ndarray) -> np.ndarray:
-            return gamma_dist.cdf(np.maximum(x - loc, 0.0), shape, scale=beta)
+    tedges_out_days = tedges_to_days(tedges_out, ref=flow_tedges[0])
+    vol_out = linear_interpolate(
+        x_ref=flow_tedges_days, y_ref=flow_cum, x_query=tedges_out_days, left=np.nan, right=np.nan
+    )
+    good_all = np.isfinite(vol_out[:-1]) & np.isfinite(vol_out[1:]) & (vol_out[1:] > vol_out[:-1])
+    if not np.any(good_all):
+        return np.full(n_out, np.nan)
+    v_lo_all = np.where(good_all, vol_out[:-1], 0.0)
+    v_hi_all = np.where(good_all, vol_out[1:], 1.0)
 
-        m0 = cdf(alpha, hi) - cdf(alpha, lo)
-        d1 = cdf(alpha + 1, hi) - cdf(alpha + 1, lo)
-        m1 = alpha * beta * d1 + loc * m0
-        d2 = cdf(alpha + 2, hi) - cdf(alpha + 2, lo)
-        m2 = alpha * (alpha + 1) * beta**2 * d2 + 2 * loc * alpha * beta * d1 + loc * loc * m0
-        return m0, m1, m2
+    # Finite support: drop the gamma tails (mass ~1e-13, far below the discretization error this
+    # closed form replaces). Restricting the integral to [support_lo, support_hi] is what keeps
+    # the per-bin flow-edge band -- and the gamma CDF evaluations -- bounded.
+    tail = 1e-13
+    support_lo = float(loc + gamma_dist.ppf(tail, alpha, scale=beta))
+    support_hi = float(loc + gamma_dist.ppf(1.0 - tail, alpha, scale=beta))
+
+    # Fixed band of flow edges each bin's look-back/forward sweep can cross over the supported
+    # pore volumes. band_width is the global maximum so every tile shares one column layout; a
+    # spurious column clips to the support and merely splits a quadratic piece without changing
+    # its integral, so the band is an exact superset.
+    a_min = v_lo_all - r * support_hi if sign < 0 else v_lo_all + r * support_lo
+    a_max = v_hi_all - r * support_lo if sign < 0 else v_hi_all + r * support_hi
+    jlo_all = np.clip(np.searchsorted(flow_cum, a_min, "left") - 1, 0, n_edges - 1)
+    jhi_all = np.clip(np.searchsorted(flow_cum, a_max, "right"), 0, n_edges - 1)
+    band_width = int((jhi_all - jlo_all).max()) + 1
+    band = np.arange(band_width)
+
+    # Tile over output bins to bound peak memory. Each bin carries ~3*band_width pieces through a
+    # (3 nodes, 3 phi-args) stack of 9 * n_pieces elements; size the tile to that element budget.
+    n_pieces = 3 * band_width + 3
+    tile = max(1, _max_tile_elements // (9 * n_pieces))
 
     result = np.full(n_out, np.nan)
-    for b in range(n_out):
-        v_lo, v_hi = vol_out[b], vol_out[b + 1]
-        if not (np.isfinite(v_lo) and np.isfinite(v_hi)) or v_hi <= v_lo:
-            continue
+    for t0 in range(0, n_out, tile):
+        t1 = min(t0 + tile, n_out)
+        nt = t1 - t0
+        good = good_all[t0:t1]
+        v_lo = v_lo_all[t0:t1]
+        v_hi = v_hi_all[t0:t1]
+        cols = np.clip(jlo_all[t0:t1, None] + band[None, :], 0, n_edges - 1)
+        fcb = flow_cum[cols]
+        vlo = v_lo[:, None]
+        vhi = v_hi[:, None]
 
-        # V_p breakpoints where a Phi argument (clipped look-back/forward limit) crosses a flow
-        # edge or a validity bound; a superset covering both directions is safe (an extra
-        # breakpoint merely splits one quadratic piece into two with the same integral).
-        candidates = np.concatenate([
-            (v_hi - flow_cum) / r,
-            (flow_cum - v_hi) / r,
-            (v_lo - flow_cum) / r,
-            (flow_cum - v_lo) / r,
-            flow_cum / r,
-            (v_end - flow_cum) / r,
-            [v_lo / r, v_hi / r, (v_end - v_lo) / r, (v_end - v_hi) / r],
-        ])
-        candidates = candidates[(candidates > 0.0) & (candidates < support_hi) & np.isfinite(candidates)]
-        edges_vp = np.unique(np.concatenate([[0.0], candidates, [support_hi]]))
-        lo, hi = edges_vp[:-1], edges_vp[1:]
+        # Direction-specific breakpoint families: the V_p values where a phi argument (a clipped
+        # look-back/forward limit) crosses a flow edge or a validity bound. Clip to the support
+        # and sort to form the integration pieces (zero-width pieces contribute nothing).
+        if sign < 0:
+            cand = np.concatenate([(vhi - fcb) / r, (vlo - fcb) / r, fcb / r, vlo / r, vhi / r], axis=1)
+        else:
+            cand = np.concatenate(
+                [(fcb - vlo) / r, (fcb - vhi) / r, (v_end - fcb) / r, (v_end - vlo) / r, (v_end - vhi) / r], axis=1
+            )
+        np.clip(cand, support_lo, support_hi, out=cand)
+        cand.sort(axis=1)
+        edges = np.concatenate([np.full((nt, 1), support_lo), cand, np.full((nt, 1), support_hi)], axis=1)
+        lo = edges[:, :-1]
+        hi = edges[:, 1:]
         mid = 0.5 * (lo + hi)
         half = 0.5 * (hi - lo)
+        nodes = np.stack([lo, mid, hi], axis=0)  # (3, nt, n_pieces)
 
-        # Evaluate the per-V_p bin integral g(V_p) = int_bin tau dv and the valid length l(V_p)
-        # at the three quadrature nodes (piece lo / mid / hi) at once; g is quadratic and l
-        # linear per piece. tau integrals are differences of Phi (the antiderivative of T).
-        vp3 = np.concatenate([lo, mid, hi])
-        if sign < 0:  # extraction_to_infiltration: look back, valid where a = v - r*V_p >= 0
-            v_start = np.maximum(v_lo, r * vp3)
-            length3 = np.maximum(v_hi - v_start, 0.0)
-            g3 = (phi(np.full_like(vp3, v_hi)) - phi(v_start)) - (
-                phi(v_hi - r * vp3) - phi(np.maximum(v_lo - r * vp3, 0.0))
-            )
-        else:  # infiltration_to_extraction: look forward, valid where a = v + r*V_p <= v_end
-            v_stop = np.minimum(v_hi, v_end - r * vp3)
-            length3 = np.maximum(v_stop - v_lo, 0.0)
-            g3 = (phi(np.minimum(v_hi + r * vp3, v_end)) - phi(v_lo + r * vp3)) - (
-                phi(v_stop) - phi(np.full_like(vp3, v_lo))
-            )
-        g3 = np.where(length3 > 0, g3, 0.0)
-        length3 = np.where(length3 > 0, length3, 0.0)
-        n_piece = len(lo)
-        g_lo, g_mid, g_hi = g3[:n_piece], g3[n_piece : 2 * n_piece], g3[2 * n_piece :]
-        l_lo, l_mid, l_hi = length3[:n_piece], length3[n_piece : 2 * n_piece], length3[2 * n_piece :]
-        m0, m1, m2 = partial_moments(lo, hi)
+        # G(V_p) at the three quadrature nodes (piece lo/mid/hi) as a difference of phi. The
+        # constant term phi(v_hi)/phi(v_lo) does not depend on V_p, so evaluate it once per bin
+        # and batch only the three V_p-dependent phi arguments.
+        if sign < 0:
+            v_start = np.maximum(vlo[None], r * nodes)
+            a_lo = np.maximum(vlo[None] - r * nodes, 0.0)
+            a_hi = vhi[None] - r * nodes
+            length = np.maximum(vhi[None] - v_start, 0.0)
+            phi_const = phi(v_hi)
+            phi_stack = phi(np.stack([v_start, a_hi, a_lo]))
+            g = phi_const[None, :, None] - phi_stack[0] - phi_stack[1] + phi_stack[2]
+        else:
+            v_stop = np.minimum(vhi[None], v_end - r * nodes)
+            a_hi = np.minimum(vhi[None] + r * nodes, v_end)
+            a_lo = vlo[None] + r * nodes
+            length = np.maximum(v_stop - vlo[None], 0.0)
+            phi_const = phi(v_lo)
+            phi_stack = phi(np.stack([a_hi, a_lo, v_stop]))
+            g = phi_stack[0] - phi_stack[1] - phi_stack[2] + phi_const[None, :, None]
+        g = np.where(length > 0, g, 0.0)
+        length = np.where(length > 0, length, 0.0)
+        g_lo, g_mid, g_hi = g
+        l_lo, l_mid, l_hi = length
 
-        # G is quadratic per piece, L linear; write both centred at mid and contract with the
-        # partial moments: int x^k f over [lo, hi] = m_k, so int (a(x-mid)^2 + b(x-mid) + c) f
-        # = a (m2 - 2 mid m1 + mid^2 m0) + b (m1 - mid m0) + c m0.
+        # Gamma partial moments over each piece: one CDF per shape on the piece edges, then diff.
+        # M1/M2 follow from the shifted-gamma partial-moment identities.
+        cdf_edges = edges - loc
+        f0 = gamma_dist.cdf(cdf_edges, alpha, scale=beta)
+        f1 = gamma_dist.cdf(cdf_edges, alpha + 1, scale=beta)
+        f2 = gamma_dist.cdf(cdf_edges, alpha + 2, scale=beta)
+        m0 = np.diff(f0, axis=1)
+        d1 = np.diff(f1, axis=1)
+        m1 = alpha * beta * d1 + loc * m0
+        d2 = np.diff(f2, axis=1)
+        m2 = alpha * (alpha + 1) * beta**2 * d2 + 2 * loc * alpha * beta * d1 + loc * loc * m0
+
+        # G is quadratic per piece, L linear; reconstruct each from its three nodes (Lagrange-
+        # exact) centred at mid and contract with the moments: int (a(x-mid)^2 + b(x-mid) + c) f
+        # = a (m2 - 2 mid m1 + mid^2 m0) + b (m1 - mid m0) + c m0. Zero-width pieces (duplicate
+        # breakpoints) divide by half == 0; their masked result is discarded by np.where.
         safe = half > 0
-        g_a = np.where(safe, (g_lo - 2 * g_mid + g_hi) / (2 * half**2), 0.0)
-        g_b = np.where(safe, (g_hi - g_lo) / (2 * half), 0.0)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            g_a = np.where(safe, (g_lo - 2 * g_mid + g_hi) / (2 * half**2), 0.0)
+            g_b = np.where(safe, (g_hi - g_lo) / (2 * half), 0.0)
+            l_b = np.where(safe, (l_hi - l_lo) / (2 * half), 0.0)
         int_g = g_a * (m2 - 2 * mid * m1 + mid**2 * m0) + g_b * (m1 - mid * m0) + g_mid * m0
-        l_b = np.where(safe, (l_hi - l_lo) / (2 * half), 0.0)
         int_l = l_b * (m1 - mid * m0) + l_mid * m0
 
-        covered = np.sum(int_l)
-        if covered > 0:
-            result[b] = np.sum(int_g) / covered
+        num = int_g.sum(axis=1)
+        den = int_l.sum(axis=1)
+        covered = good & (den > 0)
+        tile_result = np.full(nt, np.nan)
+        tile_result[covered] = num[covered] / den[covered]
+        result[t0:t1] = tile_result
     return result
 
 

--- a/tests/src/test_gamma_residence_time.py
+++ b/tests/src/test_gamma_residence_time.py
@@ -5,7 +5,8 @@ from scipy.integrate import quad
 from scipy.stats import gamma as gamma_dist
 
 from gwtransport._time import tedges_to_days
-from gwtransport.residence_time import gamma_residence_time, residence_time_full
+from gwtransport.gamma import bins as gamma_bins
+from gwtransport.residence_time import gamma_residence_time, residence_time, residence_time_full
 from gwtransport.utils import cumulative_flow_volume
 
 DIRECTIONS = ["extraction_to_infiltration", "infiltration_to_extraction"]
@@ -59,6 +60,7 @@ def test_spinup_partial_bin_matches_direct_integral(direction):
         std=std,
         direction=direction,
         retardation_factor=r,
+        spinup=0.0,  # covered-sub-mass renormalization is the spinup=0.0 mode (matches the quad reference)
     )
     alpha, beta = (mean / std) ** 2, std**2 / mean
     v_end = q * n
@@ -210,6 +212,7 @@ def test_wide_gamma_matches_double_quad(direction):
         loc=loc,
         direction=direction,
         retardation_factor=r,
+        spinup=0.0,  # covered-sub-mass renormalization is the spinup=0.0 mode (matches the quad reference)
     )
     flow_cum = cumulative_flow_volume(flow, np.diff(tedges_to_days(tedges)), strictly_monotone=True)
     tested = 0
@@ -247,3 +250,133 @@ def test_tiling_boundary_invariance(direction):
     tiny_tile = gamma_residence_time(**common, _max_tile_elements=1)
     np.testing.assert_array_equal(np.isnan(one_tile), np.isnan(tiny_tile))
     np.testing.assert_allclose(one_tile, tiny_tile, rtol=1e-12, equal_nan=True)
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+@pytest.mark.parametrize("r", [1.0, 2.5])
+def test_constant_spinup_constant_flow_exact(direction, r):
+    """Warm-start (default spinup): under constant flow tau == R * mean / Q at EVERY in-record bin.
+
+    ``spinup="constant"`` extrapolates the boundary flow over the full distribution, so there is no
+    in-record spin-up NaN: every bin -- including the former spin-up bins -- sees the fully informed
+    APVD mean, which under constant flow Q collapses to ``R * E[V_p] / Q = R * mean / Q``.
+    """
+    q = 100.0
+    mean, std = 300.0, 80.0
+    flow, tedges = _constant_flow(q=q)
+    tau = gamma_residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        mean=mean,
+        std=std,
+        direction=direction,
+        retardation_factor=r,
+    )
+    assert not np.isnan(tau).any(), "warm-start must not produce in-record spin-up NaN"
+    np.testing.assert_allclose(tau, r * mean / q, atol=0, rtol=1e-11)
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_constant_spinup_matches_discrete(direction):
+    """Default-spinup gamma mean matches the discrete equal-mass pore-volume average under warm-start.
+
+    ``gamma.bins`` returns equal-probability-mass bins, so the simple average of their
+    ``expected_values`` is an unbiased discretization of the gamma mean. With warm-start spin-up on
+    both sides, the closed-form gamma residence time and the discrete ``residence_time`` over those
+    pore volumes agree up to the discretization gap (300 bins).
+    """
+    mean, std = 700.0, 250.0
+    n = 30
+    tedges = pd.date_range("2021-01-01", periods=n + 1, freq="D")
+    rng = np.random.default_rng(7)
+    flow = np.clip(100.0 + 60.0 * np.sin(np.arange(n) / 3.0) + rng.normal(0, 10, n), 10.0, None)
+    tau = gamma_residence_time(
+        flow=flow, flow_tedges=tedges, tedges_out=tedges, mean=mean, std=std, direction=direction
+    )
+    expected_values = gamma_bins(mean=mean, std=std, n_bins=300)["expected_values"]
+    disc = residence_time(
+        flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=expected_values, direction=direction
+    )
+    mask = np.isfinite(tau) & np.isfinite(disc)
+    assert mask.any()
+    np.testing.assert_allclose(tau[mask], disc[mask], atol=5e-3)
+
+
+def test_spinup_invalid_raises():
+    """A bad ``spinup`` (not "constant", not a float in [0, 1)) raises ValueError mentioning spinup."""
+    flow, tedges = _constant_flow()
+    with pytest.raises(ValueError, match="spinup"):
+        gamma_residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, mean=300.0, std=80.0, spinup="bad")
+    with pytest.raises(ValueError, match="spinup"):
+        gamma_residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, mean=300.0, std=80.0, spinup=1.0)
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_spinup_zero_vs_constant_differ_in_spinup_agree_deep(direction):
+    """spinup=0.0 and spinup="constant" differ in early spin-up bins but agree in deep informed bins.
+
+    The warm-start extrapolates the boundary flow, so spin-up bins (where the covered sub-mass is
+    partial) take a materially different value than the covered-sub-mass renormalization of
+    spinup=0.0. In a deep, fully-informed bin neither side extrapolates, so they coincide.
+    """
+    n = 80
+    tedges = pd.date_range("2021-01-01", periods=n + 1, freq="D")
+    rng = np.random.default_rng(5)
+    flow = np.clip(110.0 + 40.0 * np.sin(np.arange(n) / 9.0) + rng.normal(0, 7, n), 8.0, None)
+    common = {
+        "flow": flow,
+        "flow_tedges": tedges,
+        "tedges_out": tedges,
+        "mean": 500.0,
+        "std": 200.0,
+        "loc": 30.0,
+        "direction": direction,
+        "retardation_factor": 1.2,
+    }
+    zero = gamma_residence_time(**common, spinup=0.0)
+    constant = gamma_residence_time(**common, spinup="constant")
+    deep_idx = -1 if direction == "extraction_to_infiltration" else 0
+    spin_idx = 0 if direction == "extraction_to_infiltration" else -1
+    assert np.isfinite(zero[spin_idx])
+    assert np.isfinite(constant[spin_idx])
+    assert abs(zero[spin_idx] - constant[spin_idx]) / abs(constant[spin_idx]) > 0.1
+    np.testing.assert_allclose(zero[deep_idx], constant[deep_idx], rtol=1e-9)
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_float_spinup_threshold_gates_emission(direction):
+    """A float ``spinup`` in (0, 1) marks spin-up bins NaN below the covered-fraction threshold.
+
+    ``spinup=p`` emits a bin only where the covered sub-mass is at least fraction ``p`` of the APVD;
+    otherwise the bin is NaN. Raising the threshold therefore marks a (weakly) growing set of spin-up
+    bins NaN, and is strictly larger here. The threshold only gates emission, never the value: where
+    both thresholds emit, the bin means are identical. This pins the float-threshold branch, which is
+    otherwise exercised only at ``spinup=0.0`` (emit-whenever-covered) and never for ``0 < p < 1``.
+    """
+    n = 80
+    tedges = pd.date_range("2021-01-01", periods=n + 1, freq="D")
+    rng = np.random.default_rng(5)
+    flow = np.clip(110.0 + 40.0 * np.sin(np.arange(n) / 9.0) + rng.normal(0, 7, n), 8.0, None)
+    common = {
+        "flow": flow,
+        "flow_tedges": tedges,
+        "tedges_out": tedges,
+        "mean": 500.0,
+        "std": 200.0,
+        "loc": 30.0,
+        "direction": direction,
+        "retardation_factor": 1.2,
+    }
+    low = gamma_residence_time(**common, spinup=0.05)
+    high = gamma_residence_time(**common, spinup=0.6)
+    nan_low = np.isnan(low)
+    nan_high = np.isnan(high)
+    # Monotone: every bin NaN at the low threshold stays NaN at the higher one.
+    assert np.all(nan_high[nan_low]), "raising the threshold must not un-mask a previously-NaN bin"
+    # And the higher threshold genuinely gates more bins (otherwise the branch is untested).
+    assert nan_high.sum() > nan_low.sum(), "higher threshold should mark strictly more spin-up bins NaN"
+    # The threshold gates emission only, not the value: shared emitted bins agree to machine precision.
+    both = ~nan_low & ~nan_high
+    assert both.any()
+    np.testing.assert_allclose(low[both], high[both], atol=0, rtol=1e-12)

--- a/tests/src/test_gamma_residence_time.py
+++ b/tests/src/test_gamma_residence_time.py
@@ -4,7 +4,9 @@ import pytest
 from scipy.integrate import quad
 from scipy.stats import gamma as gamma_dist
 
+from gwtransport._time import tedges_to_days
 from gwtransport.residence_time import gamma_residence_time, residence_time_full
+from gwtransport.utils import cumulative_flow_volume
 
 DIRECTIONS = ["extraction_to_infiltration", "infiltration_to_extraction"]
 
@@ -130,3 +132,118 @@ def test_bins_outside_record_are_nan():
     tedges_out = pd.date_range("2023-01-01", periods=31, freq="D")  # 10 days past the record
     tau = gamma_residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges_out, mean=300.0, std=80.0)
     assert np.isnan(tau[-1])
+
+
+def _quad_bin_moments(flow, tedges, v_lo, v_hi, mean, std, loc, r, direction):
+    """Independent reference: numerator and denominator of the flow-weighted bin mean by quadrature.
+
+    The bin mean is ``num / den`` with ``num = int f(Vp) G_b(Vp) dVp`` and ``den = int f(Vp)
+    L_b(Vp) dVp``: ``G_b`` the per-streamtube time integral and ``L_b`` the covered length over the
+    bin's cumulative-volume window. The inverse cumulative-volume map ``T`` is built directly with
+    ``np.interp`` and both integrals are taken with ``scipy.quad`` -- independent of this module's
+    phi antiderivative and fixed-band machinery. The kink times of ``T`` are passed to the inner
+    quadrature as break points so the piecewise-linear integrand is integrated cleanly.
+    """
+    alpha, beta = (mean - loc) ** 2 / std**2, std**2 / (mean - loc)
+    td = tedges_to_days(tedges)
+    flow_cum = cumulative_flow_volume(np.asarray(flow, float), np.diff(td), strictly_monotone=True)
+    v_end = flow_cum[-1]
+    sign = -1.0 if direction == "extraction_to_infiltration" else 1.0
+
+    inner_limit = 2 * len(flow_cum) + 50
+
+    def inner(vp):  # (time integral over the covered part of the bin, covered length)
+        if sign < 0:
+            lo, hi = max(v_lo, r * vp), v_hi
+            if hi <= lo:
+                return 0.0, 0.0
+            kinks = sorted(v for v in np.concatenate([flow_cum, flow_cum + r * vp]) if lo < v < hi)
+            g, _ = quad(
+                lambda v: np.interp(v, flow_cum, td) - np.interp(v - r * vp, flow_cum, td),
+                lo,
+                hi,
+                points=kinks,
+                limit=inner_limit,
+            )
+            return g, hi - lo
+        lo, hi = v_lo, min(v_hi, v_end - r * vp)
+        if hi <= lo:
+            return 0.0, 0.0
+        kinks = sorted(v for v in np.concatenate([flow_cum, flow_cum - r * vp]) if lo < v < hi)
+        g, _ = quad(
+            lambda v: np.interp(v + r * vp, flow_cum, td) - np.interp(v, flow_cum, td),
+            lo,
+            hi,
+            points=kinks,
+            limit=inner_limit,
+        )
+        return g, hi - lo
+
+    hi_vp = loc + gamma_dist.ppf(1 - 1e-12, alpha, scale=beta)
+    num, _ = quad(lambda vp: gamma_dist.pdf(vp - loc, alpha, scale=beta) * inner(vp)[0], loc, hi_vp, limit=200)
+    den, _ = quad(lambda vp: gamma_dist.pdf(vp - loc, alpha, scale=beta) * inner(vp)[1], loc, hi_vp, limit=200)
+    return num, den
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_wide_gamma_matches_double_quad(direction):
+    """Wide gamma + variable flow: output bins match an independent double-quadrature reference.
+
+    A wide distribution makes the look-back/forward band span many flow bins, exercising the full
+    piecewise-quadratic G machinery -- the regime where a per-bin looped engine accrues FP noise.
+    Tested against ``scipy.quad`` over both cumulative volume and the gamma density (rtol=1e-7, the
+    quadrature floor), on bins ranging from spin-up to fully informed. Bins whose covered sub-mass
+    is a tiny tail sliver are skipped, since there the quadrature reference -- not the closed form
+    -- is the inaccurate one.
+    """
+    n = 14
+    tedges = pd.date_range("2021-01-01", periods=n + 1, freq="D")
+    rng = np.random.default_rng(3)
+    flow = np.clip(100.0 + 60.0 * np.sin(np.arange(n) / 3.0) + rng.normal(0, 10, n), 10.0, None)
+    mean, std, loc, r = 700.0, 450.0, 50.0, 1.6
+    tau = gamma_residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        mean=mean,
+        std=std,
+        loc=loc,
+        direction=direction,
+        retardation_factor=r,
+    )
+    flow_cum = cumulative_flow_volume(flow, np.diff(tedges_to_days(tedges)), strictly_monotone=True)
+    tested = 0
+    for b in (3, 5, 7, 9, 11):
+        num, den = _quad_bin_moments(flow, tedges, flow_cum[b], flow_cum[b + 1], mean, std, loc, r, direction)
+        if den < 1e-6 or not np.isfinite(tau[b]):  # negligible covered sub-mass -> quad-fragile, skip
+            continue
+        np.testing.assert_allclose(tau[b], num / den, rtol=1e-7)
+        tested += 1
+    assert tested >= 3, "wide-gamma reference should validate several bins from spin-up to deep"
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_tiling_boundary_invariance(direction):
+    """Tiling the output bins does not change the result: 1-bin-per-tile equals a single tile.
+
+    band_width is computed globally, so each bin's integration pieces are independent of the tile
+    it lands in; the loop boundaries must not couple bins. Compared NaN-pattern and value.
+    """
+    n = 60
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    rng = np.random.default_rng(5)
+    flow = np.clip(110.0 + 40.0 * np.sin(np.arange(n) / 9.0) + rng.normal(0, 7, n), 8.0, None)
+    common = {
+        "flow": flow,
+        "flow_tedges": tedges,
+        "tedges_out": tedges,
+        "mean": 900.0,
+        "std": 600.0,
+        "loc": 80.0,
+        "direction": direction,
+        "retardation_factor": 1.3,
+    }
+    one_tile = gamma_residence_time(**common, _max_tile_elements=10**18)
+    tiny_tile = gamma_residence_time(**common, _max_tile_elements=1)
+    np.testing.assert_array_equal(np.isnan(one_tile), np.isnan(tiny_tile))
+    np.testing.assert_allclose(one_tile, tiny_tile, rtol=1e-12, equal_nan=True)

--- a/tests/src/test_residence_time.py
+++ b/tests/src/test_residence_time.py
@@ -2,7 +2,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from gwtransport.residence_time import residence_time, residence_time_full
+from gwtransport.residence_time import (
+    fraction_explained,
+    residence_time,
+    residence_time_full,
+    residence_time_series,
+)
 
 DIRECTIONS = ["extraction_to_infiltration", "infiltration_to_extraction"]
 
@@ -18,36 +23,42 @@ def _constant_flow(n=40, q=100.0):
     return np.full(n, q), pd.date_range("2020-01-01", periods=n + 1, freq="D")
 
 
-def _manual_weighted_mean(rt, weights):
-    """Mass-weighted mean over the valid (non-NaN) streamtubes per output bin."""
-    w = np.asarray(weights, dtype=float)[:, None]
-    num = np.nansum(rt * w, axis=0)
-    den = np.sum(np.where(np.isfinite(rt), w, 0.0), axis=0)
+def _mean_over_valid(rt):
+    """Per-bin arithmetic mean over the finite per-pore-volume entries, via an explicit loop.
+
+    Structurally different from the vectorized ``nansum/count`` in the implementation, so it
+    catches the realistic mutations (renormalizing over the full ``n`` instead of the valid
+    subset, or treating NaN as 0 while keeping the full count).
+    """
     out = np.full(rt.shape[1], np.nan)
-    nonzero = den > 0
-    out[nonzero] = num[nonzero] / den[nonzero]
+    for b in range(rt.shape[1]):
+        column = rt[:, b]
+        finite = column[np.isfinite(column)]
+        if finite.size:
+            out[b] = finite.sum() / finite.size
     return out
 
 
 @pytest.mark.parametrize("direction", DIRECTIONS)
 @pytest.mark.parametrize("r", [1.0, 2.5])
-def test_discrete_equals_manual_weighted_mean(direction, r):
-    """residence_time is exactly the valid-renormalized, mass-weighted mean of residence_time_full.
+@pytest.mark.parametrize("spinup", ["constant", None])
+def test_discrete_equals_mean_over_valid_streamtubes(direction, r, spinup):
+    """residence_time is exactly the mean over the valid streamtubes of residence_time_full.
 
-    This is the defining identity of the discrete APVD mean and must hold to machine precision
-    under variable flow, retardation, and a non-uniform mass.
+    Holds to machine precision for both spin-up policies. Under ``spinup='constant'`` every
+    in-record streamtube is finite (warm-started), so it is a plain mean; under ``spinup=None`` it
+    renormalizes over the streamtubes that have broken through, dropping the rest all-or-nothing.
     """
     flow, tedges = _variable_flow()
-    apv = np.array([300.0, 800.0, 1500.0, 2600.0])
-    mass = np.array([0.4, 0.3, 0.2, 0.1])
+    apv = np.array([250.0, 600.0, 900.0, 1200.0])
     got = residence_time(
         flow=flow,
         flow_tedges=tedges,
         tedges_out=tedges,
         aquifer_pore_volumes=apv,
-        probability_mass=mass,
         direction=direction,
         retardation_factor=r,
+        spinup=spinup,
     )
     rt = residence_time_full(
         flow=flow,
@@ -57,25 +68,38 @@ def test_discrete_equals_manual_weighted_mean(direction, r):
         direction=direction,
         retardation_factor=r,
         weighting="flow",
+        spinup=spinup,
     )
-    expected = _manual_weighted_mean(rt, mass)
+    expected = _mean_over_valid(rt)
     np.testing.assert_array_equal(np.isnan(got), np.isnan(expected))
     np.testing.assert_allclose(got, expected, rtol=0, atol=0, equal_nan=True)
+    if spinup == "constant":
+        assert not np.isnan(got).any(), "constant warm-start must leave no in-record NaN"
+    else:
+        assert np.isnan(got).any(), "fixture must include a fully-uncovered (all-streamtube spin-up) bin"
 
 
-def test_uniform_default_matches_explicit_uniform_mass():
-    """probability_mass=None is exactly the uniform 1/n distribution."""
-    flow, tedges = _variable_flow()
-    apv = np.array([250.0, 900.0, 2000.0])
-    default = residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv)
-    explicit = residence_time(
+@pytest.mark.parametrize("direction", DIRECTIONS)
+@pytest.mark.parametrize("r", [1.0, 2.5])
+def test_constant_spinup_constant_flow_exact(direction, r):
+    """Constant flow + constant warm-start: tau == R*mean(V_p)/Q at every bin, no NaN.
+
+    The extrapolated boundary flow equals the in-record flow, so the spin-up bins take the same
+    value as the deep bins. This pins the warm-start to an independent analytic oracle.
+    """
+    q = 100.0
+    flow, tedges = _constant_flow(q=q)
+    apv = np.array([200.0, 500.0, 900.0])
+    got = residence_time(
         flow=flow,
         flow_tedges=tedges,
         tedges_out=tedges,
         aquifer_pore_volumes=apv,
-        probability_mass=np.full(len(apv), 1.0 / len(apv)),
+        direction=direction,
+        retardation_factor=r,
     )
-    np.testing.assert_array_equal(default, explicit)
+    assert not np.isnan(got).any()
+    np.testing.assert_allclose(got, r * apv.mean() / q, rtol=1e-11)
 
 
 def test_single_pore_volume_reduces_to_residence_time_full():
@@ -88,132 +112,78 @@ def test_single_pore_volume_reduces_to_residence_time_full():
     np.testing.assert_array_equal(got, ref)
 
 
-def test_spinup_all_or_nothing_drops_straddle_streamtube():
-    """A streamtube only partially covering a bin is dropped entirely (all-or-nothing spin-up).
+def test_spinup_none_drops_genuinely_partial_streamtube():
+    """With spinup=None a streamtube covered only part-way through a bin is dropped whole.
 
-    With constant flow the per-streamtube bin average is NaN wherever the look-back parcel leaves
-    the record part-way through the bin. residence_time renormalizes over the remaining valid
-    streamtubes rather than crediting the dropped one's partial sub-mass -- unlike
-    gamma_residence_time, which integrates the partial coverage exactly.
-    """
-    flow, tedges = _constant_flow(n=40, q=100.0)
-    apv = np.array([200.0, 3000.0])  # the large streamtube is still in spin-up where the small one is informed
-    rt = residence_time_full(
-        flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv, weighting="flow"
-    )
-    straddle = np.isfinite(rt[0]) & np.isnan(rt[1])
-    assert straddle.any(), "test setup must include a bin where only the small streamtube is informed"
-
-    got = residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv)
-    # Where only the small streamtube is valid, the mean equals its value exactly (the large one,
-    # though partially covered, contributes nothing).
-    np.testing.assert_allclose(got[straddle], rt[0][straddle], rtol=0, atol=0)
-
-
-def test_spinup_all_or_nothing_drops_genuinely_partial_streamtube():
-    """A streamtube covered only part-way *through a single output bin* is still dropped whole.
-
-    The existing straddle test uses ``tedges_out == flow_tedges``, where a streamtube's bin
-    average flips from whole-bin NaN to whole-bin finite at a bin edge -- it never spans the
-    record edge mid-bin, so it cannot distinguish all-or-nothing from sub-mass crediting. Here
-    the output grid is coarser than the flow grid (5-day bins over a daily record), so the large
-    streamtube is genuinely ~50% covered inside the transition bin while its
-    ``residence_time_full`` row is NaN. All-or-nothing must drop it: the bin mean equals the
-    small streamtube alone, not a coverage-weighted blend with the large one.
+    The output grid is coarser than the flow grid (5-day bins over a daily record), so the large
+    streamtube is genuinely ~50% covered inside the transition bin while its ``residence_time_full``
+    row is NaN. All-or-nothing must drop it: the bin mean equals the small streamtube alone, not a
+    coverage-weighted blend.
     """
     flow = np.full(40, 100.0)
     flow_tedges = pd.date_range("2020-01-01", periods=41, freq="D")
     tedges_out = pd.date_range("2020-01-01", periods=9, freq="5D")  # 8 output bins of 5 days
-    apv = np.array([200.0, 2750.0])  # large needs 27.5 days history -> transition inside bin 5 (days 25..30)
+    apv = np.array([200.0, 2750.0])  # large needs 27.5 days history -> transition inside bin 5
     rt = residence_time_full(
-        flow=flow, flow_tedges=flow_tedges, tedges_out=tedges_out, aquifer_pore_volumes=apv, weighting="flow"
+        flow=flow,
+        flow_tedges=flow_tedges,
+        tedges_out=tedges_out,
+        aquifer_pore_volumes=apv,
+        weighting="flow",
+        spinup=None,
     )
-    # Bin 5 must be exactly the configuration we rely on: small informed, large row NaN.
     assert np.isfinite(rt[0][5]), "test setup: small streamtube must be informed in bin 5"
     assert np.isnan(rt[1][5]), "test setup: large streamtube must straddle the record edge inside bin 5"
-    got = residence_time(flow=flow, flow_tedges=flow_tedges, tedges_out=tedges_out, aquifer_pore_volumes=apv)
-    # If the large tube's partial sub-mass leaked in, the mean would be pulled toward 27.5; it must
-    # stay exactly the small streamtube's 2 days.
+    got = residence_time(
+        flow=flow, flow_tedges=flow_tedges, tedges_out=tedges_out, aquifer_pore_volumes=apv, spinup=None
+    )
+    # If the large tube's partial coverage leaked in, the mean would be pulled toward 27.5 days.
     np.testing.assert_allclose(got[5], rt[0][5], rtol=0, atol=0)
 
 
-def test_loc_shift_matches_manual_weighted_mean():
-    """A non-zero gamma ``loc`` is irrelevant to the discrete mean, but the path must still hold.
-
-    The discrete API takes explicit pore volumes, so ``loc`` enters only through the user's chosen
-    ``aquifer_pore_volumes``; this exercises large shifted pore volumes (relative to the flow
-    record) under variable flow and a non-uniform mass, confirming the valid-renormalized identity
-    survives the deep-spin-up regime those large volumes induce.
-    """
-    flow, tedges = _variable_flow()
-    apv = np.array([1200.0, 1850.0, 2900.0])  # loc-shifted regime: all well into spin-up early on
-    mass = np.array([0.5, 0.3, 0.2])
-    got = residence_time(
-        flow=flow,
-        flow_tedges=tedges,
-        tedges_out=tedges,
-        aquifer_pore_volumes=apv,
-        probability_mass=mass,
-        direction="infiltration_to_extraction",
-    )
-    rt = residence_time_full(
-        flow=flow,
-        flow_tedges=tedges,
-        tedges_out=tedges,
-        aquifer_pore_volumes=apv,
-        direction="infiltration_to_extraction",
-        weighting="flow",
-    )
-    expected = _manual_weighted_mean(rt, mass)
-    np.testing.assert_array_equal(np.isnan(got), np.isnan(expected))
-    np.testing.assert_allclose(got, expected, rtol=0, atol=0, equal_nan=True)
-
-
-def test_fully_uncovered_bin_is_nan():
-    """A bin with no valid streamtube (entirely in spin-up) is NaN."""
+def test_spinup_none_fully_uncovered_bin_is_nan():
+    """With spinup=None, a bin with no valid streamtube (all in spin-up) is NaN."""
     flow, tedges = _constant_flow(n=40, q=100.0)
-    apv = np.array([3500.0, 3800.0])  # both need > 35 days of history; early bins have none
-    got = residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv)
+    apv = np.array([3500.0, 3800.0])  # both need > 35 days of history; the first bins have none
+    got = residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv, spinup=None)
     assert np.isnan(got[0])
 
 
-def test_probability_mass_negative_raises():
-    flow, tedges = _constant_flow()
-    with pytest.raises(ValueError, match="non-negative"):
-        residence_time(
-            flow=flow,
-            flow_tedges=tedges,
-            tedges_out=tedges,
-            aquifer_pore_volumes=[300.0, 600.0],
-            probability_mass=[-0.1, 1.1],
-        )
+@pytest.mark.parametrize("spinup", ["constant", None])
+def test_out_of_window_bin_is_nan(spinup):
+    """Output bins beyond the flow record are NaN under either spin-up policy."""
+    flow, tedges = _constant_flow(n=20, q=100.0)
+    tedges_out = pd.date_range("2020-01-01", periods=31, freq="D")  # extends 10 days past the record
+    got = residence_time(
+        flow=flow, flow_tedges=tedges, tedges_out=tedges_out, aquifer_pore_volumes=300.0, spinup=spinup
+    )
+    assert np.isnan(got[-1])
 
 
-def test_probability_mass_not_summing_to_one_raises():
-    flow, tedges = _constant_flow()
-    with pytest.raises(ValueError, match="sum to 1"):
-        residence_time(
-            flow=flow,
-            flow_tedges=tedges,
-            tedges_out=tedges,
-            aquifer_pore_volumes=[300.0, 600.0],
-            probability_mass=[0.4, 0.4],
-        )
+def test_series_still_marks_spinup_while_full_warm_starts():
+    """residence_time_series keeps its spin-up NaN even though residence_time_full warm-starts.
 
-
-def test_probability_mass_wrong_shape_raises():
-    flow, tedges = _constant_flow()
-    with pytest.raises(ValueError, match="same shape"):
-        residence_time(
-            flow=flow,
-            flow_tedges=tedges,
-            tedges_out=tedges,
-            aquifer_pore_volumes=[300.0, 600.0],
-            probability_mass=[0.2, 0.3, 0.5],
-        )
+    The point series is the primitive behind :func:`fraction_explained`, which therefore still
+    locates the spin-up region (fraction < 1) where the warm-started means are finite.
+    """
+    flow, tedges = _constant_flow(n=40, q=100.0)
+    apv = np.array([200.0, 1500.0])
+    series = residence_time_series(flow=flow, flow_tedges=tedges, aquifer_pore_volumes=apv)
+    full = residence_time_full(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv)
+    assert np.isnan(series).any(), "series must keep its spin-up NaN"
+    assert not np.isnan(full).any(), "full default warm-start must be finite in-record"
+    frac = fraction_explained(rt=series)
+    assert (frac < 1.0).any(), "fraction_explained must flag the spin-up region"
+    assert (frac == 1.0).any(), "fraction_explained must reach 1 outside the spin-up"
 
 
 def test_invalid_direction_raises():
     flow, tedges = _constant_flow()
     with pytest.raises(ValueError, match="direction"):
         residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=300.0, direction="bad")
+
+
+def test_invalid_spinup_raises():
+    flow, tedges = _constant_flow()
+    with pytest.raises(ValueError, match="spinup"):
+        residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=300.0, spinup="bad")

--- a/tests/src/test_residence_time.py
+++ b/tests/src/test_residence_time.py
@@ -1,0 +1,219 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from gwtransport.residence_time import residence_time, residence_time_full
+
+DIRECTIONS = ["extraction_to_infiltration", "infiltration_to_extraction"]
+
+
+def _variable_flow(n=40, seed=1):
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    rng = np.random.default_rng(seed)
+    flow = np.clip(100.0 + 30.0 * np.sin(np.arange(n) / 7.0) + rng.normal(0, 6, n), 5.0, None)
+    return flow, tedges
+
+
+def _constant_flow(n=40, q=100.0):
+    return np.full(n, q), pd.date_range("2020-01-01", periods=n + 1, freq="D")
+
+
+def _manual_weighted_mean(rt, weights):
+    """Mass-weighted mean over the valid (non-NaN) streamtubes per output bin."""
+    w = np.asarray(weights, dtype=float)[:, None]
+    num = np.nansum(rt * w, axis=0)
+    den = np.sum(np.where(np.isfinite(rt), w, 0.0), axis=0)
+    out = np.full(rt.shape[1], np.nan)
+    nonzero = den > 0
+    out[nonzero] = num[nonzero] / den[nonzero]
+    return out
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+@pytest.mark.parametrize("r", [1.0, 2.5])
+def test_discrete_equals_manual_weighted_mean(direction, r):
+    """residence_time is exactly the valid-renormalized, mass-weighted mean of residence_time_full.
+
+    This is the defining identity of the discrete APVD mean and must hold to machine precision
+    under variable flow, retardation, and a non-uniform mass.
+    """
+    flow, tedges = _variable_flow()
+    apv = np.array([300.0, 800.0, 1500.0, 2600.0])
+    mass = np.array([0.4, 0.3, 0.2, 0.1])
+    got = residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        aquifer_pore_volumes=apv,
+        probability_mass=mass,
+        direction=direction,
+        retardation_factor=r,
+    )
+    rt = residence_time_full(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        aquifer_pore_volumes=apv,
+        direction=direction,
+        retardation_factor=r,
+        weighting="flow",
+    )
+    expected = _manual_weighted_mean(rt, mass)
+    np.testing.assert_array_equal(np.isnan(got), np.isnan(expected))
+    np.testing.assert_allclose(got, expected, rtol=0, atol=0, equal_nan=True)
+
+
+def test_uniform_default_matches_explicit_uniform_mass():
+    """probability_mass=None is exactly the uniform 1/n distribution."""
+    flow, tedges = _variable_flow()
+    apv = np.array([250.0, 900.0, 2000.0])
+    default = residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv)
+    explicit = residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        aquifer_pore_volumes=apv,
+        probability_mass=np.full(len(apv), 1.0 / len(apv)),
+    )
+    np.testing.assert_array_equal(default, explicit)
+
+
+def test_single_pore_volume_reduces_to_residence_time_full():
+    """A one-element APVD collapses to that streamtube's residence_time_full row."""
+    flow, tedges = _variable_flow()
+    got = residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=750.0)
+    ref = residence_time_full(
+        flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=750.0, weighting="flow"
+    )[0]
+    np.testing.assert_array_equal(got, ref)
+
+
+def test_spinup_all_or_nothing_drops_straddle_streamtube():
+    """A streamtube only partially covering a bin is dropped entirely (all-or-nothing spin-up).
+
+    With constant flow the per-streamtube bin average is NaN wherever the look-back parcel leaves
+    the record part-way through the bin. residence_time renormalizes over the remaining valid
+    streamtubes rather than crediting the dropped one's partial sub-mass -- unlike
+    gamma_residence_time, which integrates the partial coverage exactly.
+    """
+    flow, tedges = _constant_flow(n=40, q=100.0)
+    apv = np.array([200.0, 3000.0])  # the large streamtube is still in spin-up where the small one is informed
+    rt = residence_time_full(
+        flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv, weighting="flow"
+    )
+    straddle = np.isfinite(rt[0]) & np.isnan(rt[1])
+    assert straddle.any(), "test setup must include a bin where only the small streamtube is informed"
+
+    got = residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv)
+    # Where only the small streamtube is valid, the mean equals its value exactly (the large one,
+    # though partially covered, contributes nothing).
+    np.testing.assert_allclose(got[straddle], rt[0][straddle], rtol=0, atol=0)
+
+
+def test_spinup_all_or_nothing_drops_genuinely_partial_streamtube():
+    """A streamtube covered only part-way *through a single output bin* is still dropped whole.
+
+    The existing straddle test uses ``tedges_out == flow_tedges``, where a streamtube's bin
+    average flips from whole-bin NaN to whole-bin finite at a bin edge -- it never spans the
+    record edge mid-bin, so it cannot distinguish all-or-nothing from sub-mass crediting. Here
+    the output grid is coarser than the flow grid (5-day bins over a daily record), so the large
+    streamtube is genuinely ~50% covered inside the transition bin while its
+    ``residence_time_full`` row is NaN. All-or-nothing must drop it: the bin mean equals the
+    small streamtube alone, not a coverage-weighted blend with the large one.
+    """
+    flow = np.full(40, 100.0)
+    flow_tedges = pd.date_range("2020-01-01", periods=41, freq="D")
+    tedges_out = pd.date_range("2020-01-01", periods=9, freq="5D")  # 8 output bins of 5 days
+    apv = np.array([200.0, 2750.0])  # large needs 27.5 days history -> transition inside bin 5 (days 25..30)
+    rt = residence_time_full(
+        flow=flow, flow_tedges=flow_tedges, tedges_out=tedges_out, aquifer_pore_volumes=apv, weighting="flow"
+    )
+    # Bin 5 must be exactly the configuration we rely on: small informed, large row NaN.
+    assert np.isfinite(rt[0][5]), "test setup: small streamtube must be informed in bin 5"
+    assert np.isnan(rt[1][5]), "test setup: large streamtube must straddle the record edge inside bin 5"
+    got = residence_time(flow=flow, flow_tedges=flow_tedges, tedges_out=tedges_out, aquifer_pore_volumes=apv)
+    # If the large tube's partial sub-mass leaked in, the mean would be pulled toward 27.5; it must
+    # stay exactly the small streamtube's 2 days.
+    np.testing.assert_allclose(got[5], rt[0][5], rtol=0, atol=0)
+
+
+def test_loc_shift_matches_manual_weighted_mean():
+    """A non-zero gamma ``loc`` is irrelevant to the discrete mean, but the path must still hold.
+
+    The discrete API takes explicit pore volumes, so ``loc`` enters only through the user's chosen
+    ``aquifer_pore_volumes``; this exercises large shifted pore volumes (relative to the flow
+    record) under variable flow and a non-uniform mass, confirming the valid-renormalized identity
+    survives the deep-spin-up regime those large volumes induce.
+    """
+    flow, tedges = _variable_flow()
+    apv = np.array([1200.0, 1850.0, 2900.0])  # loc-shifted regime: all well into spin-up early on
+    mass = np.array([0.5, 0.3, 0.2])
+    got = residence_time(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        aquifer_pore_volumes=apv,
+        probability_mass=mass,
+        direction="infiltration_to_extraction",
+    )
+    rt = residence_time_full(
+        flow=flow,
+        flow_tedges=tedges,
+        tedges_out=tedges,
+        aquifer_pore_volumes=apv,
+        direction="infiltration_to_extraction",
+        weighting="flow",
+    )
+    expected = _manual_weighted_mean(rt, mass)
+    np.testing.assert_array_equal(np.isnan(got), np.isnan(expected))
+    np.testing.assert_allclose(got, expected, rtol=0, atol=0, equal_nan=True)
+
+
+def test_fully_uncovered_bin_is_nan():
+    """A bin with no valid streamtube (entirely in spin-up) is NaN."""
+    flow, tedges = _constant_flow(n=40, q=100.0)
+    apv = np.array([3500.0, 3800.0])  # both need > 35 days of history; early bins have none
+    got = residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=apv)
+    assert np.isnan(got[0])
+
+
+def test_probability_mass_negative_raises():
+    flow, tedges = _constant_flow()
+    with pytest.raises(ValueError, match="non-negative"):
+        residence_time(
+            flow=flow,
+            flow_tedges=tedges,
+            tedges_out=tedges,
+            aquifer_pore_volumes=[300.0, 600.0],
+            probability_mass=[-0.1, 1.1],
+        )
+
+
+def test_probability_mass_not_summing_to_one_raises():
+    flow, tedges = _constant_flow()
+    with pytest.raises(ValueError, match="sum to 1"):
+        residence_time(
+            flow=flow,
+            flow_tedges=tedges,
+            tedges_out=tedges,
+            aquifer_pore_volumes=[300.0, 600.0],
+            probability_mass=[0.4, 0.4],
+        )
+
+
+def test_probability_mass_wrong_shape_raises():
+    flow, tedges = _constant_flow()
+    with pytest.raises(ValueError, match="same shape"):
+        residence_time(
+            flow=flow,
+            flow_tedges=tedges,
+            tedges_out=tedges,
+            aquifer_pore_volumes=[300.0, 600.0],
+            probability_mass=[0.2, 0.3, 0.5],
+        )
+
+
+def test_invalid_direction_raises():
+    flow, tedges = _constant_flow()
+    with pytest.raises(ValueError, match="direction"):
+        residence_time(flow=flow, flow_tedges=tedges, tedges_out=tedges, aquifer_pore_volumes=300.0, direction="bad")

--- a/tests/src/test_residence_time_full.py
+++ b/tests/src/test_residence_time_full.py
@@ -27,12 +27,14 @@ def test_basic_extraction(constant_flow_data):
     tedges_out = pd.date_range(start="2023-01-01", end="2023-01-09", freq="1D")
     pore_volume = 200.0
 
+    # spinup=None keeps the strict spin-up NaN at the leading extraction bins.
     result = residence_time_full(
         flow=flow_values,
         flow_tedges=flow_tedges,
         tedges_out=tedges_out,
         aquifer_pore_volumes=pore_volume,
         direction="extraction_to_infiltration",
+        spinup=None,
     )
 
     # With constant flow of 100 m³/day and pore volume of 200 m³, residence time is
@@ -42,18 +44,31 @@ def test_basic_extraction(constant_flow_data):
     assert np.isnan(result[0, 1])
     np.testing.assert_allclose(result[0, 2:], 2.0, atol=0, rtol=1e-13)
 
+    # With the default spinup='constant' the spin-up zone is warm-started, so there is
+    # no in-record NaN: residence time is exactly 2 days at every output bin.
+    result_constant = residence_time_full(
+        flow=flow_values,
+        flow_tedges=flow_tedges,
+        tedges_out=tedges_out,
+        aquifer_pore_volumes=pore_volume,
+        direction="extraction_to_infiltration",
+    )
+    np.testing.assert_allclose(result_constant[0], 2.0, atol=0, rtol=1e-13)
+
 
 def test_basic_infiltration(constant_flow_data):
     """Test basic infiltration scenario with constant flow."""
     flow_values, flow_tedges = constant_flow_data
     pore_volume = 200.0
 
+    # spinup=None keeps the strict spin-up NaN at the trailing infiltration bins.
     result = residence_time_full(
         flow=flow_values,
         flow_tedges=flow_tedges,
         tedges_out=flow_tedges,
         aquifer_pore_volumes=pore_volume,
         direction="infiltration_to_extraction",
+        spinup=None,
     )
 
     # With constant flow of 100 m³/day and pore volume of 200 m³, residence time
@@ -62,6 +77,17 @@ def test_basic_infiltration(constant_flow_data):
     # Later values should be NaN as water hasn't been extracted yet
     assert np.isnan(result[0, -2])
     assert np.isnan(result[0, -1])
+
+    # With the default spinup='constant' the trailing spin-up is warm-started, so there
+    # is no in-record NaN: residence time is exactly 2 days at every output bin.
+    result_constant = residence_time_full(
+        flow=flow_values,
+        flow_tedges=flow_tedges,
+        tedges_out=flow_tedges,
+        aquifer_pore_volumes=pore_volume,
+        direction="infiltration_to_extraction",
+    )
+    np.testing.assert_allclose(result_constant[0], 2.0, atol=0, rtol=1e-13)
 
 
 def test_varying_extraction(constant_flow_data):
@@ -100,6 +126,7 @@ def test_retardation_factor(constant_flow_data):
     flow_values, flow_tedges = constant_flow_data
     pore_volume = 100.0
 
+    # spinup=None keeps the strict spin-up NaN so the leading-NaN assertions stay meaningful.
     result_no_retardation = residence_time_full(
         flow=flow_values,
         flow_tedges=flow_tedges,
@@ -107,6 +134,7 @@ def test_retardation_factor(constant_flow_data):
         aquifer_pore_volumes=pore_volume,
         retardation_factor=1.0,
         direction="extraction_to_infiltration",
+        spinup=None,
     )
 
     result_with_retardation = residence_time_full(
@@ -116,6 +144,7 @@ def test_retardation_factor(constant_flow_data):
         aquifer_pore_volumes=pore_volume,
         retardation_factor=2.0,
         direction="extraction_to_infiltration",
+        spinup=None,
     )
 
     # Residence time should double with retardation factor of 2
@@ -191,13 +220,16 @@ def test_edge_cases(sample_flow_data):
     )
     assert np.all(np.isnan(result_zero))
 
-    # Test very large pore volume
+    # Test very large pore volume. The whole output record lies inside the spin-up zone, so
+    # the strict spinup=None path marks every bin NaN. (Under the default spinup='constant'
+    # these bins are warm-started to finite, very large residence times instead.)
     result_large = residence_time_full(
         flow=flow_values,
         flow_tedges=flow_tedges,
         tedges_out=tedges_out,
         aquifer_pore_volumes=1e6,
         direction="extraction_to_infiltration",
+        spinup=None,
     )
     assert np.all(np.isnan(result_large))
 
@@ -311,12 +343,63 @@ def test_example_from_docstring():
         direction="extraction_to_infiltration",
     )
 
-    # The first values should be NaN (not enough water has passed)
-    assert np.isnan(mean_times[0, 0])
-    assert np.isnan(mean_times[0, 1])
+    # With the default spinup='constant' the docstring example warm-starts the spin-up zone,
+    # so there is no NaN: residence time is exactly 2 days at every output bin under constant flow.
+    np.testing.assert_allclose(mean_times[0], 2.0, atol=0, rtol=1e-13)
 
-    # Later values are exactly 2 days under constant flow.
-    np.testing.assert_allclose(mean_times[0, 2:], 2.0, atol=0, rtol=1e-13)
+
+def test_spinup_policy_constant_vs_none():
+    """Pin the spinup policy contract under constant flow with a spin-up region.
+
+    With constant flow Q and pore volume V_p the residence time is exactly R*V_p/Q at
+    every in-record output bin. A pore volume large enough that the look-back parcel
+    leaves the record over the first bins creates a spin-up region:
+
+    * ``spinup='constant'`` (default) warm-starts the spin-up by extrapolating the
+      boundary flow, so there is no in-record NaN and every bin equals R*V_p/Q.
+    * ``spinup=None`` is strict: the leading extraction bins are NaN, then R*V_p/Q.
+
+    An unrecognised ``spinup`` value must raise ``ValueError``.
+    """
+    flow_tedges = pd.date_range(start="2023-01-01", end="2023-01-10", freq="D")
+    flow = 100.0
+    flow_values = np.full(len(flow_tedges) - 1, flow)
+    retardation_factor = 1.0
+    # V_p = 300 with Q = 100 needs 3 days of look-back, so the first two daily output bins
+    # fall in the spin-up region under the strict policy.
+    pore_volume = 300.0
+    expected = retardation_factor * pore_volume / flow  # = 3.0 days
+
+    common = {
+        "flow": flow_values,
+        "flow_tedges": flow_tedges,
+        "tedges_out": flow_tedges,
+        "aquifer_pore_volumes": pore_volume,
+        "retardation_factor": retardation_factor,
+        "direction": "extraction_to_infiltration",
+    }
+
+    rt_constant = residence_time_full(**common, spinup="constant")
+    rt_none = residence_time_full(**common, spinup=None)
+
+    # Default warm-start: no NaN anywhere in-record, exactly R*V_p/Q at every bin.
+    assert not np.any(np.isnan(rt_constant))
+    np.testing.assert_allclose(rt_constant[0], expected, atol=0, rtol=1e-13)
+
+    # Strict: there is a genuine leading spin-up region (the first bin is NaN), it is a
+    # contiguous leading block, and every finite bin afterwards is exactly R*V_p/Q.
+    nan_mask = np.isnan(rt_none[0])
+    assert nan_mask[0]
+    n_nan = int(np.argmin(nan_mask)) if not nan_mask.all() else nan_mask.size
+    assert n_nan >= 1
+    assert not np.any(nan_mask[n_nan:])  # NaNs form a contiguous leading block
+    np.testing.assert_allclose(rt_none[0, n_nan:], expected, atol=0, rtol=1e-13)
+
+    # Wherever the strict path is finite it agrees exactly with the warm-started default.
+    np.testing.assert_allclose(rt_none[0, n_nan:], rt_constant[0, n_nan:], atol=0, rtol=1e-13)
+
+    with pytest.raises(ValueError, match="spinup"):
+        residence_time_full(**common, spinup="bad")
 
 
 # ---------------------------------------------------------------------------
@@ -450,6 +533,9 @@ def test_kink_handling_against_fine_grid():
     tedges_out = flow_tedges  # daily output bins, same as flow tedges
     n_fine = 20001
 
+    # The fine-grid reference below is built from residence_time_series, which always
+    # returns NaN in the spin-up (no warm-start). Use spinup=None so residence_time_full
+    # takes the matching strict path and the spin-up bin stays NaN in both.
     rt_mean = residence_time_full(
         flow=flow_values,
         flow_tedges=flow_tedges,
@@ -457,6 +543,7 @@ def test_kink_handling_against_fine_grid():
         aquifer_pore_volumes=pore_volume,
         direction="extraction_to_infiltration",
         weighting="time",
+        spinup=None,
     )
 
     # Independent reference: dense pointwise tau via residence_time_series, trapezoidal


### PR DESCRIPTION
## Summary

Three flow-weighted APVD-mean residence-time functions in `residence_time.py`, both directions + retardation + `loc`, with a package-consistent spin-up policy.

**`gamma_residence_time`** — the per-output-bin Python loop is replaced by a fully **vectorized `(n_out, P)` fixed-band closed-form engine** (exact, no `n_bins`). Per bin it builds a direction-specific band of flow-edge breakpoints, clips to the gamma support `[ppf(1e-13), ppf(1−1e-13)]`, reconstructs the piecewise-quadratic per-bin time integral `G_b(V_p)` Lagrange-exactly from 3 nodes of the `phi` antiderivative, and contracts `G`/covered-length against the gamma partial moments (`M0/M1/M2` via **one CDF per shape** + `np.diff`). Tiled over output bins to bound peak memory.

**`residence_time`** — a simple **discrete equal-weight mean** over `aquifer_pore_volumes` (the old `partial_moments`/`support` continuous API is removed). It is the mean over the valid streamtubes of `residence_time_full(weighting="flow")`.

**Spin-up policy (`spinup`)** — following the package convention (`advection`), all three means default to `spinup="constant"`: warm-start the spin-up by **extrapolating the boundary flow** (held constant at its first/last value), so no in-record output is NaN.
- `residence_time` / `residence_time_full`: `spinup={"constant", None}` — `None` keeps the strict per-bin spin-up NaN.
- `gamma_residence_time`: `spinup={"constant"} | float in [0, 1)` — a `float` renormalizes over the covered sub-mass with a covered-fraction threshold; `0.0` is the exact covered-sub-mass conditional mean (bit-identical to the closed-form engine, 3.6e-16).
- `residence_time_series` is unchanged (always NaN in spin-up); it and `fraction_explained` remain the spin-up-region descriptors.

The module docstring gains a `Spin-up period` section. Removed the dead `partial_moments`/`support` surface, `_GAMMA_SUPPORT_TAIL`, `Callable` import, and the `probability_mass`/`weighting` parameters from the means (flow-weighted, equal-weight only). `assumptions.rst` lists both means.

## Test plan

- `ruff format` / `ruff check` clean; `ty check` clean; module doctests pass.
- Full unit suite green (`pytest tests/src -n auto`).
- **Exactness (tolerances unchanged):** constant-flow deep bin `== R·mean/Q` (rtol=1e-11); narrow gamma (std→0) `== residence_time_full` single pore volume; `(alpha,beta)==(mean,std)`; tiling-boundary invariance (bit-identical).
- **`gamma` covered-sub-mass** (`spinup=0.0`): vs independent `scipy.quad` / double-quadrature references (rtol=1e-9 / 1e-7); bit-identical to a verified vectorized prototype (3.56e-16) and an independent brute-force quadrature oracle (~1e-12 deep bins).
- **`spinup="constant"` warm-start:** constant flow → `R·mean/Q` at *every* bin incl. former spin-up (rtol=1e-11, both directions, R≠1); gamma "constant" converges to discrete `residence_time` "constant" at the discretization limit; mutation-tested (the warm-start extrapolation is load-bearing). `pad = R·max(V_p)` proven exactly sufficient (no silent clamp).
- **`spinup=None` / float threshold:** all-or-nothing per streamtube pinned (genuinely mid-bin-partial case); float threshold gates emission monotonically; `residence_time_series` still NaN in spin-up so `fraction_explained` keeps working; out-of-window bins NaN under every policy; invalid `spinup` raises.
- Reviewer sign-off (physics, tests, leanness) on both the engine and the spin-up policy.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
