### PR TITLE
deposition: vacuous-test fixes, spinup docs, leanness (review)

### DIFF
--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -31,9 +31,9 @@ Available functions:
   choosing between different nullspace objectives (``'squared_differences'``,
   ``'summed_differences'``, or custom callables) and optimization methods.
 
-- :func:`compute_deposition_weights` - Internal helper function. Build the weight operator
-  relating deposition rates to concentration changes in a compact banded layout. Used by
-  deposition_to_extraction (forward), extraction_to_deposition (reverse), and
+- :func:`compute_deposition_weights` - Build the banded weight operator relating deposition
+  rates to concentration changes in a compact banded layout. Useful for custom inverse solvers.
+  Used by deposition_to_extraction (forward), extraction_to_deposition (reverse), and
   extraction_to_deposition_full. Calculates contact area between water parcels and aquifer
   matrix based on streamline geometry and residence times.
 
@@ -153,7 +153,6 @@ def compute_deposition_weights(
 ) -> tuple[
     npt.NDArray[np.floating],
     npt.NDArray[np.intp],
-    npt.NDArray[np.floating],
     npt.NDArray[np.bool_],
     npt.NDArray[np.bool_],
 ]:
@@ -178,13 +177,13 @@ def compute_deposition_weights(
     Parameters
     ----------
     flow : array-like
-        Flow rates in aquifer [m3/day]. Length must equal ``len(tedges) - 1``.
+        Flow rates in aquifer [m³/day]. Length must equal ``len(tedges) - 1``.
     tedges : pandas.DatetimeIndex
         Time bin edges for flow data.
     cout_tedges : pandas.DatetimeIndex
         Time bin edges for output concentration data.
     aquifer_pore_volume : float
-        Aquifer pore volume [m3].
+        Aquifer pore volume [m³].
     porosity : float
         Aquifer porosity [dimensionless].
     thickness : float
@@ -201,9 +200,6 @@ def compute_deposition_weights(
         residence time, zero-flow cout bins) are zero.
     col_start : numpy.ndarray of int
         First cin bin index of each cout row's band, shape ``(n_cout,)``.
-    extracted_volume : numpy.ndarray
-        Through-flow volume extracted during each cout bin, shape ``(n_cout,)``.
-        Zero for zero-flow cout bins.
     row_valid : numpy.ndarray of bool
         True for cout bins whose residence-time window is fully defined and
         carries flow (the finite, nonzero rows), shape ``(n_cout,)``.
@@ -275,19 +271,20 @@ def compute_deposition_weights(
     slot = np.arange(full_band)[None, :]
     widths = np.where(slot < width[:, None], widths, 0.0)
 
-    # volume = clipped_integral / width, area = volume / (porosity*thickness),
-    # numerator = area * width -- so the bin width cancels and numerator is just
-    # clipped_integral / (porosity*thickness). _clipped_linear_integral already
-    # integrates over the bin width, so do NOT multiply by widths again.
+    # _clipped_linear_integral returns the volume*time measure (m³*day) of the
+    # parcel's residence-window overlap with each cin bin; dividing by
+    # (porosity*thickness) converts that overlap to contact area * time. The bin
+    # width is already folded into the integral, so do NOT multiply by widths
+    # again.
     top_integral = _clipped_linear_integral(y_top[:, :-1], y_top[:, 1:], widths, 0.0, r_apv)
     bottom_integral = _clipped_linear_integral(y_bot[:, :-1], y_bot[:, 1:], widths, 0.0, r_apv)
-    areas = np.maximum(top_integral - bottom_integral, 0.0)
-    numerator = areas / (porosity * thickness)
+    contact_volume_time = np.maximum(top_integral - bottom_integral, 0.0)
+    numerator = contact_volume_time / (porosity * thickness)
 
     band_vals = np.zeros((n_cout, full_band))
     # row_valid implies extracted_volume > 0, so the masked divide never sees a zero.
     band_vals[row_valid] = numerator[row_valid] / extracted_volume[row_valid, None]
-    return band_vals, col_start, extracted_volume, row_valid, spinup_row
+    return band_vals, col_start, row_valid, spinup_row
 
 
 def deposition_to_extraction(
@@ -307,16 +304,16 @@ def deposition_to_extraction(
     Parameters
     ----------
     dep : array-like
-        Deposition rates [ng/m2/day]. Length must equal len(tedges) - 1.
+        Deposition rates [ng/m²/day]. Length must equal len(tedges) - 1.
     flow : array-like
-        Flow rates in aquifer [m3/day]. Length must equal len(tedges) - 1. The model
+        Flow rates in aquifer [m³/day]. Length must equal len(tedges) - 1. The model
         assumes this value is constant over each interval ``[tedges[i], tedges[i+1])``.
     tedges : pandas.DatetimeIndex
         Time bin edges for deposition and flow data.
     cout_tedges : pandas.DatetimeIndex
         Time bin edges for output concentration data.
     aquifer_pore_volume : float
-        Aquifer pore volume [m3].
+        Aquifer pore volume [m³].
     porosity : float
         Aquifer porosity [dimensionless].
     thickness : float
@@ -330,13 +327,13 @@ def deposition_to_extraction(
         ``dep`` and ``flow`` as constant at their first observed values
         over the prepended interval. ``None`` keeps the existing
         strict-validity behavior (NaN cout rows during spin-up). A float
-        threshold has no effect with a single pore volume and behaves
-        like ``None``.
+        value is accepted but silently ignored; behavior is identical to
+        ``None``.
 
     Returns
     -------
     numpy.ndarray
-        Concentration changes [ng/m3] with length len(cout_tedges) - 1.
+        Concentration changes [ng/m³] with length len(cout_tedges) - 1.
 
     Raises
     ------
@@ -349,6 +346,7 @@ def deposition_to_extraction(
     See Also
     --------
     extraction_to_deposition : Inverse operation (deconvolution)
+    spinup_duration : Earliest extraction time with a fully resolved deposition history
     gwtransport.advection.infiltration_to_extraction : For concentration transport without deposition
     :ref:`concept-transport-equation` : Flow-weighted averaging approach
 
@@ -377,6 +375,8 @@ def deposition_to_extraction(
     ...     porosity=0.3,
     ...     thickness=10.0,
     ... )
+    >>> print(f"First finite cout: {cout[np.isfinite(cout)][0]:.4f} ng/m³")
+    First finite cout: 1.6667 ng/m³
     """
     tedges, cout_tedges = pd.DatetimeIndex(tedges), pd.DatetimeIndex(cout_tedges)
     dep_values, flow_values = np.asarray(dep), np.asarray(flow)
@@ -400,13 +400,13 @@ def deposition_to_extraction(
         retardation_factor=retardation_factor,
         cin=dep_values,
     )
-    weight_dep = np.asarray(weight_dep)
+    assert weight_dep is not None  # noqa: S101 -- narrowed: cin was passed in
 
     # Build the banded forward operator and apply it as a banded einsum instead of
     # a dense W.dot(dep). Spin-up rows (NaN residence time) carry an all-zero band
     # and must return NaN. Zero-flow cout bins (extracted_volume == 0) carry a zero
     # band and return 0.
-    band_vals, col_start, _, _, spinup_row = compute_deposition_weights(
+    band_vals, col_start, _, spinup_row = compute_deposition_weights(
         flow=weight_flow,
         tedges=weight_tedges,
         cout_tedges=cout_tedges,
@@ -449,13 +449,13 @@ def extraction_to_deposition(
     Parameters
     ----------
     cout : array-like
-        Concentration changes in extracted water [ng/m3]. Length must equal
+        Concentration changes in extracted water [ng/m³]. Length must equal
         len(cout_tedges) - 1. May contain NaN values, which will be excluded
         from the computation along with corresponding rows in the weight matrix.
         The model assumes this value is constant over each interval
         ``[cout_tedges[i], cout_tedges[i+1])``.
     flow : array-like
-        Flow rates in aquifer [m3/day]. Length must equal len(tedges) - 1.
+        Flow rates in aquifer [m³/day]. Length must equal len(tedges) - 1.
         Must not contain NaN values. The model assumes this value is constant
         over each interval ``[tedges[i], tedges[i+1])``.
     tedges : pandas.DatetimeIndex
@@ -465,7 +465,7 @@ def extraction_to_deposition(
         Time bin edges for output concentration data. Length must equal
         len(cout) + 1.
     aquifer_pore_volume : float
-        Aquifer pore volume [m3].
+        Aquifer pore volume [m³].
     porosity : float
         Aquifer porosity [dimensionless].
     thickness : float
@@ -488,13 +488,13 @@ def extraction_to_deposition(
         flow as constant at its first value over the prepended interval;
         the recovered deposition vector is sliced back to the original
         ``tedges`` length so the public output shape is unchanged.
-        ``None`` keeps strict-validity behavior. A float threshold has no
-        effect with a single pore volume and behaves like ``None``.
+        ``None`` keeps strict-validity behavior. A float value is accepted
+        but silently ignored; behavior is identical to ``None``.
 
     Returns
     -------
     numpy.ndarray
-        Mean deposition rates [ng/m2/day] between tedges. Length equals
+        Mean deposition rates [ng/m²/day] between tedges. Length equals
         len(tedges) - 1.
 
     Raises
@@ -506,6 +506,7 @@ def extraction_to_deposition(
     --------
     deposition_to_extraction : Forward operation (convolution)
     extraction_to_deposition_full : Full solver with nullspace options
+    spinup_duration : Earliest extraction time with a fully resolved deposition history
     gwtransport.advection.extraction_to_infiltration : For concentration transport without deposition
     gwtransport.utils.solve_inverse_transport_banded : Banded Tikhonov solver used for inversion
     :ref:`concept-transport-equation` : Flow-weighted averaging approach
@@ -548,8 +549,8 @@ def extraction_to_deposition(
     >>> tedges = pd.date_range("2019-12-31 12:00", "2020-01-10 12:00", freq="D")
     >>> cout_tedges = pd.date_range("2020-01-03 12:00", "2020-01-12 12:00", freq="D")
     >>>
-    >>> flow = np.full(len(dates), 100.0)  # m3/day
-    >>> cout = np.ones(len(cout_tedges) - 1) * 10.0  # ng/m3
+    >>> flow = np.full(len(dates), 100.0)  # m³/day
+    >>> cout = np.ones(len(cout_tedges) - 1) * 10.0  # ng/m³
     >>>
     >>> dep = extraction_to_deposition(
     ...     cout=cout,
@@ -562,8 +563,8 @@ def extraction_to_deposition(
     ... )
     >>> print(f"Deposition rates shape: {dep.shape}")
     Deposition rates shape: (10,)
-    >>> print(f"Mean deposition rate: {np.nanmean(dep):.2f} ng/m2/day")
-    Mean deposition rate: 6.00 ng/m2/day
+    >>> print(f"Mean deposition rate: {np.nanmean(dep):.2f} ng/m²/day")
+    Mean deposition rate: 6.00 ng/m²/day
     """
     tedges, cout_tedges = pd.DatetimeIndex(tedges), pd.DatetimeIndex(cout_tedges)
     cout_values, flow_values = np.asarray(cout), np.asarray(flow)
@@ -589,7 +590,7 @@ def extraction_to_deposition(
     )
 
     # Build the banded forward operator (rows sum to r_k = RT_k/(porosity*thickness)).
-    band_vals, col_start, _, row_valid, _ = compute_deposition_weights(
+    band_vals, col_start, row_valid, _ = compute_deposition_weights(
         flow=weight_flow,
         tedges=weight_tedges,
         cout_tedges=cout_tedges,
@@ -651,11 +652,11 @@ def extraction_to_deposition_full(
     Parameters
     ----------
     cout : array-like
-        Concentration changes in extracted water [ng/m3]. Length must equal
+        Concentration changes in extracted water [ng/m³]. Length must equal
         len(cout_tedges) - 1. May contain NaN values, which will be excluded
         from the computation along with corresponding rows in the weight matrix.
     flow : array-like
-        Flow rates in aquifer [m3/day]. Length must equal len(tedges) - 1.
+        Flow rates in aquifer [m³/day]. Length must equal len(tedges) - 1.
         Must not contain NaN values.
     tedges : pandas.DatetimeIndex
         Time bin edges for deposition and flow data. Length must equal
@@ -664,7 +665,7 @@ def extraction_to_deposition_full(
         Time bin edges for output concentration data. Length must equal
         len(cout) + 1.
     aquifer_pore_volume : float
-        Aquifer pore volume [m3].
+        Aquifer pore volume [m³].
     porosity : float
         Aquifer porosity [dimensionless].
     thickness : float
@@ -690,12 +691,14 @@ def extraction_to_deposition_full(
         Default ``"constant"`` shifts ``tedges[0]`` backward by
         ``retardation_factor * aquifer_pore_volume / flow[0]``; the
         recovered deposition is sliced back to the original ``tedges``
-        length. See :func:`extraction_to_deposition` for full semantics.
+        length. ``None`` keeps strict-validity behavior. A float value is
+        accepted but silently ignored; behavior is identical to ``None``.
+        See :func:`extraction_to_deposition` for full semantics.
 
     Returns
     -------
     numpy.ndarray
-        Mean deposition rates [ng/m2/day] between tedges. Length equals
+        Mean deposition rates [ng/m²/day] between tedges. Length equals
         len(tedges) - 1.
 
     Raises
@@ -709,6 +712,7 @@ def extraction_to_deposition_full(
     See Also
     --------
     extraction_to_deposition : Recommended solver using Tikhonov regularization.
+    spinup_duration : Earliest extraction time with a fully resolved deposition history.
     gwtransport.utils.solve_underdetermined_system : Underlying solver.
 
     Notes
@@ -743,7 +747,7 @@ def extraction_to_deposition_full(
     # The nullspace solver (lstsq + null_space SVD) genuinely needs a dense matrix,
     # so build the band and densify it. Spin-up rows are set to NaN to match the
     # behavior of the historical dense build (which left those rows entirely NaN).
-    band_vals, col_start, _, _, spinup_row = compute_deposition_weights(
+    band_vals, col_start, _, spinup_row = compute_deposition_weights(
         flow=weight_flow,
         tedges=weight_tedges,
         cout_tedges=cout_tedges,
@@ -769,8 +773,8 @@ def extraction_to_deposition_full(
 
 def spinup_duration(
     *,
-    flow: np.ndarray,
-    flow_tedges: pd.DatetimeIndex,
+    flow: npt.ArrayLike,
+    tedges: pd.DatetimeIndex,
     aquifer_pore_volume: float,
     retardation_factor: float,
 ) -> float:
@@ -778,21 +782,21 @@ def spinup_duration(
     Compute the spinup duration for deposition modeling.
 
     The spinup duration is the smallest extraction time ``t*`` (relative to
-    ``flow_tedges[0]``) at which the extracted water was infiltrated exactly
-    at ``flow_tedges[0]``: equivalently, the time at which the cumulative
-    flow first reaches ``retardation_factor * aquifer_pore_volume``. For
-    extraction times earlier than ``t*`` the extracted concentration lacks
-    complete deposition history. Under constant flow this equals
+    ``tedges[0]``) at which the extracted water was infiltrated exactly at
+    ``tedges[0]``: equivalently, the time at which the cumulative flow first
+    reaches ``retardation_factor * aquifer_pore_volume``. For extraction times
+    earlier than ``t*`` the extracted concentration lacks complete deposition
+    history. Under constant flow this equals
     ``aquifer_pore_volume * retardation_factor / flow``.
 
     Parameters
     ----------
-    flow : numpy.ndarray
-        Flow rate of water in the aquifer [m3/day].
-    flow_tedges : pandas.DatetimeIndex
+    flow : array-like
+        Flow rate of water in the aquifer [m³/day].
+    tedges : pandas.DatetimeIndex
         Time edges for the flow data.
     aquifer_pore_volume : float
-        Pore volume of the aquifer [m3].
+        Pore volume of the aquifer [m³].
     retardation_factor : float
         Retardation factor of the compound in the aquifer [dimensionless].
 
@@ -804,9 +808,14 @@ def spinup_duration(
     Raises
     ------
     ValueError
-        If the cumulative flow over the entire ``flow_tedges`` window does
-        not reach ``retardation_factor * aquifer_pore_volume``, indicating
-        the flow timeseries is too short to fully characterise the aquifer.
+        If the cumulative flow over the entire ``tedges`` window does not
+        reach ``retardation_factor * aquifer_pore_volume``, indicating the
+        flow timeseries is too short to characterise the spin-up duration.
+
+    See Also
+    --------
+    deposition_to_extraction : Forward solver that uses the spin-up duration to resolve NaN cout rows.
+    extraction_to_deposition : Inverse solver.
     """
     # Spin-up is the residence time of water *currently being extracted*: how
     # far back in history we must know deposition to fully characterise the
@@ -817,27 +826,27 @@ def spinup_duration(
     # forward-in-time question that is not what spin-up means).
     #
     # The smallest extraction time t* at which the extracted water was
-    # infiltrated exactly at flow_tedges[0] satisfies
+    # infiltrated exactly at tedges[0] satisfies
     # ``flow_cum(t*) = R * V_pore``; the spin-up duration is then
     # ``t* - 0 = t*``. Inverting the cumulative flow gives this value
-    # exactly (no quantisation to flow_tedges spacing). Under constant flow
+    # exactly (no quantisation to tedges spacing). Under constant flow
     # this matches V*R/Q.
     flow_arr = np.asarray(flow)
-    flow_tedges_days = tedges_to_days(flow_tedges)
-    dt_days = np.diff(flow_tedges_days)
+    tedges_days = tedges_to_days(tedges)
+    dt_days = np.diff(tedges_days)
     target_cum = retardation_factor * float(aquifer_pore_volume)
     # Feasibility guard on the *un-bumped* cumulative total: the request is infeasible iff
     # R*V_pore exceeds the true total infiltrated volume. (The monotone bump below would
     # otherwise lift a trailing Q=0 plateau above target_cum and admit an infeasible request.)
     flow_cum_raw = cumulative_flow_volume(flow_arr, dt_days)
     if not flow_cum_raw[-1] >= target_cum:
-        msg = "Residence time at the first time step is NaN. This indicates that the aquifer is not fully informed: flow timeseries too short."
+        msg = (
+            f"Cumulative flow over the entire tedges window ({flow_cum_raw[-1]:.6g} m³) does not reach "
+            f"retardation_factor * aquifer_pore_volume ({target_cum:.6g} m³); the flow timeseries is too "
+            "short to characterise the spin-up duration."
+        )
         raise ValueError(msg)
     # Plateaus in flow_cum from Q = 0 bins make V → t inversion multi-valued; bump duplicates
     # by the smallest representable amount so np.interp resolves consistently at plateau levels.
     flow_cum = cumulative_flow_volume(flow_arr, dt_days, strictly_monotone=True)
-    rt_value = float(linear_interpolate(x_ref=flow_cum, y_ref=flow_tedges_days, x_query=target_cum))
-    if np.isnan(rt_value):
-        msg = "Residence time at the first time step is NaN. This indicates that the aquifer is not fully informed: flow timeseries too short."
-        raise ValueError(msg)
-    return rt_value
+    return float(linear_interpolate(x_ref=flow_cum, y_ref=tedges_days, x_query=target_cum))

--- a/src/gwtransport/deposition_utils.py
+++ b/src/gwtransport/deposition_utils.py
@@ -34,8 +34,6 @@ def _positive_part_integral(
         Integral values.
     """
     both_pos = (a > 0) & (b > 0)
-    only_a_pos = (a > 0) & ~both_pos
-    only_b_pos = (b > 0) & ~both_pos
 
     abs_diff = np.abs(a - b)
     # Sentinel ``1.0`` avoids division by zero in the ``excess**2 / (2*safe_diff)``
@@ -44,7 +42,11 @@ def _positive_part_integral(
     # is used instead), so the sentinel value is never observed in the output.
     safe_diff = np.where(abs_diff > 0, abs_diff, 1.0)
 
-    excess = np.where(only_a_pos, a, np.where(only_b_pos, b, 0.0))
+    # When exactly one endpoint is positive, ``excess`` is that endpoint;
+    # when neither is positive it is 0. ``max(max(a, b), 0)`` yields both:
+    # the positive endpoint when only one is positive, 0 otherwise. The
+    # both-positive case is discarded by the ``np.where`` below.
+    excess = np.maximum(np.maximum(a, b), 0.0)
 
     return np.where(
         both_pos,

--- a/tests/src/test_deposition.py
+++ b/tests/src/test_deposition.py
@@ -35,7 +35,7 @@ def _dense_weights(**kwargs):
     to NaN to match the historical dense build. Tests that need the dense operator
     use this helper; the densified band equals the old dense matrix on its support.
     """
-    band_vals, col_start, _, _, spinup_row = compute_deposition_weights(**kwargs)
+    band_vals, col_start, _, spinup_row = compute_deposition_weights(**kwargs)
     n_cin = len(kwargs["tedges"]) - 1
     dense = _densify_weights(band_vals, col_start, n_cin)
     dense[spinup_row] = np.nan
@@ -464,8 +464,8 @@ def test_linearity_exact():
     valid_double = cout_double[~np.isnan(cout_double)]
 
     min_len = min(len(valid_base), len(valid_double))
-    if min_len >= 1:
-        np.testing.assert_allclose(valid_double[:min_len], 2.0 * valid_base[:min_len], rtol=1e-12, atol=0)
+    assert min_len >= 1, "setup must produce at least one valid cout bin"
+    np.testing.assert_allclose(valid_double[:min_len], 2.0 * valid_base[:min_len], rtol=1e-12, atol=0)
 
 
 def test_negative_deposition_linearity():
@@ -510,8 +510,8 @@ def test_negative_deposition_linearity():
     valid_neg = cout_negative[~np.isnan(cout_negative)]
 
     min_len = min(len(valid_pos), len(valid_neg))
-    if min_len >= 1:
-        np.testing.assert_allclose(valid_neg[:min_len], -valid_pos[:min_len], rtol=1e-12, atol=0)
+    assert min_len >= 1, "setup must produce at least one valid cout bin"
+    np.testing.assert_allclose(valid_neg[:min_len], -valid_pos[:min_len], rtol=1e-12, atol=0)
 
 
 def test_parameter_scaling_exact():
@@ -562,16 +562,23 @@ def test_parameter_scaling_exact():
     valid_2 = cout_2[~np.isnan(cout_2)]
 
     min_len = min(len(valid_1), len(valid_2))
-    if min_len >= 1:
-        for i in range(min_len):
-            ratio = valid_1[i] / valid_2[i]
-            expected_ratio = porosity_2 / porosity_1  # Should be 2.0
-            rel_error = abs(ratio - expected_ratio) / expected_ratio
-            assert rel_error < 1e-10, f"Porosity scaling failed: ratio={ratio:.6f}, expected={expected_ratio:.6f}"
+    assert min_len >= 1, "setup must produce at least one valid cout bin"
+    for i in range(min_len):
+        ratio = valid_1[i] / valid_2[i]
+        expected_ratio = porosity_2 / porosity_1  # Should be 2.0
+        rel_error = abs(ratio - expected_ratio) / expected_ratio
+        assert rel_error < 1e-10, f"Porosity scaling failed: ratio={ratio:.6f}, expected={expected_ratio:.6f}"
 
 
-def test_input_validation():
-    """Test input validation with exact error messages."""
+def test_input_validation_public_api_wires_validator():
+    """The public forward/inverse entry points invoke ``_validate_deposition_inputs``.
+
+    Per-message coverage of every ValueError branch lives in the parametrized
+    ``test_validate_deposition_inputs_raises_on_bad_input``; this test keeps only a
+    single forward and a single inverse public-API smoke check so the wiring
+    (entry point -> validator) stays pinned without duplicating the per-message
+    assertions.
+    """
     dates = pd.date_range("2020-01-01", "2020-01-04", freq="D")
     tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
 
@@ -582,44 +589,24 @@ def test_input_validation():
         "retardation_factor": 1.0,
     }
 
-    # Test tedges length mismatch
+    # Forward entry point surfaces a validator error (tedges/flow parity).
     with pytest.raises(ValueError, match="tedges must have one more element than flow"):
         deposition_to_extraction(
             dep=np.ones(3),
             flow=np.ones(4),
             tedges=tedges[:4],
             cout_tedges=tedges[1:3],
-            aquifer_pore_volume=params["aquifer_pore_volume"],
-            porosity=params["porosity"],
-            thickness=params["thickness"],
-            retardation_factor=params["retardation_factor"],
+            **params,
         )
 
-    # Test cout_tedges length mismatch in extraction_to_deposition
+    # Inverse entry point surfaces a validator error (cout_tedges/cout parity).
     with pytest.raises(ValueError, match="cout_tedges must have one more element than cout"):
         extraction_to_deposition(
             cout=np.ones(3),
             flow=np.ones(3),
             tedges=tedges[:4],
             cout_tedges=tedges[:3],
-            aquifer_pore_volume=params["aquifer_pore_volume"],
-            porosity=params["porosity"],
-            thickness=params["thickness"],
-            retardation_factor=params["retardation_factor"],
-        )
-
-    # Test NaN in flow (should be rejected)
-    flow_with_nan = np.array([50.0, np.nan, 60.0])
-    with pytest.raises(ValueError, match="flow array cannot contain NaN values"):
-        extraction_to_deposition(
-            cout=np.ones(2),
-            flow=flow_with_nan,
-            tedges=tedges[:4],
-            cout_tedges=tedges[1:4],
-            aquifer_pore_volume=params["aquifer_pore_volume"],
-            porosity=params["porosity"],
-            thickness=params["thickness"],
-            retardation_factor=params["retardation_factor"],
+            **params,
         )
 
 
@@ -799,6 +786,69 @@ def test_extraction_to_deposition_full_with_rcond(full_solver_overdetermined_set
     np.testing.assert_allclose(recovered, original_deposition, rtol=1e-10, atol=1e-10)
 
 
+def test_extraction_to_deposition_full_objective_selection_underdetermined():
+    """On an underdetermined system the two nullspace objectives select different fits.
+
+    The overdetermined fixtures collapse the nullspace to dimension zero, so the
+    objective argument is dead there -- both objectives return the same unique
+    least-squares solution and the selection logic is never exercised. Here 8
+    daily cin bins are observed through only 3 valid (coarse 2-day) cout bins, so
+    the nullspace has dimension 5 and the objective genuinely picks one solution
+    out of an affine family. We assert:
+
+    (a) each objective exactly fits the data on the valid rows
+        (``W_valid @ dep_rec == cout_valid`` to machine precision), confirming
+        both stay on the solution manifold, and
+    (b) the smooth (``squared_differences``) and sparse (``summed_differences``)
+        objectives land on genuinely different points of that manifold, proving
+        the objective selection is load-bearing.
+    """
+    n = 8
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    # Coarse 2-day cout edges -> 4 cout bins for 8 cin bins (underdetermined).
+    cout_tedges = pd.date_range("2020-01-01", periods=5, freq="2D")
+    flow = np.full(n, 100.0)
+    params = {
+        "aquifer_pore_volume": 150.0,  # RT = 1.5 days
+        "porosity": 0.25,
+        "thickness": 4.0,
+        "retardation_factor": 1.0,
+    }
+    dep_true = np.array([10.0, 20.0, 30.0, 25.0, 15.0, 35.0, 40.0, 30.0])
+
+    # spinup=None keeps the operator un-padded so the densified W matches the
+    # solver's matrix exactly (no warm-start prefix to slice off).
+    cout = deposition_to_extraction(
+        dep=dep_true, flow=flow, tedges=tedges, cout_tedges=cout_tedges, spinup=None, **params
+    )
+
+    dense = _dense_weights(flow=flow, tedges=tedges, cout_tedges=cout_tedges, **params)
+    valid = ~np.isnan(dense).any(axis=1) & (np.abs(dense).sum(axis=1) > 0)
+    # Genuinely underdetermined: fewer valid equations than unknowns.
+    assert 0 < valid.sum() < n, "setup must be underdetermined with at least one valid row"
+
+    recovered = {}
+    for objective, method in [("squared_differences", "BFGS"), ("summed_differences", "Nelder-Mead")]:
+        dep_rec = extraction_to_deposition_full(
+            cout=cout,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            nullspace_objective=objective,
+            optimization_method=method,
+            spinup=None,
+            **params,  # pyright: ignore[reportArgumentType]
+        )
+        recovered[objective] = dep_rec
+        # (a) Each objective exactly reproduces the observed cout on the valid rows.
+        np.testing.assert_allclose(
+            dense[valid] @ dep_rec, cout[valid], rtol=0, atol=1e-10, err_msg=f"objective={objective} data fit"
+        )
+
+    # (b) The two objectives genuinely disagree inside the nullspace.
+    assert np.max(np.abs(recovered["squared_differences"] - recovered["summed_differences"])) > 1e-3
+
+
 def test_roundtrip_varying_deposition():
     """Roundtrip with sinusoidal deposition on a longer time series.
 
@@ -887,97 +937,36 @@ def test_extraction_to_deposition_sparse_sampling_rank_deficient_no_warning():
 # =============================================================================
 
 
-def test_spinup_duration_constant_flow():
-    """Test spinup_duration with constant flow."""
-    dates = pd.date_range(start="2020-01-01", periods=100, freq="D")
-    tedges = pd.date_range(start="2020-01-01", periods=101, freq="D")
-    flow = np.ones(len(dates)) * 100.0  # m³/day
-    pore_volume = 5000.0  # m³
-    retardation_factor = 1.0
+@pytest.mark.parametrize(
+    ("flow_rate", "pore_volume", "retardation_factor"),
+    [
+        (100.0, 5000.0, 1.0),  # baseline: 50 days
+        (100.0, 5000.0, 2.0),  # R > 1 (temperature transport): 100 days
+        (500.0, 5000.0, 1.0),  # high flow: short spinup (10 days)
+        (20.0, 5000.0, 1.0),  # low flow: long spinup (250 days)
+        (100.0, 20000.0, 1.5),  # large pore volume + R > 1: 300 days
+    ],
+    ids=["baseline", "retardation", "high_flow", "low_flow", "large_pore_volume"],
+)
+def test_spinup_duration_constant_flow_closed_form(flow_rate, pore_volume, retardation_factor):
+    """Constant-flow spin-up equals the closed-form V*R/Q exactly.
+
+    Under constant flow the cumulative-flow inversion ``flow_cum(t*) = R*V_pore``
+    is algebraically exact, so the spin-up duration is ``pore_volume *
+    retardation_factor / flow``. The flow history is sized to always exceed the
+    target volume. The R > 1 cases keep the retardation factor exercised in the
+    ``target_cum`` computation.
+    """
+    expected_duration = pore_volume * retardation_factor / flow_rate
+    # Size the flow history so the cumulative volume exceeds R*V_pore.
+    n = int(np.ceil(expected_duration)) + 50
+    tedges = pd.date_range(start="2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, flow_rate)
 
     duration = spinup_duration(
-        flow=flow, flow_tedges=tedges, aquifer_pore_volume=pore_volume, retardation_factor=retardation_factor
+        flow=flow, tedges=tedges, aquifer_pore_volume=pore_volume, retardation_factor=retardation_factor
     )
 
-    # Spinup should equal residence time at first time point
-    # RT = pore_volume * retardation / flow = 5000 * 1.0 / 100 = 50 days
-    # Under constant flow, V*R/Q is algebraically exact.
-    expected_duration = pore_volume * retardation_factor / flow[0]
-    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
-
-
-def test_spinup_duration_with_retardation():
-    """Test spinup_duration with retardation factor > 1."""
-    # RT = 5000 * 2.0 / 100 = 100 days, so need at least 100 days of flow history
-    dates = pd.date_range(start="2020-01-01", periods=150, freq="D")
-    tedges = pd.date_range(start="2020-01-01", periods=151, freq="D")
-    flow = np.ones(len(dates)) * 100.0
-    pore_volume = 5000.0
-    retardation_factor = 2.0  # Temperature transport
-
-    duration = spinup_duration(
-        flow=flow, flow_tedges=tedges, aquifer_pore_volume=pore_volume, retardation_factor=retardation_factor
-    )
-
-    # Spinup should be longer with retardation
-    # RT = 5000 * 2.0 / 100 = 100 days
-    expected_duration = pore_volume * retardation_factor / flow[0]
-    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
-    assert duration > 50.0  # Longer than without retardation
-
-
-def test_spinup_duration_high_flow():
-    """Test spinup_duration with high flow (short spinup)."""
-    dates = pd.date_range(start="2020-01-01", periods=100, freq="D")
-    tedges = pd.date_range(start="2020-01-01", periods=101, freq="D")
-    flow = np.ones(len(dates)) * 500.0  # High flow
-    pore_volume = 5000.0
-    retardation_factor = 1.0
-
-    duration = spinup_duration(
-        flow=flow, flow_tedges=tedges, aquifer_pore_volume=pore_volume, retardation_factor=retardation_factor
-    )
-
-    # RT = 5000 * 1.0 / 500 = 10 days
-    expected_duration = pore_volume * retardation_factor / flow[0]
-    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
-    assert duration < 20.0  # Short spinup with high flow
-
-
-def test_spinup_duration_low_flow():
-    """Test spinup_duration with low flow (long spinup)."""
-    # RT = 5000 * 1.0 / 20 = 250 days, so need at least 250 days of flow history
-    dates = pd.date_range(start="2020-01-01", periods=300, freq="D")
-    tedges = pd.date_range(start="2020-01-01", periods=301, freq="D")
-    flow = np.ones(len(dates)) * 20.0  # Low flow
-    pore_volume = 5000.0
-    retardation_factor = 1.0
-
-    duration = spinup_duration(
-        flow=flow, flow_tedges=tedges, aquifer_pore_volume=pore_volume, retardation_factor=retardation_factor
-    )
-
-    # RT = 5000 * 1.0 / 20 = 250 days
-    expected_duration = pore_volume * retardation_factor / flow[0]
-    np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
-    assert duration > 200.0  # Long spinup with low flow
-
-
-def test_spinup_duration_large_pore_volume():
-    """Test spinup_duration with large pore volume."""
-    # RT = 20000 * 1.5 / 100 = 300 days, so need at least 300 days of flow history
-    dates = pd.date_range(start="2020-01-01", periods=400, freq="D")
-    tedges = pd.date_range(start="2020-01-01", periods=401, freq="D")
-    flow = np.ones(len(dates)) * 100.0
-    pore_volume = 20000.0  # Large aquifer
-    retardation_factor = 1.5
-
-    duration = spinup_duration(
-        flow=flow, flow_tedges=tedges, aquifer_pore_volume=pore_volume, retardation_factor=retardation_factor
-    )
-
-    # RT = 20000 * 1.5 / 100 = 300 days
-    expected_duration = pore_volume * retardation_factor / flow[0]
     np.testing.assert_allclose(duration, expected_duration, rtol=0, atol=1e-12)
 
 
@@ -1000,7 +989,7 @@ def test_spinup_duration_variable_flow_uses_extraction_direction():
     slow_then_fast = np.concatenate([np.full(50, 50.0), np.full(50, 200.0)])
     duration = spinup_duration(
         flow=slow_then_fast,
-        flow_tedges=tedges,
+        tedges=tedges,
         aquifer_pore_volume=pore_volume,
         retardation_factor=retardation_factor,
     )
@@ -1010,7 +999,7 @@ def test_spinup_duration_variable_flow_uses_extraction_direction():
     fast_then_slow = np.concatenate([np.full(50, 200.0), np.full(50, 50.0)])
     duration_asym = spinup_duration(
         flow=fast_then_slow,
-        flow_tedges=tedges,
+        tedges=tedges,
         aquifer_pore_volume=pore_volume,
         retardation_factor=retardation_factor,
     )
@@ -1032,7 +1021,7 @@ def test_spinup_duration_with_zero_flow_plateau():
     flow = np.array([100.0, 0.0, 100.0])
     duration = spinup_duration(
         flow=flow,
-        flow_tedges=flow_tedges,
+        tedges=flow_tedges,
         aquifer_pore_volume=1.0,
         retardation_factor=200.0,
     )
@@ -1064,7 +1053,7 @@ def test_spinup_duration_nonuniform_flow_tedges_weights_by_dt():
 
     duration = spinup_duration(
         flow=flow,
-        flow_tedges=flow_tedges,
+        tedges=flow_tedges,
         aquifer_pore_volume=aquifer_pore_volume,
         retardation_factor=retardation_factor,
     )
@@ -1175,14 +1164,20 @@ def test_compute_deposition_weights_with_retardation():
     """Row-sum scales with R: sum(W[i,:]) * porosity * thickness == RT_i at both R=1 and R=2.
 
     Replaces the prior `not np.allclose(weights_r1, weights_r2)` diff-only
-    assertion, which a wrong-but-different implementation would pass.
+    assertion, which a wrong-but-different implementation would pass. The pore
+    volume is kept small (500 m³ -> RT_water = 5 days) and the cout window starts
+    well past the longest spin-up (R=2 -> RT = 10 days) so that the
+    extraction_to_infiltration residence time is fully defined for every cout
+    bin at both R; the row-sum invariant is then asserted on real (finite)
+    values rather than vacuously on NaN.
     """
     dates = pd.date_range(start="2020-01-01", periods=50, freq="D")
     tedges = pd.date_range(start="2020-01-01", periods=51, freq="D")
-    cout_tedges = pd.date_range(start="2020-01-12", periods=31, freq="D")
+    # Start after the R=2 spin-up (RT = 10 days) so all rows are finite at both R.
+    cout_tedges = pd.date_range(start="2020-01-21", periods=31, freq="D")
 
     flow = np.ones(len(dates)) * 100.0
-    aquifer_pore_volume = 5000.0
+    aquifer_pore_volume = 500.0  # RT_water = 5 days
     porosity = 0.35
     thickness = 3.0
 
@@ -1205,9 +1200,13 @@ def test_compute_deposition_weights_with_retardation():
             direction="extraction_to_infiltration",
         )[0]
         rt_per_bin = rt[:-1]
+        valid = np.isfinite(rt_per_bin) & ~np.isnan(weights).any(axis=1)
+        assert valid.sum() >= 1, f"setup must produce at least one finite row for R={retardation_factor}"
+        # Row sum scales linearly with R through RT_i; under R=2 the sums are
+        # twice the R=1 sums, so this is not vacuously satisfiable.
         np.testing.assert_allclose(
-            weights.sum(axis=1) * porosity * thickness,
-            rt_per_bin,
+            weights[valid].sum(axis=1) * porosity * thickness,
+            rt_per_bin[valid],
             rtol=0,
             atol=1e-12,
             err_msg=f"R={retardation_factor}",
@@ -1369,7 +1368,7 @@ def test_banded_full_band_independent_of_record_length():
     for n in (200, 800, 3200):
         tedges = pd.date_range("2019-12-31 12:00", periods=n + 1, freq="D")
         flow = np.full(n, 100.0)
-        band_vals, _, _, _, _ = compute_deposition_weights(
+        band_vals, _, _, _ = compute_deposition_weights(
             flow=flow,
             tedges=tedges,
             cout_tedges=tedges,
@@ -2002,7 +2001,7 @@ def test_spinup_duration_first_bin_zero_flow():
     flow = np.full(n, 100.0)
     flow[0:3] = 0.0  # 3 days of zero flow at start
 
-    duration = spinup_duration(flow=flow, flow_tedges=tedges, aquifer_pore_volume=500.0, retardation_factor=1.0)
+    duration = spinup_duration(flow=flow, tedges=tedges, aquifer_pore_volume=500.0, retardation_factor=1.0)
     np.testing.assert_allclose(duration, 8.0, rtol=0, atol=1e-12)
 
 


### PR DESCRIPTION
## Summary

Part of the package-wide review — per-module PR for `gwtransport.deposition`. **Draft.**

**Tests (3 HIGH vacuous-test fixes, mutation-verified):**
- `test_compute_deposition_weights_with_retardation` de-vacuified (was comparing all-NaN to all-NaN; now the residence time is informed and the row-sum invariant is asserted on finite rows — catches a 1.5× scaling mutation).
- Added an underdetermined-nullspace test for `extraction_to_deposition_full` objective selection (the existing fixture had an empty nullspace, so both objectives were identical).
- Replaced `if min_len >= 1:` guards with `assert min_len >= 1` so an all-NaN forward output fails loudly.

**Docs/behavior:** float `spinup` documented as "accepted but silently ignored" (behavior unchanged — no sign-off). `spinup_duration` param `flow_tedges`→`tedges`. See Also sections, Unicode units.

**Leanness:** dropped the unread `extracted_volume` from `compute_deposition_weights` (5-tuple→4-tuple; all callers updated); collapsed redundant tests; tidied a validation message.

## Test plan

- `pytest --doctest-modules src/gwtransport/deposition.py src/gwtransport/deposition_utils.py tests/src/test_deposition.py tests/src/test_deposition_utils.py` — 95 passed.
- `ty check` + `ruff` — clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
