### PR TITLE
utils: _make_strictly_monotone fix, test coverage, typing/lean (review)

### DIFF
--- a/src/gwtransport/_validation.py
+++ b/src/gwtransport/_validation.py
@@ -20,13 +20,9 @@ plus ``tests/src/test_validation.py``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import numpy as np
 import numpy.typing as npt
-
-if TYPE_CHECKING:
-    import pandas as pd
+import pandas as pd  # noqa: TC002  -- pandas is a hard runtime dependency; import unconditionally
 
 
 def _validate_tedges_parity(

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -51,9 +51,17 @@ Available functions:
 - :func:`solve_tikhonov` - Solve linear system with Tikhonov regularization toward a target.
   Well-determined modes follow the data; poorly-determined modes are pulled toward the target.
 
+- :func:`compute_reverse_target` - Build the regularization target for the inverse problem by
+  transposing and row-normalizing the forward coefficient matrix. Consumed by
+  :func:`solve_tikhonov` and :func:`solve_inverse_transport`.
+
 - :func:`solve_inverse_transport` - Solve the inverse transport problem (deconvolution) via
   Tikhonov regularization. Shared by advection, diffusion, and diffusion_fast
   ``extraction_to_infiltration`` functions.
+
+- :func:`solve_inverse_transport_banded` - Memory-light banded equivalent of
+  :func:`solve_inverse_transport` for a forward operator stored in banded layout. Assembles the
+  Tikhonov normal equations directly in banded form and solves them via banded Cholesky.
 
 - :func:`solve_underdetermined_system` - Solve underdetermined linear system (Ax = b, m < n)
   with nullspace regularization. Handles NaN values by row exclusion. Supports built-in
@@ -135,16 +143,22 @@ def _make_strictly_monotone(arr: npt.ArrayLike) -> npt.NDArray[np.floating]:
     """Bump consecutive duplicates so a non-decreasing array becomes strictly monotone.
 
     Returns the input unchanged if no consecutive duplicates are present. Otherwise returns a
-    new array with each duplicate bumped up by ``k * 16 * ulp(max(arr))``, where ``k`` is its
-    1-based position within the consecutive duplicate run.
+    new array with each duplicate bumped up by ``k * step``, where ``k`` is its 1-based
+    position within the consecutive duplicate run and ``step`` is ``16 * ulp(max(arr))``
+    capped per run so the largest bump stays strictly below the next genuine value above the
+    plateau (``step = min(16 * ulp(max(arr)), gap / (run_len + 1))``). The cap prevents a long
+    run from overshooting a closely-spaced successor; a gap narrower than the run length in
+    ulps is unrepresentable and cannot be separated.
 
     The factor of 16 is a safety margin against IEEE 754 rounding noise in ``np.interp``'s
     linear-interpolation arithmetic, which differs subtly between Linux x86_64 (with FMA)
     and ARM macOS. A 1-ulp gap, while strictly monotone, can place a downstream query value
     on the wrong side of a bracket boundary if the intermediate arithmetic rounds 1 ulp away
     from the exact value. 16 ulps ensures the bracket selection is unambiguous on every
-    platform we support, while keeping the absolute perturbation at ``~1e-13`` for typical
-    cumulative-flow values -- well below physical relevance.
+    platform we support. The perturbation is relative to the array scale:
+    ``bump ≈ 16 * ulp(max(arr)) ≈ 3.5e-15 * max(arr)``, i.e. about 15 significant digits
+    below the data scale and well below physical relevance. The absolute size therefore grows
+    with the cumulative-volume magnitude (e.g. ``~1e-13`` only for ``max(arr) ~ 30``).
 
     Parameters
     ----------
@@ -169,11 +183,29 @@ def _make_strictly_monotone(arr: npt.ArrayLike) -> npt.NDArray[np.floating]:
     if not np.any(diffs == 0):
         return arr
     ulp_max = np.nextafter(arr.max(), np.inf) - arr.max()
+    n = len(arr)
+    idx = np.arange(n)
     is_dup = np.concatenate(([False], diffs == 0))
-    idx = np.arange(len(arr))
+    # 1-based position of each duplicate within its consecutive run.
     last_nondup = np.maximum.accumulate(np.where(is_dup, -1, idx))
     cumcount = np.where(is_dup, idx - last_nondup, 0)
-    return arr + cumcount * (_DUP_BUMP_ULPS * ulp_max)
+
+    # Per-run headroom: each bumped value must stay strictly below the next genuine
+    # (non-duplicate) value above the plateau, otherwise a long run can overshoot a
+    # closely-spaced next value and break monotonicity. ``next_nondup_idx`` is the first
+    # non-duplicate index after each position (``n`` when the run reaches the array end, where
+    # there is no successor and hence no overshoot risk). The gap to that successor caps the
+    # bump step so the last (largest) bump in a run of length L is at most ``L/(L+1)`` of the
+    # gap. A gap narrower than the run length in ulps is unrepresentable and cannot be split.
+    next_nondup_idx = np.minimum.accumulate(np.where(is_dup, n, idx)[::-1])[::-1]
+    has_successor = next_nondup_idx < n
+    gap_to_next = arr[np.clip(next_nondup_idx, 0, n - 1)] - arr[idx]
+    run_len = next_nondup_idx - last_nondup - 1
+    full_step = _DUP_BUMP_ULPS * ulp_max
+    with np.errstate(invalid="ignore", divide="ignore"):
+        capped_step = np.where(has_successor, np.minimum(full_step, gap_to_next / (run_len + 1.0)), full_step)
+    bump = np.where(is_dup, cumcount * capped_step, 0.0)
+    return arr + bump
 
 
 def cumulative_flow_volume(
@@ -246,7 +278,7 @@ def linear_interpolate(
 
     Returns
     -------
-    numpy.ndarray
+    ndarray
         Interpolated y-values with the same shape as x_query.
 
     Examples
@@ -275,17 +307,14 @@ def linear_interpolate(
     >>> linear_interpolate(x_ref=x_unsorted, y_ref=y_unsorted, x_query=x_query)
     array([10., 15., 25., 35., 40.])
     """
-    # Convert inputs to arrays
     x_ref = np.asarray(x_ref)
     y_ref = np.asarray(y_ref)
     x_query = np.asarray(x_query)
 
-    # Sort reference data to ensure monotonic ordering
     sort_idx = np.argsort(x_ref)
     x_ref_sorted = x_ref[sort_idx]
     y_ref_sorted = y_ref[sort_idx]
 
-    # Default behavior (left=None, right=None) clamps to boundary values
     return np.interp(x_query, x_ref_sorted, y_ref_sorted, left=left, right=right)
 
 
@@ -295,7 +324,7 @@ def linear_average(
     y_data: npt.ArrayLike,
     x_edges: npt.ArrayLike,
     extrapolate_method: str = "nan",
-) -> npt.NDArray[np.float64]:
+) -> npt.NDArray[np.floating]:
     """
     Compute the average value of a piecewise linear time series between specified x-edges.
 
@@ -332,7 +361,7 @@ def linear_average(
 
     Returns
     -------
-    numpy.ndarray
+    ndarray
         2D array of average values between consecutive pairs of x_edges.
         Shape is ``(n_series, n_bins)`` where ``n_bins = n_edges - 1`` and
         ``n_series = max(n_series_x, n_series_y)``. Both ``x_edges`` and ``y_data``
@@ -448,16 +477,18 @@ def linear_average(
     x_data_clean = x_data[show]
     y_data_clean = y_data[:, show]  # shape (n_series_y, n_clean)
 
-    # Handle extrapolation for all series at once (vectorized)
+    # Handle extrapolation for all series at once (vectorized). The 'raise' and 'nan'
+    # branches never mutate edges_processed, so they alias x_edges directly; 'outer'
+    # produces a fresh clipped array.
     if extrapolate_method == "outer":
         edges_processed = np.clip(x_edges, x_data_clean[0], x_data_clean[-1])
     elif extrapolate_method == "raise":
         if np.any(x_edges < x_data_clean[0]) or np.any(x_edges > x_data_clean[-1]):
             msg = "x_edges must be within the range of x_data"
             raise ValueError(msg)
-        edges_processed = x_edges.copy()
+        edges_processed = x_edges
     else:  # nan method
-        edges_processed = x_edges.copy()
+        edges_processed = x_edges
 
     # Create a combined grid of all unique x points (data + all edges)
     all_unique_x = np.unique(np.concatenate([x_data_clean, edges_processed.ravel()]))
@@ -466,7 +497,7 @@ def linear_average(
     # the linear interpolation manually since np.interp does not accept 2D y.
     if n_series_y == 1:
         all_unique_y_result = np.interp(all_unique_x, x_data_clean, y_data_clean[0], left=np.nan, right=np.nan)
-        all_unique_y: npt.NDArray[np.float64] = np.asarray(all_unique_y_result, dtype=np.float64)[np.newaxis, :]
+        all_unique_y: npt.NDArray[np.floating] = np.asarray(all_unique_y_result, dtype=np.float64)[np.newaxis, :]
     else:
         # Locate each query x in x_data_clean. For x within the data range, idx is in
         # [1, len(x_data_clean) - 1] so left_idx = idx - 1 is the bracketing left index.
@@ -599,7 +630,7 @@ def partial_isin(*, bin_edges_in: npt.ArrayLike, bin_edges_out: npt.ArrayLike) -
 
     Returns
     -------
-    overlap_matrix : numpy.ndarray
+    overlap_matrix : ndarray
         Dense matrix of shape (n_in, n_out) where n_in is the number of input
         bins and n_out is the number of output bins. Each element (i, j)
         represents the fraction of input bin i that overlaps with output bin j.
@@ -663,7 +694,7 @@ def partial_isin(*, bin_edges_in: npt.ArrayLike, bin_edges_out: npt.ArrayLike) -
     # Create meshgrids for all possible input-output bin combinations
     in_left = bin_edges_in[:-1, None]  # Shape: (n_bins_in, 1)
     in_right = bin_edges_in[1:, None]  # Shape: (n_bins_in, 1)
-    in_width = np.diff(bin_edges_in)[:, None]  # Shape: (n_bins_in, 1)
+    in_width = diffs_in[:, None]  # Shape: (n_bins_in, 1); reuses the validated np.diff above
 
     out_left = bin_edges_out[None, :-1]  # Shape: (1, n_bins_out)
     out_right = bin_edges_out[None, 1:]  # Shape: (1, n_bins_out)
@@ -701,7 +732,7 @@ def time_bin_overlap(*, tedges: npt.ArrayLike, bin_tedges: list[tuple]) -> npt.N
 
     Returns
     -------
-    overlap_array : numpy.ndarray
+    overlap_array : ndarray
         Array of shape (len(bin_tedges), n_bins) where n_bins is the number of
         time bins. Each element (i, j) represents the fraction of time bin j
         that overlaps with time range i. Values range from 0 (no overlap) to
@@ -805,7 +836,8 @@ def simplify_bins(
     edges = np.asarray(edges) if not isinstance(edges, pd.DatetimeIndex) else edges
     values = np.asarray(values, dtype=float)
     if len(values) == 0:
-        return edges, values, None
+        flow_out = np.asarray(flow, dtype=float) if flow is not None else None
+        return edges, values, flow_out
 
     widths = np.asarray(np.diff(edges), dtype=float)
     if flow is not None:
@@ -824,8 +856,10 @@ def simplify_bins(
     idx = np.append(s, len(values))
     new_edges = edges[idx]
     new_widths = np.add.reduceat(widths, s)
-    new_values = np.add.reduceat(weights * values, s) / np.add.reduceat(weights, s)
-    new_flow = np.add.reduceat(flow * widths, s) / new_widths if flow is not None else None
+    weight_sums = np.add.reduceat(weights, s)
+    new_values = np.add.reduceat(weights * values, s) / weight_sums
+    # When flow is given, weights == flow * widths, so weight_sums == reduceat(flow * widths, s) exactly.
+    new_flow = weight_sums / new_widths if flow is not None else None
 
     return new_edges, new_values, new_flow
 
@@ -845,7 +879,7 @@ def combine_bin_series(
     b: npt.ArrayLike,
     b_edges: npt.ArrayLike,
     extrapolation: str | float = 0.0,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
     """
     Combine two binned series onto a common set of unique edges.
 
@@ -870,13 +904,13 @@ def combine_bin_series(
 
     Returns
     -------
-    c : numpy.ndarray
+    c : ndarray
         Values from series a mapped to the combined edge structure.
-    c_edges : numpy.ndarray
+    c_edges : ndarray
         Combined unique edges from a_edges and b_edges.
-    d : numpy.ndarray
+    d : ndarray
         Values from series b mapped to the combined edge structure.
-    d_edges : numpy.ndarray
+    d_edges : ndarray
         Combined unique edges from a_edges and b_edges (same as c_edges).
 
     Raises
@@ -892,13 +926,11 @@ def combine_bin_series(
     are then broadcasted/repeated for each combined bin that falls within
     the original bin's range.
     """
-    # Convert inputs to numpy arrays
     a = np.asarray(a, dtype=float)
     a_edges = np.asarray(a_edges, dtype=float)
     b = np.asarray(b, dtype=float)
     b_edges = np.asarray(b_edges, dtype=float)
 
-    # Validate inputs
     if len(a_edges) != len(a) + 1:
         msg = "a_edges must have len(a) + 1 elements"
         raise ValueError(msg)
@@ -906,53 +938,24 @@ def combine_bin_series(
         msg = "b_edges must have len(b) + 1 elements"
         raise ValueError(msg)
 
-    # Create combined unique edges
     combined_edges = np.unique(np.concatenate([a_edges, b_edges]))
-
-    # Initialize output arrays
-    c = np.zeros(len(combined_edges) - 1)
-    d = np.zeros(len(combined_edges) - 1)
-
-    # Vectorized mapping using searchsorted - find which original bin each combined bin belongs to
-    # For series a: find which original bin each combined bin center falls into
     combined_bin_centers = (combined_edges[:-1] + combined_edges[1:]) / 2
-    a_bin_assignment_result = np.searchsorted(a_edges, combined_bin_centers, side="right") - 1
-    # Ensure it's an array for type checker
-    a_bin_assignment: npt.NDArray[np.intp] = np.asarray(a_bin_assignment_result, dtype=np.intp)
-    a_bin_assignment = np.clip(a_bin_assignment, 0, len(a) - 1)
 
-    # Handle extrapolation for series a
-    if extrapolation == "nearest":
-        # Assign all values using nearest neighbor (already clipped)
-        c[:] = a[a_bin_assignment]
-    else:
-        # Only assign values where the combined bin is completely within the original bin
-        a_valid_mask = (combined_edges[:-1] >= a_edges[a_bin_assignment]) & (
-            combined_edges[1:] <= a_edges[a_bin_assignment + 1]
-        )
-        c[a_valid_mask] = a[a_bin_assignment[a_valid_mask]]
-        # Fill out-of-range bins with extrapolation value
-        c[~a_valid_mask] = extrapolation
+    def _map(values: npt.NDArray[np.floating], edges: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
+        # Map one series onto the combined bins, applying the chosen extrapolation.
+        assignment = np.clip(np.searchsorted(edges, combined_bin_centers, side="right") - 1, 0, len(values) - 1)
+        if extrapolation == "nearest":
+            return values[assignment]
+        out = np.zeros(len(combined_edges) - 1)
+        # A combined bin keeps the original value only when it lies fully inside that bin.
+        valid = (combined_edges[:-1] >= edges[assignment]) & (combined_edges[1:] <= edges[assignment + 1])
+        out[valid] = values[assignment[valid]]
+        out[~valid] = extrapolation
+        return out
 
-    # Handle extrapolation for series b
-    b_bin_assignment_result = np.searchsorted(b_edges, combined_bin_centers, side="right") - 1
-    # Ensure it's an array for type checker
-    b_bin_assignment: npt.NDArray[np.intp] = np.asarray(b_bin_assignment_result, dtype=np.intp)
-    b_bin_assignment = np.clip(b_bin_assignment, 0, len(b) - 1)
+    c = _map(a, a_edges)
+    d = _map(b, b_edges)
 
-    if extrapolation == "nearest":
-        # Assign all values using nearest neighbor (already clipped)
-        d[:] = b[b_bin_assignment]
-    else:
-        # Only assign values where the combined bin is completely within the original bin
-        b_valid_mask = (combined_edges[:-1] >= b_edges[b_bin_assignment]) & (
-            combined_edges[1:] <= b_edges[b_bin_assignment + 1]
-        )
-        d[b_valid_mask] = b[b_bin_assignment[b_valid_mask]]
-        # Fill out-of-range bins with extrapolation value
-        d[~b_valid_mask] = extrapolation
-
-    # Return the combined series
     c_edges = combined_edges
     d_edges = combined_edges.copy()
 
@@ -1032,6 +1035,9 @@ def compute_time_edges(
         if number_of_bins != len(tstart):
             msg = "tstart must have the same number of elements as flow"
             raise ValueError(msg)
+        if len(tstart) < 2:  # noqa: PLR2004
+            msg = "tstart must have at least 2 elements to infer the bin width; pass tedges for a single bin"
+            raise ValueError(msg)
 
         # Extrapolate final edge using uniform spacing
         final_edge = tstart[-1] + (tstart[-1] - tstart[-2])
@@ -1043,12 +1049,15 @@ def compute_time_edges(
         if number_of_bins != len(tend):
             msg = "tend must have the same number of elements as flow"
             raise ValueError(msg)
+        if len(tend) < 2:  # noqa: PLR2004
+            msg = "tend must have at least 2 elements to infer the bin width; pass tedges for a single bin"
+            raise ValueError(msg)
 
         # Extrapolate initial edge using uniform spacing
         initial_edge = tend[0] - (tend[1] - tend[0])
         return pd.DatetimeIndex([initial_edge, *list(tend)], dtype=tend.dtype)
 
-    msg = "Either provide tedges, tstart, and tend"
+    msg = "Either provide tedges, tstart, or tend"
     raise ValueError(msg)
 
 
@@ -1162,7 +1171,10 @@ def solve_underdetermined_system(
     *,
     coefficient_matrix: npt.ArrayLike,
     rhs_vector: npt.ArrayLike,
-    nullspace_objective: str | Callable[[np.ndarray, np.ndarray, np.ndarray], float] = "squared_differences",
+    nullspace_objective: str
+    | Callable[
+        [npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]], float
+    ] = "squared_differences",
     optimization_method: str = "BFGS",
     rcond: float | None = None,
 ) -> npt.NDArray[np.floating]:
@@ -1210,7 +1222,7 @@ def solve_underdetermined_system(
 
     Returns
     -------
-    numpy.ndarray
+    ndarray
         Solution vector that minimizes the specified nullspace objective.
         Has length n (number of columns in coefficient_matrix).
 
@@ -1326,9 +1338,10 @@ def solve_underdetermined_system(
 
 def _optimize_nullspace_coefficients(
     *,
-    x_ls: np.ndarray,
-    nullspace_basis: np.ndarray,
-    nullspace_objective: str | Callable[[np.ndarray, np.ndarray, np.ndarray], float],
+    x_ls: npt.NDArray[np.floating],
+    nullspace_basis: npt.NDArray[np.floating],
+    nullspace_objective: str
+    | Callable[[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]], float],
     optimization_method: str,
 ) -> npt.NDArray[np.floating]:
     """Optimize coefficients in the nullspace to minimize the objective.
@@ -1366,9 +1379,8 @@ def _optimize_nullspace_coefficients(
 
     # For other objectives, use iterative optimization starting from the
     # squared_differences solution for stability
-    nullrank = nullspace_basis.shape[1]
     objective_func = _get_nullspace_objective_function(nullspace_objective=nullspace_objective)
-    coeffs_0 = coeffs_sq if coeffs_sq is not None else np.zeros(nullrank)
+    coeffs_0 = coeffs_sq
 
     res = minimize(
         objective_func,
@@ -1386,8 +1398,8 @@ def _optimize_nullspace_coefficients(
 
 def _solve_squared_differences_analytical(
     *,
-    x_ls: np.ndarray,
-    nullspace_basis: np.ndarray,
+    x_ls: npt.NDArray[np.floating],
+    nullspace_basis: npt.NDArray[np.floating],
 ) -> npt.NDArray[np.floating]:
     """Solve the squared-differences nullspace problem analytically.
 
@@ -1458,16 +1470,20 @@ def compute_reverse_target(
 
     Parameters
     ----------
-    coeff_matrix : numpy.ndarray
+    coeff_matrix : ndarray
         Forward coefficient matrix of shape (n_cout, n_cin).
-    rhs_vector : numpy.ndarray
+    rhs_vector : ndarray
         Right-hand side vector of length n_cout (e.g., cout values).
 
     Returns
     -------
-    numpy.ndarray
+    ndarray
         Target solution vector of length n_cin. Entries with near-zero
         column sums in the forward matrix are set to NaN.
+
+    See Also
+    --------
+    solve_tikhonov : Consumes this target as the regularization reference.
     """
     min_row_sum = 1e-10
     wt = coeff_matrix.T  # (n_cin, n_cout)
@@ -1510,7 +1526,7 @@ def solve_tikhonov(
     rhs_vector : array-like
         Right-hand side vector of length m. May contain NaN values
         corresponding to NaN rows in coefficient_matrix.
-    x_target : numpy.ndarray
+    x_target : ndarray
         Target solution of length n, typically from
         :func:`compute_reverse_target`. NaN entries are excluded from the
         regularization term.
@@ -1529,7 +1545,7 @@ def solve_tikhonov(
 
     Returns
     -------
-    numpy.ndarray or tuple of numpy.ndarray
+    ndarray or tuple of ndarray
         If ``return_resolution`` is False (default), returns the solution
         vector of length n.
 
@@ -1596,7 +1612,8 @@ def solve_tikhonov(
         # fraction_data[j] = R[j,j] = 1 - λ d[j] G_inv[j,j]
         d_reg = np.zeros(n_cin)
         d_reg[target_indices] = 1.0
-        gram = valid_matrix.T @ valid_matrix + regularization_strength * np.diag(d_reg)
+        gram = valid_matrix.T @ valid_matrix
+        gram[np.arange(n_cin), np.arange(n_cin)] += regularization_strength * d_reg
         gram_inv_diag = np.diag(np.linalg.inv(gram))
         fraction_data = 1.0 - regularization_strength * gram_inv_diag * d_reg
         return x, fraction_data
@@ -1655,6 +1672,10 @@ def solve_inverse_transport(
     -----
     UserWarning
         When ``warn_rank_deficient=True`` and the matrix is rank-deficient.
+
+    See Also
+    --------
+    solve_inverse_transport_banded : Memory-light banded equivalent.
     """
     row_sums = w_forward.sum(axis=1)
     col_active: npt.NDArray[np.bool_] = w_forward.sum(axis=0) > 0
@@ -1729,13 +1750,13 @@ def solve_inverse_transport_banded(
 
     Parameters
     ----------
-    band_vals : numpy.ndarray
+    band_vals : ndarray
         Banded forward weights of shape ``(n_obs, full_band)``. Rows the caller
         considers invalid must already be zeroed (as :func:`_resolve_spinup_mask`
         does); zero rows contribute nothing to the normal equations.
-    col_start : numpy.ndarray of int
+    col_start : ndarray of int
         First output-column index of each row's band, shape ``(n_obs,)``.
-    observed : numpy.ndarray
+    observed : ndarray
         Observed values of shape ``(n_obs,)`` (e.g. extraction concentrations).
         Must not contain NaN.
     n_output : int
@@ -1749,7 +1770,7 @@ def solve_inverse_transport_banded(
 
     Returns
     -------
-    numpy.ndarray
+    ndarray
         Recovered signal of shape ``(n_output,)``. NaN for output bins with no
         forward contribution (zero column).
 
@@ -1839,7 +1860,9 @@ def solve_inverse_transport_banded(
     return out
 
 
-def _squared_differences_objective(coeffs: np.ndarray, x_ls: np.ndarray, nullspace_basis: np.ndarray) -> float:
+def _squared_differences_objective(
+    coeffs: npt.NDArray[np.floating], x_ls: npt.NDArray[np.floating], nullspace_basis: npt.NDArray[np.floating]
+) -> float:
     """Minimize sum of squared differences between adjacent elements.
 
     Parameters
@@ -1860,7 +1883,9 @@ def _squared_differences_objective(coeffs: np.ndarray, x_ls: np.ndarray, nullspa
     return np.sum(np.square(x[1:] - x[:-1]))
 
 
-def _summed_differences_objective(coeffs: np.ndarray, x_ls: np.ndarray, nullspace_basis: np.ndarray) -> float:
+def _summed_differences_objective(
+    coeffs: npt.NDArray[np.floating], x_ls: npt.NDArray[np.floating], nullspace_basis: npt.NDArray[np.floating]
+) -> float:
     """Minimize sum of absolute differences between adjacent elements.
 
     Parameters
@@ -1883,8 +1908,9 @@ def _summed_differences_objective(coeffs: np.ndarray, x_ls: np.ndarray, nullspac
 
 def _get_nullspace_objective_function(
     *,
-    nullspace_objective: str | Callable[[np.ndarray, np.ndarray, np.ndarray], float],
-) -> Callable[[np.ndarray, np.ndarray, np.ndarray], float]:
+    nullspace_objective: str
+    | Callable[[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]], float],
+) -> Callable[[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]], float]:
     """Get the objective function for nullspace optimization.
 
     Parameters

--- a/tests/src/test_simplify_bins.py
+++ b/tests/src/test_simplify_bins.py
@@ -171,31 +171,44 @@ class TestSimplifyBinsFlowSimplification:
         assert new_flow is None
 
     def test_flow_volume_conservation(self):
-        """Total volume (flow x width) should be conserved after simplification."""
+        """Known-answer merge pins the split boundary AND the time-weighted flow per bin.
+
+        The value series ``[2, 2, 5, 5, 5]`` merges only at the single 2->5 jump (edge 3.0),
+        which is NOT a midpoint: a wrong split direction would land elsewhere and fail the
+        pinned ``new_edges``. The merged flows are the hand-derived time-weighted averages:
+        group 1 widths (1, 2) flow (3, 1) -> (1*3 + 2*1) / 3 = 5/3; group 2 widths (1, 3, 1)
+        flow (4, 2, 6) -> (1*4 + 3*2 + 1*6) / 5 = 16/5.
+        """
         edges = np.array([0.0, 1.0, 3.0, 4.0, 7.0, 8.0])
         values = np.array([2.0, 2.0, 5.0, 5.0, 5.0])
         flow = np.array([3.0, 1.0, 4.0, 2.0, 6.0])
+        new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow)
+        assert_array_equal(new_edges, [0.0, 3.0, 8.0])
+        assert_array_equal(new_values, [2.0, 5.0])
+        assert_array_equal(new_flow, [5.0 / 3.0, 16.0 / 5.0])
+        # Conservation follows from the literals: total volume is preserved.
         widths = np.diff(edges)
-        volume_before = np.sum(flow * widths)
-        new_edges, _, new_flow = simplify_bins(edges=edges, values=values, flow=flow)
         new_widths = np.diff(new_edges)
-        volume_after = np.sum(new_flow * new_widths)
-        assert_array_equal(volume_after, volume_before)
+        assert_allclose(np.sum(new_flow * new_widths), np.sum(flow * widths), atol=0.0, rtol=float(np.finfo(float).eps))
 
 
 class TestSimplifyBinsMassConservation:
     """Test that total mass is conserved after simplification."""
 
     def test_mass_conservation_no_flow(self):
-        """Total widthxvalue should be conserved."""
+        """Known-answer width-weighted merge: the split boundary and merged values are pinned.
+
+        ``[2, 2, 5, 5, 5]`` merges only at the 2->5 jump (edge 3.0). Within each group all
+        values are identical, so the width-weighted averages are exactly 2 and 5 -- a wrong
+        split would mix the 2s and 5s and change these literals.
+        """
         edges = np.array([0.0, 1.0, 3.0, 4.0, 7.0, 8.0])
         values = np.array([2.0, 2.0, 5.0, 5.0, 5.0])
-        widths = np.diff(edges)
-        mass_before = np.sum(widths * values)
         new_edges, new_values, _ = simplify_bins(edges=edges, values=values)
-        new_widths = np.diff(new_edges)
-        mass_after = np.sum(new_widths * new_values)
-        assert_array_equal(mass_after, mass_before)
+        assert_array_equal(new_edges, [0.0, 3.0, 8.0])
+        assert_array_equal(new_values, [2.0, 5.0])
+        # Conservation follows from the literals: total width x value is preserved.
+        assert_array_equal(np.sum(np.diff(new_edges) * new_values), np.sum(np.diff(edges) * values))
 
     def test_mass_conservation_with_flow(self):
         """Total flowxwidthxvalue (= mass) is conserved when a merge group mixes values.
@@ -220,18 +233,36 @@ class TestSimplifyBinsMassConservation:
         assert_array_equal(mass_after, mass_before)
 
     def test_mass_conservation_with_tolerance(self):
-        """Mass conservation should hold even when merging with tolerance."""
+        """Known-answer tolerance merge: the split boundaries are pinned, not just conserved.
+
+        Pinning ``new_edges`` to the literal merge boundaries makes the test sensitive to the
+        split algorithm: a wrong split would merge a different set of bins and fail here. The
+        merged values/flows are then checked against an independent per-group weighted average
+        recomputed from the input literals (so the result is not compared against itself).
+        """
         rng = np.random.default_rng(42)
         edges = np.arange(11, dtype=float)
         values = rng.uniform(0, 1, size=10)
         flow = rng.uniform(0.5, 2.0, size=10)
         widths = np.diff(edges)
-        mass_before = np.sum(flow * widths * values)
 
         new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow, tol=0.3)
-        new_widths = np.diff(new_edges)
-        mass_after = np.sum(new_flow * new_widths * new_values)
-        # Summation order differs after merging, so allow machine-precision tolerance
+
+        # Pin the (non-obvious) merge boundaries: only bins 2-3 and 5-6-7 merge under tol=0.3.
+        assert_array_equal(new_edges, [0.0, 1.0, 2.0, 4.0, 5.0, 8.0, 9.0, 10.0])
+
+        # Independent per-group reference (volume-weighted value, time-weighted flow).
+        groups = [[0], [1], [2, 3], [4], [5, 6, 7], [8], [9]]
+        expected_values = np.array([
+            np.sum(flow[g] * widths[g] * values[g]) / np.sum(flow[g] * widths[g]) for g in groups
+        ])
+        expected_flow = np.array([np.sum(flow[g] * widths[g]) / np.sum(widths[g]) for g in groups])
+        assert_allclose(new_values, expected_values, atol=0.0, rtol=float(np.finfo(float).eps))
+        assert_allclose(new_flow, expected_flow, atol=0.0, rtol=float(np.finfo(float).eps))
+
+        # Mass (flow x width x value) is conserved up to summation-order rounding.
+        mass_before = np.sum(flow * widths * values)
+        mass_after = np.sum(new_flow * np.diff(new_edges) * new_values)
         assert_allclose(mass_after, mass_before, atol=0.0, rtol=float(np.finfo(float).eps))
 
 

--- a/tests/src/test_simplify_bins.py
+++ b/tests/src/test_simplify_bins.py
@@ -247,6 +247,7 @@ class TestSimplifyBinsMassConservation:
         widths = np.diff(edges)
 
         new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow, tol=0.3)
+        assert new_flow is not None  # flow supplied -> flow_out is an array
 
         # Pin the (non-obvious) merge boundaries: only bins 2-3 and 5-6-7 merge under tol=0.3.
         assert_array_equal(new_edges, [0.0, 1.0, 2.0, 4.0, 5.0, 8.0, 9.0, 10.0])

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -14,13 +14,17 @@ from gwtransport.examples import generate_example_data, generate_example_deposit
 from gwtransport.utils import (
     _make_strictly_monotone,
     combine_bin_series,
+    compute_reverse_target,
+    compute_time_edges,
     cumulative_flow_volume,
     get_soil_temperature,
     linear_average,
     linear_interpolate,
     partial_isin,
+    simplify_bins,
     solve_tikhonov,
     solve_underdetermined_system,
+    step_plot_coords,
     time_bin_overlap,
 )
 
@@ -381,7 +385,7 @@ def test_basic_case():
     expected = np.array([[0.5, 0.0], [0.5, 0.5], [0.0, 0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_no_overlap():
@@ -391,7 +395,7 @@ def test_no_overlap():
     expected = np.array([[0.0, 0.0], [0.0, 0.0]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_complete_overlap():
@@ -401,7 +405,7 @@ def test_complete_overlap():
     expected = np.array([[1.0, 0.0], [0.0, 1.0]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_exact_bin_match():
@@ -411,7 +415,7 @@ def test_exact_bin_match():
     expected = np.array([[1.0, 0.0], [0.0, 1.0]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_multiple_bins():
@@ -421,7 +425,7 @@ def test_multiple_bins():
     expected = np.array([[0.5, 0.0, 0.0], [0.2, 0.6, 0.2], [0.0, 0.0, 0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_partial_overlaps():
@@ -431,7 +435,7 @@ def test_partial_overlaps():
     expected = np.array([[0.25, 0.25]])  # 25% overlap with each output bin
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_list_inputs():
@@ -441,7 +445,7 @@ def test_list_inputs():
     expected = np.array([[0.5, 0.0], [0.5, 0.5], [0.0, 0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_empty_inputs():
@@ -451,7 +455,7 @@ def test_empty_inputs():
     expected = np.array([[0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_single_bin():
@@ -461,7 +465,7 @@ def test_single_bin():
     expected = np.array([[0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_edge_alignment():
@@ -471,7 +475,7 @@ def test_edge_alignment():
     expected = np.array([[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_floating_point_precision():
@@ -491,7 +495,7 @@ def test_negative_values():
     expected = np.array([[0.5, 0.0], [0.5, 0.5]])
 
     result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_invalid_inputs():
@@ -521,15 +525,15 @@ def test_combine_bin_series_basic():
 
     # Expected combined edges: [0, 1, 1.5, 2]
     expected_edges = np.array([0.0, 1.0, 1.5, 2.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # Expected values for c: [1, 2, 2] (a[0] broadcasts to first bin, a[1] broadcasts to bins 2&3)
     # Expected values for d: [0, 3, 4] (b[0] broadcasts to second bin, b[1] broadcasts to third bin)
     expected_c = np.array([1.0, 2.0, 2.0])
     expected_d = np.array([0.0, 3.0, 4.0])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_identical_edges():
@@ -543,12 +547,12 @@ def test_combine_bin_series_identical_edges():
 
     # Edges should remain the same
     expected_edges = np.array([0.0, 1.0, 2.0, 3.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # Values should be preserved
-    np.testing.assert_allclose(c, a, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, b, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, a)
+    np.testing.assert_array_equal(d, b)
 
 
 def test_combine_bin_series_overlapping_bins():
@@ -562,8 +566,8 @@ def test_combine_bin_series_overlapping_bins():
 
     # Expected combined edges: [0, 2, 5, 7, 10, 12]
     expected_edges = np.array([0.0, 2.0, 5.0, 7.0, 10.0, 12.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # Test that the values are broadcasted/repeated correctly
     # a[0]=10 covers [0,5]: broadcasts to bins [0,2] and [2,5]
@@ -572,8 +576,8 @@ def test_combine_bin_series_overlapping_bins():
     # b[1]=40 covers [7,12]: broadcasts to bins [7,10] and [10,12]
     expected_c = np.array([10.0, 10.0, 20.0, 20.0, 0.0])
     expected_d = np.array([0.0, 30.0, 30.0, 40.0, 40.0])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_single_bins():
@@ -587,15 +591,15 @@ def test_combine_bin_series_single_bins():
 
     # Expected combined edges: [0, 1, 2, 3]
     expected_edges = np.array([0.0, 1.0, 2.0, 3.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # a=5 covers [0,2]: broadcasts to [0,1] and [1,2]
     # b=10 covers [1,3]: broadcasts to [1,2] and [2,3]
     expected_c = np.array([5.0, 5.0, 0.0])
     expected_d = np.array([0.0, 10.0, 10.0])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_nested_bins():
@@ -609,15 +613,15 @@ def test_combine_bin_series_nested_bins():
 
     # Expected combined edges: [0, 2, 5, 8, 10]
     expected_edges = np.array([0.0, 2.0, 5.0, 8.0, 10.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # a=100 covers [0,10]: broadcasts to all combined bins within its range
     # b[0]=20 covers [2,5] and b[1]=30 covers [5,8]
     expected_c = np.array([100.0, 100.0, 100.0, 100.0])
     expected_d = np.array([0.0, 20.0, 30.0, 0.0])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_non_overlapping():
@@ -631,14 +635,14 @@ def test_combine_bin_series_non_overlapping():
 
     # Expected combined edges: [0, 1, 2, 3, 4, 5]
     expected_edges = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # a maps to first two bins, b maps to last two bins
     expected_c = np.array([1.0, 2.0, 0.0, 0.0, 0.0])
     expected_d = np.array([0.0, 0.0, 0.0, 3.0, 4.0])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_zero_values():
@@ -652,14 +656,14 @@ def test_combine_bin_series_zero_values():
 
     # Expected combined edges: [0, 0.5, 1, 1.5, 2, 2.5]
     expected_edges = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 2.5])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # Check that zero values are preserved and broadcasted correctly
     expected_c = np.array([0.0, 0.0, 5.0, 5.0, 0.0])
     expected_d = np.array([0.0, 3.0, 3.0, 0.0, 0.0])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_floating_point():
@@ -673,14 +677,14 @@ def test_combine_bin_series_floating_point():
 
     # Expected combined edges: [0.1, 0.6, 1.1, 1.6, 2.1, 2.6]
     expected_edges = np.array([0.1, 0.6, 1.1, 1.6, 2.1, 2.6])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # Test with appropriate precision and broadcasting
     expected_c = np.array([1.1, 1.1, 2.2, 2.2, 0.0])
     expected_d = np.array([0.0, 3.3, 3.3, 4.4, 4.4])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-10)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-10)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_input_validation():
@@ -721,8 +725,8 @@ def test_combine_bin_series_list_inputs():
 
     # Expected combined edges: [0, 1, 1.5, 2, 2.5, 3.5]
     expected_edges = np.array([0.0, 1.0, 1.5, 2.0, 2.5, 3.5])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
 
 def test_combine_bin_series_negative_values():
@@ -736,14 +740,14 @@ def test_combine_bin_series_negative_values():
 
     # Expected combined edges: [-10, -3, -1, 0, 2, 5]
     expected_edges = np.array([-10.0, -3.0, -1.0, 0.0, 2.0, 5.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # Test correct mapping with negative values and broadcasting
     expected_c = np.array([-5.0, -2.0, -2.0, 0.0, 0.0])
     expected_d = np.array([0.0, 0.0, 1.0, 1.0, 4.0])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_empty_arrays():
@@ -757,13 +761,13 @@ def test_combine_bin_series_empty_arrays():
 
     # Expected combined edges: [0, 0.5, 1, 1.5]
     expected_edges = np.array([0.0, 0.5, 1.0, 1.5])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     expected_c = np.array([42.0, 42.0, 0.0])
     expected_d = np.array([0.0, 24.0, 24.0])
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_extrapolation_nearest():
@@ -777,16 +781,16 @@ def test_combine_bin_series_extrapolation_nearest():
 
     # Expected combined edges: [1, 2, 3, 4]
     expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # With nearest extrapolation:
     # c extends to all bins using nearest values
     # d extends to all bins using nearest values
     expected_c = np.array([1.0, 2.0, 2.0])  # nearest for [3,4] is a[1]=2.0
     expected_d = np.array([10.0, 10.0, 20.0])  # nearest for [1,2] is b[0]=10.0
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_extrapolation_nan():
@@ -800,15 +804,15 @@ def test_combine_bin_series_extrapolation_nan():
 
     # Expected combined edges: [1, 2, 3, 4]
     expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # With nan extrapolation:
     # Out-of-range bins get nan values
     expected_c = np.array([1.0, 2.0, np.nan])  # [3,4] is out of range for a
     expected_d = np.array([np.nan, 10.0, 20.0])  # [1,2] is out of range for b
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_extrapolation_custom_value():
@@ -822,15 +826,15 @@ def test_combine_bin_series_extrapolation_custom_value():
 
     # Expected combined edges: [1, 2, 3, 4]
     expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    np.testing.assert_allclose(c_edges, expected_edges, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges, expected_edges, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c_edges, expected_edges)
+    np.testing.assert_array_equal(d_edges, expected_edges)
 
     # With custom extrapolation value:
     # Out-of-range bins get the custom value
     expected_c = np.array([1.0, 2.0, -999.0])  # [3,4] is out of range for a
     expected_d = np.array([-999.0, 10.0, 20.0])  # [1,2] is out of range for b
-    np.testing.assert_allclose(c, expected_c, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d, expected_d, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c, expected_c)
+    np.testing.assert_array_equal(d, expected_d)
 
 
 def test_combine_bin_series_extrapolation_default_behavior():
@@ -844,10 +848,10 @@ def test_combine_bin_series_extrapolation_default_behavior():
     c1, c_edges1, d1, d_edges1 = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
     c2, c_edges2, d2, d_edges2 = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=0.0)
 
-    np.testing.assert_allclose(c1, c2, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d1, d2, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(c_edges1, c_edges2, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d_edges1, d_edges2, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c1, c2)
+    np.testing.assert_array_equal(d1, d2)
+    np.testing.assert_array_equal(c_edges1, c_edges2)
+    np.testing.assert_array_equal(d_edges1, d_edges2)
 
 
 def test_combine_bin_series_extrapolation_no_out_of_range():
@@ -862,10 +866,10 @@ def test_combine_bin_series_extrapolation_no_out_of_range():
     c2, _, d2, _ = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=np.nan)
     c3, _, d3, _ = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=0.0)
 
-    np.testing.assert_allclose(c1, c2, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(c1, c3, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d1, d2, rtol=0, atol=1e-6)
-    np.testing.assert_allclose(d1, d3, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(c1, c2)
+    np.testing.assert_array_equal(c1, c3)
+    np.testing.assert_array_equal(d1, d2)
+    np.testing.assert_array_equal(d1, d3)
 
 
 def test_get_soil_temperature_basic():
@@ -948,7 +952,7 @@ def test_time_bin_overlap_basic():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_no_overlap():
@@ -958,7 +962,7 @@ def test_time_bin_overlap_no_overlap():
     expected = np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_complete_overlap():
@@ -968,7 +972,7 @@ def test_time_bin_overlap_complete_overlap():
     expected = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_partial_overlap():
@@ -978,7 +982,7 @@ def test_time_bin_overlap_partial_overlap():
     expected = np.array([[0.5, 1.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_single_bin():
@@ -988,7 +992,7 @@ def test_time_bin_overlap_single_bin():
     expected = np.array([[0.5], [0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_edge_alignment():
@@ -998,7 +1002,7 @@ def test_time_bin_overlap_edge_alignment():
     expected = np.array([[1.0, 1.0, 0.0], [0.0, 1.0, 1.0]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_floating_point():
@@ -1018,7 +1022,7 @@ def test_time_bin_overlap_negative_values():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_overlapping_ranges():
@@ -1028,7 +1032,7 @@ def test_time_bin_overlap_overlapping_ranges():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 1.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_zero_width_bins():
@@ -1038,7 +1042,7 @@ def test_time_bin_overlap_zero_width_bins():
     expected = np.array([[0.5, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_large_range():
@@ -1048,7 +1052,7 @@ def test_time_bin_overlap_large_range():
     expected = np.array([[1.0, 1.0, 1.0]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_list_inputs():
@@ -1058,7 +1062,7 @@ def test_time_bin_overlap_list_inputs():
     expected = np.array([[0.5, 0.5, 0.0], [0.0, 0.0, 0.5]])
 
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 def test_time_bin_overlap_input_validation():
@@ -1100,7 +1104,7 @@ def test_time_bin_overlap_many_ranges():
     for i in range(len(bin_tedges)):
         # Each range spans 10 units, so total overlap should be 10
         total_overlap = np.sum(result[i, :])
-        np.testing.assert_allclose([total_overlap], [10.0], rtol=0, atol=1e-06)
+        np.testing.assert_array_equal([total_overlap], [10.0])
 
 
 def test_time_bin_overlap_boundary_cases():
@@ -1111,13 +1115,13 @@ def test_time_bin_overlap_boundary_cases():
     bin_tedges = [(10, 10)]
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
     expected = np.array([[0.0, 0.0, 0.0, 0.0]])
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
     # Range that exactly matches a bin
     bin_tedges = [(5, 10)]
     result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
     expected = np.array([[0.0, 1.0, 0.0, 0.0]])
-    np.testing.assert_allclose(result, expected, rtol=0, atol=1e-6)
+    np.testing.assert_array_equal(result, expected)
 
 
 # =============================================================================
@@ -1142,7 +1146,7 @@ def test_solve_tikhonov_resolution_well_determined():
     )
 
     np.testing.assert_allclose(x, x_true, atol=1e-6)
-    np.testing.assert_allclose(fraction_data, 1.0, atol=1e-4)
+    np.testing.assert_allclose(fraction_data, 1.0, rtol=0, atol=1e-9)
 
 
 def test_solve_tikhonov_resolution_underdetermined():
@@ -1281,13 +1285,13 @@ def test_generate_example_data_seed_changes_output():
 
 @pytest.mark.parametrize("seed", list(range(20)))
 def test_generate_example_data_flow_floor_enforced(seed):
-    """Flow floor of 5 m3/day must hold even after the spill loop divides flow.
+    """Flow floor of 5 m³/day must hold even after the spill loop divides flow.
 
     Regression test for issue 167: the floor was applied before spills, so
-    spill divisions could push flow well below 5 m3/day (observed min ~0.3).
+    spill divisions could push flow well below 5 m³/day (observed min ~0.3).
     """
     df, _ = generate_example_data(rng=seed)
-    assert df["flow"].min() >= 5.0, f"flow min {df['flow'].min()} below 5.0 m3/day for seed={seed}"
+    assert df["flow"].min() >= 5.0, f"flow min {df['flow'].min()} below 5.0 m³/day for seed={seed}"
 
 
 # =============================================================================
@@ -1532,3 +1536,313 @@ def test_dt_to_days_matches_reference_widths():
     assert result.dtype == np.float64
     # Consistency with tedges_to_days: widths are the successive differences.
     np.testing.assert_array_equal(result, np.diff(tedges_to_days(tedges)))
+
+
+# ---------------------------------------------------------------------------
+# step_plot_coords
+# ---------------------------------------------------------------------------
+
+
+def test_step_plot_coords_single_bin():
+    """n=1: one bin doubles each edge-pair and repeats the single value."""
+    edges = np.array([0.0, 2.0])
+    values = np.array([7.0])
+    x, y = step_plot_coords(edges, values)
+    # repeat(edges,2)[1:-1] = [0,0,2,2][1:-1] = [0,2]; repeat(values,2) = [7,7].
+    np.testing.assert_array_equal(x, [0.0, 2.0])
+    np.testing.assert_array_equal(y, [7.0, 7.0])
+
+
+def test_step_plot_coords_three_bins():
+    """n=3: hand-computed paired step coordinates for a piecewise-constant series."""
+    edges = np.array([0.0, 1.0, 3.0, 6.0])
+    values = np.array([2.0, 5.0, 1.0])
+    x, y = step_plot_coords(edges, values)
+    np.testing.assert_array_equal(x, [0.0, 1.0, 1.0, 3.0, 3.0, 6.0])
+    np.testing.assert_array_equal(y, [2.0, 2.0, 5.0, 5.0, 1.0, 1.0])
+    # The step coordinates have 2n points for n bins.
+    assert x.shape == (2 * values.size,)
+    assert y.shape == (2 * values.size,)
+
+
+def test_step_plot_coords_datetime_edges_preserve_dtype():
+    """Datetime edges round-trip through the step expansion without losing dtype."""
+    edges = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-04"])
+    values = np.array([1.0, 2.0])
+    x, y = step_plot_coords(np.asarray(edges), values)
+    expected_x = np.asarray(edges)[[0, 1, 1, 2]]
+    np.testing.assert_array_equal(x, expected_x)
+    np.testing.assert_array_equal(y, [1.0, 1.0, 2.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# compute_time_edges
+# ---------------------------------------------------------------------------
+
+
+def test_compute_time_edges_explicit_tedges_roundtrip():
+    """Explicit tedges pass through unchanged (ns unit) when the length matches."""
+    tedges = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"])
+    result = compute_time_edges(tedges=tedges, tstart=None, tend=None, number_of_bins=2)
+    assert isinstance(result, pd.DatetimeIndex)
+    assert result.dtype == np.dtype("datetime64[ns]")
+    np.testing.assert_array_equal(result.to_numpy(), tedges.as_unit("ns").to_numpy())
+
+
+def test_compute_time_edges_explicit_tedges_wrong_length():
+    """tedges with the wrong length (not number_of_bins + 1) is rejected."""
+    tedges = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"])
+    with pytest.raises(ValueError, match="tedges must have one more element than flow"):
+        compute_time_edges(tedges=tedges, tstart=None, tend=None, number_of_bins=5)
+
+
+def test_compute_time_edges_tstart_extrapolates_final_edge():
+    """tstart: the FINAL edge is extrapolated as tstart[-1] + (tstart[-1] - tstart[-2])."""
+    tstart = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"])
+    result = compute_time_edges(tedges=None, tstart=tstart, tend=None, number_of_bins=3)
+    expected = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"])
+    np.testing.assert_array_equal(result.to_numpy(), expected.as_unit("ns").to_numpy())
+
+
+def test_compute_time_edges_tstart_wrong_length():
+    """tstart length must equal number_of_bins."""
+    tstart = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"])
+    with pytest.raises(ValueError, match="tstart must have the same number of elements as flow"):
+        compute_time_edges(tedges=None, tstart=tstart, tend=None, number_of_bins=2)
+
+
+def test_compute_time_edges_tend_extrapolates_initial_edge():
+    """tend: the INITIAL edge is extrapolated as tend[0] - (tend[1] - tend[0])."""
+    tend = pd.DatetimeIndex(["2020-01-02", "2020-01-03", "2020-01-04"])
+    result = compute_time_edges(tedges=None, tstart=None, tend=tend, number_of_bins=3)
+    expected = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04"])
+    np.testing.assert_array_equal(result.to_numpy(), expected.as_unit("ns").to_numpy())
+
+
+def test_compute_time_edges_tend_wrong_length():
+    """tend length must equal number_of_bins."""
+    tend = pd.DatetimeIndex(["2020-01-02", "2020-01-03"])
+    with pytest.raises(ValueError, match="tend must have the same number of elements as flow"):
+        compute_time_edges(tedges=None, tstart=None, tend=tend, number_of_bins=3)
+
+
+def test_compute_time_edges_none_provided_raises():
+    """With none of tedges/tstart/tend provided, a clear 'or' message is raised."""
+    with pytest.raises(ValueError, match="Either provide tedges, tstart, or tend"):
+        compute_time_edges(tedges=None, tstart=None, tend=None, number_of_bins=3)
+
+
+def test_compute_time_edges_tstart_single_bin_raises():
+    """A single-bin series from tstart leaves the bin width undefined: a clear ValueError."""
+    tstart = pd.DatetimeIndex(["2020-01-01"])
+    with pytest.raises(ValueError, match="tstart must have at least 2 elements"):
+        compute_time_edges(tedges=None, tstart=tstart, tend=None, number_of_bins=1)
+
+
+def test_compute_time_edges_tend_single_bin_raises():
+    """A single-bin series from tend leaves the bin width undefined: a clear ValueError."""
+    tend = pd.DatetimeIndex(["2020-01-01"])
+    with pytest.raises(ValueError, match="tend must have at least 2 elements"):
+        compute_time_edges(tedges=None, tstart=None, tend=tend, number_of_bins=1)
+
+
+# ---------------------------------------------------------------------------
+# compute_reverse_target
+# ---------------------------------------------------------------------------
+
+
+def test_compute_reverse_target_transpose_normalize():
+    """The target is the row-normalized transpose of the forward matrix applied to observed.
+
+    For a forward matrix whose columns map cin to cout, transpose-and-normalize reconstructs
+    each cin bin as the column-sum-weighted average of the cout values it fed. The expected
+    values here are hand-derived rational numbers, so the check is exact.
+    """
+    # Column 0 feeds rows 0 and 1; column 1 feeds only row 1.
+    coeff = np.array([[1.0, 0.0], [1.0, 2.0]])
+    observed = np.array([4.0, 10.0])
+    # wt = coeff.T = [[1,1],[0,2]]; row_sums = [2, 2].
+    # x_target[0] = (1*4 + 1*10) / 2 = 7; x_target[1] = (0*4 + 2*10) / 2 = 10.
+    result = compute_reverse_target(coeff_matrix=coeff, rhs_vector=observed)
+    np.testing.assert_array_equal(result, [7.0, 10.0])
+
+
+def test_compute_reverse_target_zero_column_is_nan():
+    """A cin bin with a near-zero forward column sum is returned as NaN (undetermined)."""
+    coeff = np.array([[1.0, 0.0], [1.0, 0.0]])  # column 1 has zero sum
+    observed = np.array([3.0, 5.0])
+    result = compute_reverse_target(coeff_matrix=coeff, rhs_vector=observed)
+    # column 0 sum = 2; x_target[0] = (3 + 5) / 2 = 4. column 1 -> NaN.
+    np.testing.assert_array_equal(result[0], 4.0)
+    assert np.isnan(result[1])
+
+
+# ---------------------------------------------------------------------------
+# _make_strictly_monotone overshoot regression
+# ---------------------------------------------------------------------------
+
+
+def test_make_strictly_monotone_long_run_does_not_overshoot_close_successor():
+    """A long plateau followed by a closely-spaced genuine value must stay strictly monotone.
+
+    Regression: the unconditional ``cumcount * 16 * ulp`` bump could push the last duplicate of
+    a long run past a successor only a few ulps above the plateau, producing a NON-monotone
+    array. The per-run cap (step <= gap / (run_len + 1)) prevents the overshoot.
+    """
+    base = 1.0
+    ulp = np.nextafter(base, np.inf) - base
+    # Run of 4 duplicates at ``base`` followed by a genuine value only 10 ulps above; the
+    # uncapped bump (up to 4 * 16 = 64 ulp) would overshoot the 10-ulp gap.
+    arr = np.array([0.0, base, base, base, base, base + 10 * ulp])
+    result = _make_strictly_monotone(arr)
+    assert np.all(np.diff(result) > 0), f"non-monotone result: {result}"
+    # The successor value is preserved (never exceeded).
+    assert result[-1] == base + 10 * ulp
+
+
+def test_make_strictly_monotone_trailing_plateau_uses_full_bump():
+    """A plateau at the array end has no successor, so the uncapped bump applies."""
+    arr = np.array([0.0, 1.0, 1.0, 1.0])
+    ulp_max = np.nextafter(1.0, np.inf) - 1.0
+    bump = 16 * ulp_max
+    expected = np.array([0.0, 1.0, 1.0 + bump, 1.0 + 2 * bump])
+    result = _make_strictly_monotone(arr)
+    np.testing.assert_array_equal(result, expected)
+    assert np.all(np.diff(result) > 0)
+
+
+# ---------------------------------------------------------------------------
+# partial_isin zero-width and NaN-edge handling
+# ---------------------------------------------------------------------------
+
+
+def test_partial_isin_zero_width_input_bin_is_zero():
+    """A zero-width (degenerate) input bin yields 0.0 overlap (no water passed)."""
+    bin_edges_in = np.array([0.0, 10.0, 10.0, 20.0])  # middle bin has zero width
+    bin_edges_out = np.array([0.0, 20.0])
+    result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
+    # First and third bins fully overlap the single output bin; the zero-width bin is 0.
+    np.testing.assert_array_equal(result, [[1.0], [0.0], [1.0]])
+
+
+def test_partial_isin_nan_input_edge_propagates_nan():
+    """A NaN input edge propagates as NaN fractions for the adjacent bins (spin-up masking)."""
+    bin_edges_in = np.array([0.0, np.nan, 20.0])
+    bin_edges_out = np.array([0.0, 10.0, 20.0])
+    result = partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
+    # Both bins are adjacent to the NaN edge, so every fraction is NaN.
+    assert np.isnan(result).all()
+
+
+# ---------------------------------------------------------------------------
+# linear_average extrapolate_method='raise' and 1D NaN bridging
+# ---------------------------------------------------------------------------
+
+
+def test_linear_average_raise_out_of_range():
+    """extrapolate_method='raise' rejects any edge outside the data range."""
+    x_data = np.array([0.0, 1.0, 2.0])
+    y_data = np.array([0.0, 1.0, 2.0])
+    with pytest.raises(ValueError, match="x_edges must be within the range of x_data"):
+        linear_average(x_data=x_data, y_data=y_data, x_edges=np.array([-1.0, 2.0]), extrapolate_method="raise")
+
+
+def test_linear_average_raise_in_range_passes():
+    """extrapolate_method='raise' returns the in-range average when all edges are in range."""
+    x_data = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    y_data = np.array([0.0, 1.0, 2.0, 3.0, 4.0])  # y = x
+    result = linear_average(x_data=x_data, y_data=y_data, x_edges=np.array([1.0, 3.0]), extrapolate_method="raise")
+    # mean of y = x over [1, 3] = 2.
+    np.testing.assert_array_equal(result, [[2.0]])
+
+
+def test_linear_average_1d_nan_bridging():
+    """1D y_data silently bridges an interior NaN by linear interpolation across the gap.
+
+    This pins the documented 1D-vs-2D asymmetry: a 1D series treats an interior NaN as a gap
+    to interpolate across, so a bin spanning it returns the bridged linear mean.
+    """
+    x_data = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    y_data = np.array([0.0, 1.0, np.nan, 3.0, 4.0])  # y = x with an interior hole at x=2
+    # The NaN sample is dropped; the remaining points still lie on y = x, so the bridged
+    # value at x=2 is 2. Mean of y = x over [1, 3] is therefore 2 (no NaN leaks through).
+    result = linear_average(x_data=x_data, y_data=y_data, x_edges=np.array([1.0, 3.0]))
+    np.testing.assert_array_equal(result, [[2.0]])
+
+
+# ---------------------------------------------------------------------------
+# solve_underdetermined_system: summed_differences and NaN-row paths
+# ---------------------------------------------------------------------------
+
+
+def test_solve_underdetermined_system_summed_differences_is_feasible_and_sparse():
+    """The summed_differences objective stays feasible and yields a sparser difference profile.
+
+    summed_differences (L1 on adjacent differences) promotes piecewise-constant solutions, so
+    its difference vector must have strictly more (near-)zero entries than the smooth
+    squared_differences (L2) solution while still satisfying A x = b exactly. The L1 objective
+    is non-smooth at its piecewise-constant optimum, so a derivative-free method is used.
+    """
+    # Block-structured system: each equation constrains a separate pair of unknowns.
+    matrix = np.array([[1.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 1.0]])
+    rhs = np.array([4.0, 6.0])
+
+    x_summed = solve_underdetermined_system(
+        coefficient_matrix=matrix,
+        rhs_vector=rhs,
+        nullspace_objective="summed_differences",
+        optimization_method="Nelder-Mead",
+    )
+    x_squared = solve_underdetermined_system(
+        coefficient_matrix=matrix, rhs_vector=rhs, nullspace_objective="squared_differences"
+    )
+
+    # (1) Feasibility of the L1 solution.
+    np.testing.assert_allclose(matrix @ x_summed, rhs, atol=1e-8)
+
+    # (2) The L1 minimizer is piecewise-constant within each block: [2, 2, 3, 3].
+    np.testing.assert_allclose(x_summed, [2.0, 2.0, 3.0, 3.0], atol=1e-6)
+
+    # (3) Strictly sparser difference profile than the smooth L2 solution.
+    n_zero_summed = int(np.sum(np.abs(np.diff(x_summed)) < 1e-6))
+    n_zero_squared = int(np.sum(np.abs(np.diff(x_squared)) < 1e-6))
+    assert n_zero_summed > n_zero_squared
+
+
+def test_solve_underdetermined_system_excludes_nan_row():
+    """A NaN row is dropped from the system; the solution still satisfies the finite equations."""
+    matrix = np.array([
+        [1.0, 2.0, 1.0, 0.0],
+        [np.nan, np.nan, np.nan, np.nan],
+        [0.0, 1.0, 2.0, 1.0],
+    ])
+    rhs = np.array([5.0, np.nan, 4.0])
+    result = solve_underdetermined_system(coefficient_matrix=matrix, rhs_vector=rhs)
+    finite = np.array([[1.0, 2.0, 1.0, 0.0], [0.0, 1.0, 2.0, 1.0]])
+    np.testing.assert_allclose(finite @ result, [5.0, 4.0], atol=1e-8)
+
+
+def test_solve_underdetermined_system_all_nan_rows_raises():
+    """When every row contains NaN, no valid rows remain and a ValueError is raised."""
+    matrix = np.full((2, 3), np.nan)
+    rhs = np.array([np.nan, np.nan])
+    with pytest.raises(ValueError, match="No valid rows found"):
+        solve_underdetermined_system(coefficient_matrix=matrix, rhs_vector=rhs)
+
+
+# ---------------------------------------------------------------------------
+# simplify_bins early-exit must echo the flow array when flow is provided
+# ---------------------------------------------------------------------------
+
+
+def test_simplify_bins_empty_with_flow_returns_empty_flow_array():
+    """Empty input with flow provided returns an empty float array, not None."""
+    edges = np.array([0.0])
+    values = np.array([])
+    flow = np.array([])
+    new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow)
+    assert len(new_edges) == 1
+    assert len(new_values) == 0
+    assert new_flow is not None
+    assert new_flow.dtype == np.float64
+    assert len(new_flow) == 0


### PR DESCRIPTION
## Summary

Part of the package-wide review — per-module PR for `gwtransport.utils` (+ `_validation`, `_time`). **Draft.**

- **Bug fix:** `_make_strictly_monotone` overshoot capped per run (`step=min(16*ulp, gap/(run_len+1))`) so long zero-flow plateaus do not overrun the next distinct value; regression test fails on pre-fix code.
- **Tests:** added coverage for previously-untested `step_plot_coords`/`compute_time_edges`/`compute_reverse_target`; reframed tautological `simplify_bins` conservation tests as hand-derived known-answer tests; tightened ~87 exact-arithmetic assertions to `assert_array_equal`; tightened `solve_tikhonov` tolerance to the achieved floor.
- **Lean/typing:** factored the duplicated `combine_bin_series` mapping; removed dead null-guards; `np.float64`→`np.floating`, bare `np.ndarray`→`npt.NDArray[np.floating]`; dropped `typing.TYPE_CHECKING` (pandas is a hard dep); Unicode units.
- **Deferred:** making `step_plot_coords`/`cumulative_flow_volume` keyword-only (called positionally across modules — a cross-module signature change).

## Test plan

- `pytest --doctest-modules` over utils/_validation/_time + their tests — 196 passed. `ty` + `ruff` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
