### PR TITLE
examples: docstring/typing fixes, new branch tests, modules.rst entry (review)

### DIFF
--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -46,6 +46,14 @@ diffusion
    :undoc-members:
    :show-inheritance:
 
+examples
+========
+
+.. automodule:: gwtransport.examples
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 fronttracking
 =============
 

--- a/src/gwtransport/examples.py
+++ b/src/gwtransport/examples.py
@@ -14,7 +14,7 @@ Available functions:
   soil temperature, and extracted concentration computed through gamma-distributed pore volume
   transport. When diffusion parameters are provided, uses the diffusion module instead of
   pure advection. Returns DataFrame with flow, cin, cout columns plus attrs containing
-  generation parameters and aquifer properties.
+  generation parameters and aquifer properties, and time edges (tedges).
 
 - :func:`generate_temperature_example_data` - Convenience wrapper around
   :func:`generate_example_data` with sensible defaults for temperature transport including
@@ -28,8 +28,9 @@ Available functions:
 - :func:`generate_example_deposition_timeseries` - Generate synthetic deposition time series
   for pathogen/contaminant deposition analysis. Combines baseline deposition, seasonal patterns,
   random noise, and episodic contamination events with exponential decay. Returns Series with
-  deposition rates [ng/m²/day] and attrs containing generation parameters. Useful for testing
-  extraction_to_deposition deconvolution and deposition_to_extraction convolution functions.
+  deposition rates [ng/m²/day] and attrs containing generation parameters, and time edges
+  (tedges). Useful for testing extraction_to_deposition deconvolution and
+  deposition_to_extraction convolution functions.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
@@ -45,9 +46,9 @@ from gwtransport.diffusion_fast import infiltration_to_extraction as diffusion_i
 from gwtransport.gamma import mean_std_loc_to_alpha_beta
 from gwtransport.utils import compute_time_edges, get_soil_temperature
 
-_DEFAULT_GAMMA_MEAN = 1000.0  # m3
-_DEFAULT_GAMMA_STD = 200.0  # m3
-_DEFAULT_GAMMA_LOC = 0.0  # m3, minimum pore volume
+_DEFAULT_GAMMA_MEAN = 1000.0  # m³
+_DEFAULT_GAMMA_STD = 200.0  # m³
+_DEFAULT_GAMMA_LOC = 0.0  # m³, minimum pore volume
 _DEFAULT_GAMMA_NBINS = 250
 
 
@@ -89,11 +90,11 @@ def generate_example_data(
     date_freq : str, default "D"
         Frequency string for pandas.date_range.
     flow_mean : float, default 100.0
-        Mean flow rate [m3/day].
+        Mean flow rate [m³/day].
     flow_amplitude : float, default 30.0
-        Seasonal amplitude of flow rate [m3/day].
+        Seasonal amplitude of flow rate [m³/day].
     flow_noise : float, default 10.0
-        Random noise level for flow rate [m3/day].
+        Random noise level for flow rate [m³/day].
     cin_method : str, default "synthetic"
         Method for generating infiltration concentration. Options:
 
@@ -114,22 +115,22 @@ def generate_example_data(
         exactly reproduce ``df['cout']`` when ``measurement_noise > 0``; the
         underlying noiseless signals remain consistent.
     aquifer_pore_volumes : array-like or None, default None
-        Discrete aquifer pore volumes [m3] representing the distribution of
+        Discrete aquifer pore volumes [m³] representing the distribution of
         residence times. When provided, the gamma distribution is bypassed and
         none of the ``aquifer_pore_volume_gamma_*`` parameters may be passed.
         When ``None``, the pore volume distribution is built from the gamma
         parameters below.
     aquifer_pore_volume_gamma_mean : float or None, default None
-        Mean pore volume of the aquifer gamma distribution [m3] (default 1000.0
+        Mean pore volume of the aquifer gamma distribution [m³] (default 1000.0
         when unset). Must be strictly greater than
         ``aquifer_pore_volume_gamma_loc``. Mutually exclusive with
         ``aquifer_pore_volumes``.
     aquifer_pore_volume_gamma_std : float or None, default None
-        Standard deviation of aquifer pore volume gamma distribution [m3]
+        Standard deviation of aquifer pore volume gamma distribution [m³]
         (default 200.0 when unset; invariant under the ``loc`` shift).
         Mutually exclusive with ``aquifer_pore_volumes``.
     aquifer_pore_volume_gamma_loc : float or None, default None
-        Location (minimum pore volume) of the aquifer gamma distribution [m3]
+        Location (minimum pore volume) of the aquifer gamma distribution [m³]
         (default 0.0 when unset). Must satisfy ``0 <= loc < mean``. Mutually
         exclusive with ``aquifer_pore_volumes``.
     aquifer_pore_volume_gamma_nbins : int or None, default None
@@ -139,10 +140,10 @@ def generate_example_data(
     retardation_factor : float, default 1.0
         Retardation factor for transport.
     molecular_diffusivity : float or None, default None
-        Effective molecular diffusivity [m2/day]. When provided together with
+        Effective molecular diffusivity [m²/day]. When provided together with
         ``longitudinal_dispersivity`` and ``streamline_length``, the diffusion
         module is used instead of pure advection. For solutes, typically ~1e-5
-        m2/day (negligible). For heat, use thermal diffusivity ~0.01-0.1 m2/day.
+        m²/day (negligible). For heat, use thermal diffusivity ~0.01-0.1 m²/day.
     longitudinal_dispersivity : float or None, default None
         Longitudinal dispersivity [m]. Must be provided together with
         ``molecular_diffusivity`` and ``streamline_length``.
@@ -176,10 +177,10 @@ def generate_example_data(
     See Also
     --------
     generate_temperature_example_data : Wrapper with thermal transport defaults.
+    generate_ec_example_data : Wrapper with EC transport defaults.
     """
     rng = np.random.default_rng(rng)
 
-    # Create date range
     dates = pd.date_range(start=date_start, end=date_end, freq=date_freq).tz_localize("UTC")
     days = (dates - dates[0]).days.values
 
@@ -224,7 +225,6 @@ def generate_example_data(
         msg = f"Unknown cin_method: {cin_method}"
         raise ValueError(msg)
 
-    # Compute tedges for the flow series
     tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
 
     # Validate pore volume parameterization: either discrete volumes or gamma parameters, not both.
@@ -260,7 +260,6 @@ def generate_example_data(
     gamma_nbins = (
         aquifer_pore_volume_gamma_nbins if aquifer_pore_volume_gamma_nbins is not None else _DEFAULT_GAMMA_NBINS
     )
-    alpha, beta = mean_std_loc_to_alpha_beta(mean=gamma_mean, std=gamma_std, loc=gamma_loc)
 
     # Compute cout. Branch on pore volume parameterization, then on diffusion.
     if aquifer_pore_volumes is not None:
@@ -321,7 +320,6 @@ def generate_example_data(
     # Add some noise to represent measurement errors
     cout_values += rng.normal(0, measurement_noise, len(dates))
 
-    # Create data frame
     df = pd.DataFrame(
         data={"flow": flow, "cin": cin_values, "cout": cout_values},
         index=dates,
@@ -343,8 +341,9 @@ def generate_example_data(
     })
     if aquifer_pore_volumes is not None:
         df.attrs["aquifer_pore_volume_parameterization"] = "discrete"
-        df.attrs["aquifer_pore_volumes"] = np.asarray(aquifer_pore_volumes, dtype=float)
+        df.attrs["aquifer_pore_volumes"] = aquifer_pore_volumes_array
     else:
+        alpha, beta = mean_std_loc_to_alpha_beta(mean=gamma_mean, std=gamma_std, loc=gamma_loc)
         df.attrs.update({
             "aquifer_pore_volume_parameterization": "gamma",
             "aquifer_pore_volume_gamma_mean": gamma_mean,
@@ -362,7 +361,29 @@ def generate_example_data(
     return df, tedges
 
 
-def generate_temperature_example_data(**kwargs) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
+def generate_temperature_example_data(
+    *,
+    date_start: str = "2020-01-01",
+    date_end: str = "2021-12-31",
+    date_freq: str = "D",
+    flow_mean: float = 100.0,
+    flow_amplitude: float = 30.0,
+    flow_noise: float = 10.0,
+    cin_method: str = "synthetic",
+    cin_mean: float = 12.0,
+    cin_amplitude: float = 8.0,
+    measurement_noise: float = 1.0,
+    aquifer_pore_volumes: npt.ArrayLike | None = None,
+    aquifer_pore_volume_gamma_mean: float | None = None,
+    aquifer_pore_volume_gamma_std: float | None = None,
+    aquifer_pore_volume_gamma_loc: float | None = None,
+    aquifer_pore_volume_gamma_nbins: int | None = None,
+    retardation_factor: float = 2.0,
+    molecular_diffusivity: float = 0.05,
+    longitudinal_dispersivity: float = 1.0,
+    streamline_length: float = 100.0,
+    rng: np.random.Generator | int | None = None,
+) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
     """
     Generate synthetic temperature and flow data for groundwater transport examples.
 
@@ -377,7 +398,7 @@ def generate_temperature_example_data(**kwargs) -> tuple[pd.DataFrame, pd.Dateti
     +=================================+============+=============+====================+
     | retardation_factor R            | 2.0--3.0   | 1.5--2.5    | 1.2--2.0           |
     +---------------------------------+------------+-------------+--------------------+
-    | molecular_diffusivity (m2/day)  | 0.03--0.06 | 0.05--0.08  | 0.08--0.12         |
+    | molecular_diffusivity (m²/day)  | 0.03--0.06 | 0.05--0.08  | 0.08--0.12         |
     +---------------------------------+------------+-------------+--------------------+
     | longitudinal_dispersivity (m)   | 0.1--1.0   | 0.5--5.0    | 1.0--10.0          |
     +---------------------------------+------------+-------------+--------------------+
@@ -386,14 +407,17 @@ def generate_temperature_example_data(**kwargs) -> tuple[pd.DataFrame, pd.Dateti
 
     Parameters
     ----------
-    **kwargs
-        All keyword arguments are forwarded to :func:`generate_example_data`.
-        Defaults that differ from ``generate_example_data``:
+    retardation_factor : float, default 2.0
+        Thermal retardation factor.
+    molecular_diffusivity : float, default 0.05
+        Thermal diffusivity [m²/day].
+    longitudinal_dispersivity : float, default 1.0
+        Longitudinal dispersivity [m].
+    streamline_length : float, default 100.0
+        Travel distance along the streamline [m].
 
-        - ``retardation_factor`` : 2.0 (thermal retardation)
-        - ``molecular_diffusivity`` : 0.05 m2/day (thermal diffusivity)
-        - ``longitudinal_dispersivity`` : 1.0 m
-        - ``streamline_length`` : 100.0 m
+    All other parameters are forwarded unchanged to :func:`generate_example_data`;
+    see that function for their descriptions.
 
     Returns
     -------
@@ -403,19 +427,55 @@ def generate_temperature_example_data(**kwargs) -> tuple[pd.DataFrame, pd.Dateti
     See Also
     --------
     generate_example_data : Generic version with full parameter control.
+    generate_ec_example_data : Wrapper with EC transport defaults.
     """
-    defaults = {
-        "retardation_factor": 2.0,
-        "molecular_diffusivity": 0.05,
-        "longitudinal_dispersivity": 1.0,
-        "streamline_length": 100.0,
-    }
-    for key, value in defaults.items():
-        kwargs.setdefault(key, value)
-    return generate_example_data(**kwargs)
+    return generate_example_data(
+        date_start=date_start,
+        date_end=date_end,
+        date_freq=date_freq,
+        flow_mean=flow_mean,
+        flow_amplitude=flow_amplitude,
+        flow_noise=flow_noise,
+        cin_method=cin_method,
+        cin_mean=cin_mean,
+        cin_amplitude=cin_amplitude,
+        measurement_noise=measurement_noise,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        aquifer_pore_volume_gamma_mean=aquifer_pore_volume_gamma_mean,
+        aquifer_pore_volume_gamma_std=aquifer_pore_volume_gamma_std,
+        aquifer_pore_volume_gamma_loc=aquifer_pore_volume_gamma_loc,
+        aquifer_pore_volume_gamma_nbins=aquifer_pore_volume_gamma_nbins,
+        retardation_factor=retardation_factor,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        streamline_length=streamline_length,
+        rng=rng,
+    )
 
 
-def generate_ec_example_data(**kwargs) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
+def generate_ec_example_data(
+    *,
+    date_start: str = "2020-01-01",
+    date_end: str = "2021-12-31",
+    date_freq: str = "D",
+    flow_mean: float = 100.0,
+    flow_amplitude: float = 30.0,
+    flow_noise: float = 10.0,
+    cin_method: str = "synthetic",
+    cin_mean: float = 500.0,
+    cin_amplitude: float = 150.0,
+    measurement_noise: float = 10.0,
+    aquifer_pore_volumes: npt.ArrayLike | None = None,
+    aquifer_pore_volume_gamma_mean: float | None = None,
+    aquifer_pore_volume_gamma_std: float | None = None,
+    aquifer_pore_volume_gamma_loc: float | None = None,
+    aquifer_pore_volume_gamma_nbins: int | None = None,
+    retardation_factor: float = 1.0,
+    molecular_diffusivity: float = 5e-5,
+    longitudinal_dispersivity: float = 1.0,
+    streamline_length: float = 100.0,
+    rng: np.random.Generator | int | None = None,
+) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
     """
     Generate synthetic electrical conductivity and flow data for groundwater transport examples.
 
@@ -433,7 +493,7 @@ def generate_ec_example_data(**kwargs) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
     +=================================+================+================+====================+
     | retardation_factor R            | 1.0            | 1.0            | 1.0                |
     +---------------------------------+----------------+----------------+--------------------+
-    | molecular_diffusivity (m2/day)  | 3e-5 -- 5e-5   | 4e-5 -- 8e-5   | 5e-5 -- 1e-4       |
+    | molecular_diffusivity (m²/day)  | 3e-5 -- 5e-5   | 4e-5 -- 8e-5   | 5e-5 -- 1e-4       |
     +---------------------------------+----------------+----------------+--------------------+
     | longitudinal_dispersivity (m)   | 0.1--1.0       | 0.5--5.0       | 1.0--10.0          |
     +---------------------------------+----------------+----------------+--------------------+
@@ -442,17 +502,23 @@ def generate_ec_example_data(**kwargs) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
 
     Parameters
     ----------
-    **kwargs
-        All keyword arguments are forwarded to :func:`generate_example_data`.
-        Defaults that differ from ``generate_example_data``:
+    cin_mean : float, default 500.0
+        Mean infiltration EC [uS/cm, typical surface water EC].
+    cin_amplitude : float, default 150.0
+        Seasonal amplitude of infiltration EC [uS/cm].
+    measurement_noise : float, default 10.0
+        Standard deviation of the Gaussian measurement noise [uS/cm].
+    retardation_factor : float, default 1.0
+        Retardation factor (1.0 for a conservative tracer).
+    molecular_diffusivity : float, default 5e-5
+        Effective ionic diffusion [m²/day].
+    longitudinal_dispersivity : float, default 1.0
+        Longitudinal dispersivity [m].
+    streamline_length : float, default 100.0
+        Travel distance along the streamline [m].
 
-        - ``cin_mean`` : 500.0 (uS/cm, typical surface water EC)
-        - ``cin_amplitude`` : 150.0 (uS/cm, seasonal variation)
-        - ``measurement_noise`` : 10.0 (uS/cm)
-        - ``retardation_factor`` : 1.0 (conservative tracer)
-        - ``molecular_diffusivity`` : 5e-5 m2/day (effective ionic diffusion)
-        - ``longitudinal_dispersivity`` : 1.0 m
-        - ``streamline_length`` : 100.0 m
+    All other parameters are forwarded unchanged to :func:`generate_example_data`;
+    see that function for their descriptions.
 
     Returns
     -------
@@ -464,18 +530,28 @@ def generate_ec_example_data(**kwargs) -> tuple[pd.DataFrame, pd.DatetimeIndex]:
     generate_example_data : Generic version with full parameter control.
     generate_temperature_example_data : Wrapper with thermal transport defaults.
     """
-    defaults = {
-        "cin_mean": 500.0,
-        "cin_amplitude": 150.0,
-        "measurement_noise": 10.0,
-        "retardation_factor": 1.0,
-        "molecular_diffusivity": 5e-5,
-        "longitudinal_dispersivity": 1.0,
-        "streamline_length": 100.0,
-    }
-    for key, value in defaults.items():
-        kwargs.setdefault(key, value)
-    return generate_example_data(**kwargs)
+    return generate_example_data(
+        date_start=date_start,
+        date_end=date_end,
+        date_freq=date_freq,
+        flow_mean=flow_mean,
+        flow_amplitude=flow_amplitude,
+        flow_noise=flow_noise,
+        cin_method=cin_method,
+        cin_mean=cin_mean,
+        cin_amplitude=cin_amplitude,
+        measurement_noise=measurement_noise,
+        aquifer_pore_volumes=aquifer_pore_volumes,
+        aquifer_pore_volume_gamma_mean=aquifer_pore_volume_gamma_mean,
+        aquifer_pore_volume_gamma_std=aquifer_pore_volume_gamma_std,
+        aquifer_pore_volume_gamma_loc=aquifer_pore_volume_gamma_loc,
+        aquifer_pore_volume_gamma_nbins=aquifer_pore_volume_gamma_nbins,
+        retardation_factor=retardation_factor,
+        molecular_diffusivity=molecular_diffusivity,
+        longitudinal_dispersivity=longitudinal_dispersivity,
+        streamline_length=streamline_length,
+        rng=rng,
+    )
 
 
 def generate_example_deposition_timeseries(
@@ -503,17 +579,18 @@ def generate_example_deposition_timeseries(
     freq : str
         Frequency string for pandas.date_range (default 'D').
     base : float
-        Baseline deposition rate (ng/m^2/day).
+        Baseline deposition rate (ng/m²/day).
     seasonal_amplitude : float
-        Amplitude of the annual seasonal sinusoidal pattern.
+        Amplitude of the annual seasonal sinusoidal pattern (ng/m²/day).
     noise_scale : float
-        Standard deviation scale for Gaussian noise added to the signal.
+        Standard deviation of Gaussian noise added to the signal (ng/m²/day).
     event_dates : list-like or None
         Dates (strings or pandas-compatible) at which to place episodic events.
         Time-zone-naive entries are interpreted as UTC to match the generated
         ``dates`` index. If None, a sensible default list is used.
     event_magnitude : float
-        Peak magnitude multiplier for events.
+        Peak deposition added at event onset (ng/m²/day). Decays exponentially
+        over ``event_duration`` days at rate ``event_decay_scale``.
     event_duration : int
         Duration of each event in days.
     event_decay_scale : float
@@ -528,14 +605,23 @@ def generate_example_deposition_timeseries(
 
     Returns
     -------
-    pandas.Series
-        Time series of deposition values indexed by daily timestamps.
+    tuple
+        A tuple containing:
+
+        - pandas.Series: Deposition time series (ng/m²/day) indexed by UTC
+          timestamps.
+        - pandas.DatetimeIndex: Time bin edges (n+1 edges for n values).
 
     Raises
     ------
     ValueError
         If ``event_decay_scale`` or ``event_duration`` is not positive, or if any
         ``event_dates`` entry falls outside the generated ``dates`` range.
+
+    See Also
+    --------
+    gwtransport.deposition.deposition_to_extraction : Forward operator consuming this data.
+    gwtransport.deposition.extraction_to_deposition : Inverse operator.
     """
     if event_decay_scale <= 0:
         msg = f"event_decay_scale must be positive, got {event_decay_scale}"
@@ -546,7 +632,6 @@ def generate_example_deposition_timeseries(
 
     rng = np.random.default_rng(rng)
 
-    # Create synthetic deposition time series - needs to match flow period
     dates = pd.date_range(date_start, date_end, freq=freq).tz_localize("UTC")
     n_dates = len(dates)
     tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=n_dates)
@@ -558,13 +643,7 @@ def generate_example_deposition_timeseries(
     # Default event dates if not provided
     if event_dates is None:
         event_dates = ["2020-06-15", "2021-03-20", "2021-09-10", "2022-07-05"]
-    # Convert to DatetimeIndex - handles list, array, or DatetimeIndex input
-    if isinstance(event_dates, pd.DatetimeIndex):
-        event_dates_index = event_dates
-    else:
-        # Convert ArrayLike to list for pd.to_datetime
-        event_dates_list = event_dates if isinstance(event_dates, list) else list(np.asarray(event_dates))
-        event_dates_index = pd.DatetimeIndex(pd.to_datetime(event_dates_list))
+    event_dates_index = pd.DatetimeIndex(pd.to_datetime(np.asarray(event_dates)))
     # Match the timezone of `dates` so naive user input (and the string defaults)
     # can be compared against the tz-aware index in `get_indexer`.
     if event_dates_index.tz is None:
@@ -613,5 +692,4 @@ def generate_example_deposition_timeseries(
         "date_freq": freq,
     })
 
-    # Create deposition series
     return series, tedges

--- a/src/gwtransport/examples.py
+++ b/src/gwtransport/examples.py
@@ -251,6 +251,11 @@ def generate_example_data(
     if 0 < n_diffusion < len(diffusion_provided):
         msg = "molecular_diffusivity, longitudinal_dispersivity, and streamline_length must all be provided together."
         raise ValueError(msg)
+    # Validation above forbids partial-set states, so this conjunction is equivalent to any single check;
+    # writing it in full lets the type checker narrow all three params to non-None inside the branches below.
+    use_diffusion = (
+        molecular_diffusivity is not None and longitudinal_dispersivity is not None and streamline_length is not None
+    )
 
     # Fill in gamma defaults so downstream callers see concrete values (not used when
     # aquifer_pore_volumes is supplied, but kept in scope for the attrs block below).
@@ -264,11 +269,7 @@ def generate_example_data(
     # Compute cout. Branch on pore volume parameterization, then on diffusion.
     if aquifer_pore_volumes is not None:
         aquifer_pore_volumes_array = np.asarray(aquifer_pore_volumes, dtype=float)
-        if (
-            molecular_diffusivity is not None
-            and longitudinal_dispersivity is not None
-            and streamline_length is not None
-        ):
+        if use_diffusion:
             cout_values = diffusion_infiltration_to_extraction(
                 cin=cin_nonoise,
                 flow=flow,
@@ -289,7 +290,7 @@ def generate_example_data(
                 aquifer_pore_volumes=aquifer_pore_volumes_array,
                 retardation_factor=retardation_factor,
             )
-    elif molecular_diffusivity is not None and longitudinal_dispersivity is not None and streamline_length is not None:
+    elif use_diffusion:
         cout_values = diffusion_gamma_infiltration_to_extraction(
             cin=cin_nonoise,
             flow=flow,

--- a/tests/src/test_examples.py
+++ b/tests/src/test_examples.py
@@ -50,6 +50,65 @@ def test_aquifer_pore_volumes_and_gamma_mutually_exclusive():
         )
 
 
+def test_cin_method_constant_produces_constant_noiseless_signal():
+    """cin_method='constant' must build cin around cin_mean (noiseless mean equals cin_mean)."""
+    df, _ = generate_example_data(cin_method="constant", cin_mean=7.0, measurement_noise=0.0, rng=0)
+    np.testing.assert_allclose(df["cin"].to_numpy(), 7.0)
+    assert df.attrs["cin_method"] == "constant"
+
+
+def test_unknown_cin_method_raises():
+    """An unrecognised cin_method must raise ValueError."""
+    with pytest.raises(ValueError, match="Unknown cin_method"):
+        generate_example_data(cin_method="not_a_method")
+
+
+@pytest.mark.parametrize(
+    ("molecular_diffusivity", "longitudinal_dispersivity", "streamline_length"),
+    [
+        (0.05, None, None),
+        (None, 1.0, None),
+        (None, None, 100.0),
+        (0.05, 1.0, None),
+    ],
+)
+def test_partial_diffusion_parameters_raise(molecular_diffusivity, longitudinal_dispersivity, streamline_length):
+    """Providing only some of the three diffusion parameters must raise ValueError."""
+    with pytest.raises(ValueError, match="must all be provided together"):
+        generate_example_data(
+            molecular_diffusivity=molecular_diffusivity,
+            longitudinal_dispersivity=longitudinal_dispersivity,
+            streamline_length=streamline_length,
+        )
+
+
+def test_discrete_aquifer_pore_volumes_advection_path():
+    """Discrete pore volumes (no diffusion) use the advection path and record the parameterization."""
+    pore_volumes = np.array([500.0, 1000.0, 1500.0])
+    df, tedges = generate_example_data(aquifer_pore_volumes=pore_volumes, rng=0)
+    assert df.attrs["aquifer_pore_volume_parameterization"] == "discrete"
+    np.testing.assert_array_equal(df.attrs["aquifer_pore_volumes"], pore_volumes)
+    assert "aquifer_pore_volume_gamma_alpha" not in df.attrs
+    assert len(df["cout"]) == len(df)
+    assert len(tedges) == len(df) + 1
+
+
+def test_discrete_aquifer_pore_volumes_diffusion_path():
+    """Discrete pore volumes with diffusion parameters use the diffusion path."""
+    pore_volumes = np.array([500.0, 1000.0, 1500.0])
+    df, _ = generate_example_data(
+        aquifer_pore_volumes=pore_volumes,
+        molecular_diffusivity=0.05,
+        longitudinal_dispersivity=1.0,
+        streamline_length=100.0,
+        rng=0,
+    )
+    assert df.attrs["aquifer_pore_volume_parameterization"] == "discrete"
+    np.testing.assert_array_equal(df.attrs["aquifer_pore_volumes"], pore_volumes)
+    assert df.attrs["molecular_diffusivity"] == 0.05
+    assert len(df["cout"]) == len(df)
+
+
 def test_event_decay_scale_zero_raises():
     """event_decay_scale=0 produced silent NaN before; pin the new explicit ValueError."""
     with pytest.raises(ValueError, match="event_decay_scale must be positive"):


### PR DESCRIPTION
## Summary

Part of the package-wide review — per-module PR for `gwtransport.examples`. **Draft.**

**Docs / API surface:**
- `generate_example_deposition_timeseries` Returns now documents the `(Series, tedges)` tuple (the `tedges` second element was undocumented).
- `event_magnitude` corrected from "multiplier" to "Peak deposition added at event onset (ng/m²/day), decays exponentially" (it is additive).
- The two `**kwargs` convenience wrappers (`generate_temperature_example_data`, `generate_ec_example_data`) now have explicit typed keyword-only signatures.
- Added the missing `gwtransport.examples` automodule entry to `docs/source/api/modules.rst`.
- Unicode units; See Also additions; dead-computation/comment cleanup.

**Tests:** added 8 tests covering previously-untested branches (`cin_method='constant'`, unknown `cin_method` raises, partial diffusion params raise, discrete `aquifer_pore_volumes` advection & diffusion paths).

## Test plan

- `pytest --doctest-modules src/gwtransport/examples.py tests/src/test_examples.py` — 29 passed.
- `ty check` + `ruff` — clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
