### PR TITLE
fix(diffusion): K-Z flux mass conservation for R>1 with D_m>0 (solute-front velocity)

### DIFF
--- a/src/gwtransport/_diffusion_shared.py
+++ b/src/gwtransport/_diffusion_shared.py
@@ -2,9 +2,9 @@
 Shared closed-form helpers for the Kreft-Zuber flux-concentration transport modules.
 
 This private module holds the pieces common to :mod:`gwtransport.diffusion_fast` and
-:mod:`gwtransport.diffusion_fast_fast`: the breakthrough antiderivative, the retardation
-flux-coefficient correction, input validation, the banded Tikhonov reverse solve, and the small
-per-streamtube / spin-up helpers. Both modules import from here so these primitives are defined once
+:mod:`gwtransport.diffusion_fast_fast`: the breakthrough antiderivative, input validation, the
+banded Tikhonov reverse solve, and the small per-streamtube / spin-up helpers. Both modules import
+from here so these primitives are defined once
 and evaluate bit-identically in either module (the modules' overall transport is *not* identical:
 diffusion_fast is exact, diffusion_fast_fast approximate).
 
@@ -15,7 +15,7 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 import numpy as np
 import numpy.typing as npt
 import pandas as pd
-from scipy.special import erf, erfcx
+from scipy.special import erf
 
 from gwtransport._time import dt_to_days
 from gwtransport.utils import solve_inverse_transport_banded
@@ -33,101 +33,26 @@ _DT_FLOOR = 1e-30
 
 def _breakthrough_antideriv(
     step_widths: npt.NDArray[np.floating], dt_var: npt.NDArray[np.floating]
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+) -> npt.NDArray[np.floating]:
     r"""Closed-form antiderivative of the resident concentration, evaluated per edge.
 
     Returns :math:`I(x) = \tfrac12 x + \tfrac12[x\,\operatorname{erf}(x/s) + (s/\sqrt\pi)e^{-(x/s)^2}]`
-    with :math:`s = 2\sqrt{D_t}`, alongside ``s`` and the Gaussian factor ``exp(-(x/s)^2)`` (both
-    reused by the retardation correction). Shared by the banded ``C_F`` build
+    with :math:`s = 2\sqrt{D_t}`. Shared by the banded ``C_F`` build
     (:func:`gwtransport.diffusion_fast._pv_band_values`) and the slow quadrature, so both compute
-    identical floating-point results for the same inputs.
+    identical floating-point results for the same inputs. Because ``dD_t/dx = D_s/v_s`` is the
+    Kreft-Zuber flux coefficient at the solute-front velocity, differencing ``I`` across a cout bin
+    yields the flux concentration ``C_F`` directly.
 
     Returns
     -------
     antideriv : ndarray
         The antiderivative :math:`I(x)`.
-    s : ndarray
-        ``2 * sqrt(D_t)``.
-    gaussian : ndarray
-        ``exp(-(x/s)^2)``.
     """
     s = 2.0 * np.sqrt(dt_var)
     with np.errstate(over="ignore", invalid="ignore"):
         u = step_widths / s
         gaussian = np.exp(-(u * u))
-        antideriv = 0.5 * step_widths + 0.5 * (step_widths * erf(u) + (s / _SQRT_PI) * gaussian)
-    return antideriv, s, gaussian
-
-
-def _retardation_excess_density(
-    *,
-    x_lo: npt.NDArray[np.floating],
-    x_hi: npt.NDArray[np.floating],
-    dx: npt.NDArray[np.floating],
-    d_lo: npt.NDArray[np.floating],
-    d_hi: npt.NDArray[np.floating],
-    s_lo: npt.NDArray[np.floating],
-    s_hi: npt.NDArray[np.floating],
-    g_lo: npt.NDArray[np.floating],
-    g_hi: npt.NDArray[np.floating],
-) -> npt.NDArray[np.floating]:
-    r"""Closed-form bin-average of the Gaussian density ``<g>`` for the retardation correction.
-
-    When ``R != 1`` and ``D_m > 0`` the per-edge antiderivative bakes in an effective flux
-    coefficient ``dD_t/dx = R*D_m/v + alpha_L`` (because ``d(tau)/dx = R/v`` under retardation),
-    whereas Kreft-Zuber wants ``D_L/v = D_m/v + alpha_L``. The excess ``(R-1)*D_m/v`` is removed
-    by subtracting it times ``<g>``, the bin-average of the Gaussian density
-    ``g = e^{-x^2/(4 D_t)} / (2 sqrt(pi D_t))``. Within a bin ``D_t`` is linear in ``x``, so ``<g>``
-    is closed form: substituting ``w = D_t`` in ``int g dx`` gives
-    ``int w^{-1/2} e^{-w/(4 m^2) - c^2/(4 m^2 w)} dw`` -- a pair of error functions -- with slope
-    ``m = dD_t/dx`` and intercept ``c = D_t(x=0)``. Reusing the antiderivative's Gaussian factor
-    ``G = e^{-x^2/(4 D_t)}``, ``erfcx`` keeps the (always non-negative) ``u+`` branch overflow-free;
-    the ``u-`` branch splits: ``erfcx`` where ``u- >= 0``, ``erf`` elsewhere. Each transcendental is
-    evaluated on its own subset (fancy indexing) rather than over the full array. The slope->0
-    (constant-``D_t``) limit is the exact ``[C_R(x_hi) - C_R(x_lo)] / dx``, applied only on that subset.
-
-    Parameters
-    ----------
-    x_lo, x_hi : ndarray
-        Breakthrough coordinate ``step_widths`` at the lower / upper cout edge of each bin.
-    dx : ndarray
-        ``x_hi - x_lo``.
-    d_lo, d_hi : ndarray
-        Moving-frame dispersion product ``D_t`` at the lower / upper edge.
-    s_lo, s_hi : ndarray
-        ``2 * sqrt(D_t)`` at the lower / upper edge.
-    g_lo, g_hi : ndarray
-        Gaussian factor ``exp(-(x/s)^2)`` at the lower / upper edge.
-
-    Returns
-    -------
-    ndarray
-        Bin-averaged Gaussian density ``<g>``.
-    """
-    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
-        slope = (d_hi - d_lo) / dx
-        intercept = d_lo - slope * x_lo
-        abs_int = np.abs(intercept)
-        # s = 2*sqrt(D_t) is already computed, so slope*s = 2*slope*sqrt(D_t).
-        two_m_sqrt_lo = slope * s_lo
-        two_m_sqrt_hi = slope * s_hi
-        um_lo = (d_lo - abs_int) / two_m_sqrt_lo
-        um_hi = (d_hi - abs_int) / two_m_sqrt_hi
-        up_lo = (d_lo + abs_int) / two_m_sqrt_lo
-        up_hi = (d_hi + abs_int) / two_m_sqrt_hi
-        t_plus = g_lo * erfcx(up_lo) - g_hi * erfcx(up_hi)
-        t_minus = np.empty_like(t_plus)
-        pos = um_lo >= 0.0
-        neg = ~pos
-        t_minus[pos] = g_lo[pos] * erfcx(um_lo[pos]) - g_hi[pos] * erfcx(um_hi[pos])
-        c_minus = np.exp((intercept[neg] - abs_int[neg]) / (2.0 * slope[neg] ** 2))
-        t_minus[neg] = c_minus * (erf(um_hi[neg]) - erf(um_lo[neg]))
-        density_binavg = (t_minus + t_plus) / (2.0 * dx)
-        flat = np.abs(d_hi - d_lo) <= 1e-9 * np.maximum(d_lo, d_hi)
-        d_bar_s = 2.0 * np.sqrt(0.5 * (d_lo[flat] + d_hi[flat]))
-        density_binavg[flat] = 0.5 * (erf(x_hi[flat] / d_bar_s) - erf(x_lo[flat] / d_bar_s)) / dx[flat]
-        density_binavg[dx <= 0.0] = 0.0
-    return density_binavg
+        return 0.5 * step_widths + 0.5 * (step_widths * erf(u) + (s / _SQRT_PI) * gaussian)
 
 
 def _cout_cumulative_volume(

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -38,7 +38,15 @@ Reported outlet concentration: Kreft-Zuber (1978) flux concentration
 
 The outlet concentration reported by this module is the **flux concentration**
 
-    C_F(L, t) = C_R(L, t) - (D_L(t) / v(t)) * dC_R/dx |_{x=L}
+    C_F(L, t) = C_R(L, t) - (D_s / v_s) * dC_R/dx |_{x=L}
+
+with the solute-front (retarded-frame) velocity v_s = Q L / (R V_pore) and the
+dispersion D_s = D_m + alpha_L * v_s, so the flux coefficient is
+D_s / v_s = D_m / v_s + alpha_L = R D_m / v_fluid + alpha_L (with the fluid
+velocity v_fluid = Q L / V_pore). The resident profile C_R solves the retarded
+ADE with advection v_s and dispersion D_s, so its flux-vs-resident correction
+must use v_s — not v_fluid; pairing v_s with the moving-frame variance below is
+what conserves mass for R > 1 with D_m > 0.
 
 — the solute mass flux at the outlet divided by the volumetric fluid flux. This
 is what is measured when sampling the extracted fluid. The resident
@@ -140,7 +148,6 @@ def _cfrac_mean_volume(
     longitudinal_dispersivity: float,
     r_vpv: float,
     streamline_len: float,
-    aquifer_pore_volume: float,
 ) -> npt.NDArray[np.float64]:
     r"""Compute bin-averaged flux concentration at the outlet for each cell.
 
@@ -152,7 +159,7 @@ def _cfrac_mean_volume(
         \text{frac}_{i,j} = \frac{1}{\Delta V_i}
         \int_{V_i}^{V_{i+1}} C_F\!\left(L,\,V;\,t_j\right) dV
 
-    where :math:`C_F = C_R - (D_L / v) \, \partial_x C_R\big|_{x=L}` and
+    where :math:`C_F = C_R - (D_s / v_s) \, \partial_x C_R\big|_{x=L}` and
     :math:`C_R` is Bear's (1972) moving-frame solution:
 
     .. math::
@@ -162,13 +169,16 @@ def _cfrac_mean_volume(
         \xi_j(V) &= L \cdot (V - V_j) \,/\, (R\,V_\text{pore}) \\
         D_t(V) &= D_m\,\tau_j(V) + \alpha_L\,\xi_j(V),
             \quad \tau_j(V) = t(V) - t_j \\
-        D_L(t) &= D_m + \alpha_L\,v(t), \quad v(t) = Q(t)\,L\,/\,V_\text{pore}.
+        D_s &= D_m + \alpha_L\,v_s(t), \quad v_s(t) = Q(t)\,L\,/\,(R\,V_\text{pore}).
 
-    The added flux-correction term
+    The solute-front velocity :math:`v_s` (advection speed of the retarded ADE
+    that :math:`C_R` solves), not the fluid velocity :math:`Q L / V_\text{pore}`,
+    sets the flux coefficient :math:`D_s/v_s = D_m/v_s + \alpha_L`. The added
+    flux-correction term
 
     .. math::
 
-        \frac{D_L(t(V))}{v(t(V))} \cdot
+        \frac{D_s}{v_s(t(V))} \cdot
         \frac{1}{\sqrt{4\pi\,D_t(V)}}\,
         \exp\!\left( -\frac{(L - \xi_j(V))^2}{4\,D_t(V)} \right)
 
@@ -200,8 +210,8 @@ def _cfrac_mean_volume(
     tedges_days : ndarray, shape (n_cin_edges,)
         Flow time edges in days.
     molecular_diffusivity : float
-        Effective molecular diffusivity D_m [m²/day]. Contributes
-        ``D_m * tau`` to the dispersion product ``D_t``.
+        Effective (retarded-frame) molecular diffusivity D_m [m²/day].
+        Contributes ``D_m * tau`` to the dispersion product ``D_t``.
     longitudinal_dispersivity : float
         Longitudinal dispersivity alpha_L [m]. Contributes ``alpha_L * xi``
         to the dispersion product ``D_t``.
@@ -209,9 +219,6 @@ def _cfrac_mean_volume(
         Retardation factor times pore volume = R * V_pore [m³].
     streamline_len : float
         Streamline length L [m].
-    aquifer_pore_volume : float
-        Pore volume V_pore [m³]. Used to compute fluid velocity
-        ``v = Q * L / V_pore`` for the K-Z flux correction.
 
     Returns
     -------
@@ -245,13 +252,17 @@ def _cfrac_mean_volume(
         cr_no_disp = np.where(dx == 0.0, 0.5 + 0.5 * np.sign(x_lo), cr_no_disp)
         return np.where(is_valid, cr_no_disp, frac)
 
-    # --- Pre-compute fluid velocity and K-Z coefficient (D_L/v) per flow bin ---
+    # --- Pre-compute solute-front velocity and K-Z coefficient (D_s/v_s) per flow bin ---
     dv_per_bin = np.diff(cumulative_volume_at_cin_tedges)
     dt_per_bin = np.diff(tedges_days)
     with np.errstate(divide="ignore", invalid="ignore"):
         q_per_bin = np.where(dt_per_bin > 0, dv_per_bin / dt_per_bin, 0.0)
-        v_per_bin = q_per_bin * streamline_len / aquifer_pore_volume
-        # (D_L/v) = D_m/v + alpha_L. At v=0 the bin has dV=0 and is skipped below.
+        # Solute-front velocity v_s = Q L / (R V_pore) -- the advection speed of the retarded ADE
+        # that C_R actually solves. Kreft-Zuber requires the flux coefficient D_s/v_s = D_m/v_s +
+        # alpha_L to use THAT velocity (not the fluid velocity Q L / V_pore); pairing it with the
+        # moving-frame variance D_t = D_m tau + alpha_L xi is what conserves mass for R>1, D_m>0.
+        v_per_bin = q_per_bin * streamline_len / r_vpv
+        # (D_s/v_s) = D_m/v_s + alpha_L. At v_s=0 the bin has dV=0 and is skipped below.
         dl_over_v_per_bin = np.where(
             v_per_bin > 0,
             molecular_diffusivity / np.where(v_per_bin > 0, v_per_bin, 1.0) + longitudinal_dispersivity,
@@ -317,7 +328,7 @@ def _cfrac_mean_volume(
         erf_vals = np.where(np.isfinite(arg), special.erf(arg), np.sign(x_nodes))
         cr_vals = 0.5 * (1.0 + erf_vals)
 
-        # K-Z flux correction: FC = (D_L/v) * (1/sqrt(4 pi D_t)) * exp(-arg^2)
+        # K-Z flux correction: FC = (D_s/v_s) * (1/sqrt(4 pi D_t)) * exp(-arg^2)
         with np.errstate(divide="ignore", invalid="ignore"):
             gauss_vals = np.where(
                 dt_nodes > 0.0,
@@ -553,7 +564,6 @@ def _infiltration_to_extraction_coeff_matrix(
             longitudinal_dispersivity=float(longitudinal_dispersivity[i_pv]),
             r_vpv=r_vpv,
             streamline_len=streamline_length[i_pv],
-            aquifer_pore_volume=float(aquifer_pore_volumes[i_pv]),
         )
 
         frac_start = frac[:, :-1]
@@ -599,10 +609,11 @@ def infiltration_to_extraction(
     concentration** at the outlet, defined as the solute mass flux divided
     by the volumetric fluid flux. This is what is measured when sampling the
     outflowing fluid. Compared to Bear's leading-order resident concentration,
-    it includes the dispersive boundary flux ``-D_L * dC_R/dx`` at
-    ``x = L``, which is what makes the column-sum invariant
-    ``integral Q c_out dt = integral Q c_in dt`` hold exactly under variable
-    flow.
+    it includes the dispersive boundary flux ``-D_s * dC_R/dx`` at
+    ``x = L`` (with the solute-front dispersion ``D_s = D_m + alpha_L * v_s``
+    and velocity ``v_s = Q L / (R V_pore)``), which is what makes the column-sum
+    invariant ``integral Q c_out dt = integral Q c_in dt`` hold exactly under
+    variable flow.
 
     Longitudinal dispersion enters as the moving-frame variance
 
@@ -638,19 +649,21 @@ def infiltration_to_extraction(
         Array of travel distances [m] corresponding to each pore volume.
         Must have the same length as aquifer_pore_volumes.
     molecular_diffusivity : float or array-like
-        Effective molecular diffusivity [m2/day]. Can be a scalar (same for all
-        pore volumes) or an array with the same length as aquifer_pore_volumes.
-        Must be non-negative. For solute transport, this is the molecular
-        diffusion coefficient D_m [m2/day] — typically ~1e-5 m2/day, negligible
-        compared to mechanical dispersion. For heat transport, pass the thermal
-        diffusivity D_th = lambda / (rho*c)_eff [m2/day], typically 0.01-0.1
-        m2/day.
+        Effective (retarded-frame) molecular diffusivity [m2/day]. Can be a
+        scalar (same for all pore volumes) or an array with the same length as
+        aquifer_pore_volumes. Must be non-negative. For solute transport, this is
+        the molecular diffusion coefficient D_m [m2/day] — typically ~1e-5 m2/day,
+        negligible compared to mechanical dispersion. For heat transport, pass the
+        thermal diffusivity D_th = lambda / (rho*c)_eff [m2/day], typically
+        0.01-0.1 m2/day.
 
         Internally, this contributes ``2 * molecular_diffusivity * tau`` to the
         variance, where ``tau`` is the elapsed time in days (no extra factor of
-        R). For heat transport, the thermal diffusivity already represents the
-        effective diffusivity D_eff in the porous matrix; for solutes the
-        contribution is typically negligible.
+        R). The retardation factor instead enters the flux coefficient
+        ``D_s/v_s = R D_m / v_fluid + alpha_L`` through the solute-front velocity
+        ``v_s = Q L / (R V_pore)``. For heat transport, the thermal diffusivity
+        already represents the effective diffusivity D_eff in the porous matrix;
+        for solutes the contribution is typically negligible.
     longitudinal_dispersivity : float or array-like
         Longitudinal dispersivity [m]. Can be a scalar (same for all pore
         volumes) or an array with the same length as aquifer_pore_volumes.
@@ -702,7 +715,8 @@ def infiltration_to_extraction(
 
     4. Average coefficients across all pore volumes.
 
-    The K-Z flux-correction term in C_F = C_R - (D_L/v) * dC_R/dx is what
+    The K-Z flux-correction term in C_F = C_R - (D_s/v_s) * dC_R/dx (solute-front
+    velocity v_s = Q L / (R V_pore), dispersion D_s = D_m + alpha_L * v_s) is what
     makes the column-sum invariant exact under variable Q; see the module
     docstring for the derivation.
 

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -13,9 +13,10 @@ the moving-frame dispersion product. Its bin-average over a cout bin has the clo
 antiderivative ``I(x) = 0.5*x + 0.5*[x*erf(x/s) + (s/sqrt(pi))*exp(-(x/s)^2)]``,
 ``s = 2*sqrt(D_t)``. Evaluating ``I`` once per cout edge with ``D_t`` carried *per edge*
 and differencing yields the flux concentration ``C_F`` directly -- not merely ``C_R`` --
-because ``dD_t/dx = D_m/v + alpha_L = D_L/v`` is exactly the Kreft-Zuber flux coefficient
-(using ``d(tau)/dx = 1/v``). The dispersive boundary-flux correction therefore emerges from
-the ``D_t`` variation across the bin; no explicit correction term is added.
+because ``dD_t/dx = D_m/v_s + alpha_L = D_s/v_s`` is exactly the Kreft-Zuber flux coefficient
+at the solute-front velocity ``v_s = Q*L/(R*V_pore)`` (using ``d(tau)/dx = 1/v_s`` with
+``tau = R*V/(L*Q)``). The dispersive boundary-flux correction therefore emerges from the
+``D_t`` variation across the bin; no explicit correction term is added.
 
 The elapsed time ``tau`` and travel distance ``xi`` are read directly from the time and
 cumulative-volume edges (``tau_ij = t_cout_i - t_cin_j``, ``xi`` geometric), so no per-cell
@@ -44,8 +45,8 @@ concentration on 1D streamtubes, with retardation and the moving-frame variance
 ``molecular_diffusivity`` / ``longitudinal_dispersivity`` arrays. Whenever the cout grid is
 at or finer than the flow grid, this module reproduces :mod:`gwtransport.diffusion` to
 machine precision for *every* parameter regime -- including ``retardation_factor != 1`` with
-``molecular_diffusivity > 0``, whose flux correction is itself evaluated in closed form
-(its Gaussian-density bin-average has an exact erf/erfcx form) -- while being ~80-90x faster
+``molecular_diffusivity > 0``, where the antiderivative's slope ``dD_t/dx = D_s/v_s`` already
+carries the solute-front Kreft-Zuber flux coefficient natively -- while being ~80-90x faster
 even before banding (closed form, no Gauss-Legendre quadrature, no residence-time inversion),
 and the banded build computes only the non-zero breakthrough band -- faster still at the
 weak-to-moderate dispersion of realistic problems. So it is the right default. The only case that favours
@@ -83,7 +84,6 @@ from gwtransport._diffusion_shared import (
     _broadcast_to_pore_volumes,
     _cout_cumulative_volume,
     _extend_tedges_flag,
-    _retardation_excess_density,
     _solve_reverse_banded,
     _validate_inputs,
 )
@@ -214,18 +214,19 @@ def _pv_band_values(
     length: float,
     molecular_diffusivity: float,
     longitudinal_dispersivity: float,
-    retardation_factor: float,
-    velocity: npt.NDArray[np.floating],
 ) -> npt.NDArray[np.floating]:
     r"""Bin-averaged ``C_F`` stripe for one streamtube on the shared band (values pass).
 
     ``C_F`` over a cout bin is ``(I(x_hi) - I(x_lo)) / dx`` with the closed-form antiderivative
-    ``I`` evaluated at both cout edges over the band cin edges, plus the same closed-form
-    retardation correction as the slow quadrature. The stripe is the band itself: each row spans
-    cin edges ``col_start[k] .. col_start[k] + full_band`` (``full_band + 1`` edges), so the
-    coefficient for band offset ``b`` (cin bin ``col_start[k] + b``) is ``frac[b] - frac[b + 1]``.
-    The zero-dispersion limit is exact here too: ``D_t`` floors to ``_DT_FLOOR``, so ``C_F`` is a
-    step smoothed by ~1e-15.
+    ``I`` evaluated at both cout edges over the band cin edges. Because ``D_t = D_m*tau + alpha_L*xi``
+    with ``tau = R*V/(L*Q)``, the antiderivative's slope ``dD_t/dx = R*D_m/v_fluid + alpha_L =
+    D_s/v_s`` is exactly the Kreft-Zuber flux coefficient at the solute-front velocity
+    ``v_s = Q*L/(R*V_pore)``, so the flux concentration emerges natively -- no correction term is
+    added. The stripe is the band itself: each row spans cin edges
+    ``col_start[k] .. col_start[k] + full_band`` (``full_band + 1`` edges), so the coefficient for
+    band offset ``b`` (cin bin ``col_start[k] + b``) is ``frac[b] - frac[b + 1]``. The
+    zero-dispersion limit is exact here too: ``D_t`` floors to ``_DT_FLOOR``, so ``C_F`` is a step
+    smoothed by ~1e-15.
 
     Returns
     -------
@@ -268,17 +269,11 @@ def _pv_band_values(
         + longitudinal_dispersivity * np.maximum(sw_hi + length, 0.0),
         _DT_FLOOR,
     )
-    i_lo, s_lo, g_lo = _breakthrough_antideriv(sw_lo, dt_lo)
-    i_hi, s_hi, g_hi = _breakthrough_antideriv(sw_hi, dt_hi)
+    i_lo = _breakthrough_antideriv(sw_lo, dt_lo)
+    i_hi = _breakthrough_antideriv(sw_hi, dt_hi)
     dx = sw_hi - sw_lo
     with np.errstate(divide="ignore", invalid="ignore"):
         frac = np.where(dx > 0.0, (i_hi - i_lo) / dx, 0.0)
-    if retardation_factor != 1.0 and molecular_diffusivity > 0.0:
-        density_binavg = _retardation_excess_density(
-            x_lo=sw_lo, x_hi=sw_hi, dx=dx, d_lo=dt_lo, d_hi=dt_hi, s_lo=s_lo, s_hi=s_hi, g_lo=g_lo, g_hi=g_hi
-        )
-        excess = np.where(velocity > 0.0, (retardation_factor - 1.0) * molecular_diffusivity / velocity, 0.0)
-        frac -= excess[:, None] * density_binavg
 
     return frac[:, :-1] - frac[:, 1:]
 
@@ -355,13 +350,6 @@ def _closed_form_coeff_matrix(
     )
     valid_cout_bins = ~np.any(np.isnan(rt_at_cout_tedges[:, :-1]) | np.isnan(rt_at_cout_tedges[:, 1:]), axis=0)
 
-    # Fluid (unretarded) velocity in each cout bin: q_cout * L / V_pore (V_pore folded in
-    # per streamtube below). q_cout = dV_cout / dt_cout.
-    dv_cout = np.diff(cumulative_volume_at_cout)
-    dt_cout = np.diff(cout_tedges_days)
-    with np.errstate(divide="ignore", invalid="ignore"):
-        q_cout = np.where(dt_cout > 0, dv_cout / dt_cout, 0.0)
-
     # Slowest cin-side flow rate, used to bound the broken-through band width (the slowest flow
     # gives the steepest dD_t/dx). Zero when flow is everywhere zero -> the band widens (capped
     # at n_cin_bins), and the resulting no-flow rows are masked invalid anyway.
@@ -398,7 +386,7 @@ def _closed_form_coeff_matrix(
         )
         np.minimum(union_lo, lo, out=union_lo)
         np.maximum(union_hi, hi, out=union_hi)
-        geometry.append((r_vpv, length, d_m, alpha_l, v_pore))
+        geometry.append((r_vpv, length, d_m, alpha_l))
 
     col_start = union_lo
     full_band = min(int(np.max(union_hi - union_lo)) + 1, n_cin_bins)
@@ -406,8 +394,7 @@ def _closed_form_coeff_matrix(
 
     # PASS 2 (values): each streamtube's C_F stripe is built on the shared band (col_start,
     # full_band), so its coeff is already offset-aligned and accumulates directly into the buffer.
-    for r_vpv, length, d_m, alpha_l, v_pore in geometry:
-        velocity = q_cout * length / v_pore
+    for r_vpv, length, d_m, alpha_l in geometry:
         band_vals += _pv_band_values(
             col_start=col_start,
             full_band=full_band,
@@ -419,8 +406,6 @@ def _closed_form_coeff_matrix(
             length=length,
             molecular_diffusivity=d_m,
             longitudinal_dispersivity=alpha_l,
-            retardation_factor=retardation_factor,
-            velocity=velocity,
         )
 
     band_vals /= len(aquifer_pore_volumes)

--- a/src/gwtransport/diffusion_fast_fast.py
+++ b/src/gwtransport/diffusion_fast_fast.py
@@ -171,7 +171,7 @@ def _summed_antideriv(
 
     x = (grid[None, :] - r_vpv[:, None]) * streamline_length[:, None] / r_vpv[:, None]
     dt_var = np.maximum(longitudinal_dispersivity[:, None] * np.maximum(x + streamline_length[:, None], 0.0), _DT_FLOOR)
-    antideriv, _, _ = _breakthrough_antideriv(x, dt_var)
+    antideriv = _breakthrough_antideriv(x, dt_var)
     ibar = ((r_vpv[:, None] / streamline_length[:, None]) * antideriv).mean(axis=0)
     return grid, ibar, mean_r_vpv, off_lo, off_hi
 

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -1607,6 +1607,43 @@ class TestFlowWeightedDiffusion:
         ratios = mass_out_per_cin[10:42] / v_in_interior
         np.testing.assert_allclose(ratios, 1.0, atol=1e-10, rtol=0)
 
+    @pytest.mark.parametrize("retardation_factor", [1.0, 2.7])
+    def test_mass_conservation_retardation_with_molecular_diffusion(self, retardation_factor):
+        """Flux-weighted mass ``∫Q·c_out dt = ∫Q·c_in dt`` holds under variable flow for R>1 AND D_m>0.
+
+        Regression for the Kreft-Zuber flux coefficient: it must use the solute-front velocity
+        ``v_s = Q·L/(R·V_pore)`` (so ``D_s/v_s = R·D_m/v_fluid + alpha_L``), not the fluid velocity.
+        With the fluid velocity the molecular term breaks conservation for R>1, D_m>0 by O((R-1)·D_m)
+        under variable flow (≈ -6e-4 at R=2.7, D_m=0.5); R=1 and D_m=0 are unaffected, which is why the
+        defect stayed hidden. Fails on the pre-fix code.
+        """
+        n = 120
+        tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+        rng = np.random.default_rng(7)
+        flow = 60.0 + 40.0 * rng.random(n)  # variable, strictly positive
+        cin = np.zeros(n)
+        cin[20:25] = 10.0  # compact pulse well inside the record
+        dt = np.diff(tedges) / pd.Timedelta("1D")
+
+        cout = infiltration_to_extraction(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([300.0]),
+            streamline_length=np.array([20.0]),
+            molecular_diffusivity=0.5,
+            longitudinal_dispersivity=0.0,
+            retardation_factor=retardation_factor,
+            spinup=None,
+        )
+        valid = ~np.isnan(cout)
+        # The output window must capture all breakthrough mass (no leakage at the right edge).
+        assert np.allclose(cout[valid][-3:], 0.0, atol=1e-6), "breakthrough not fully captured in window"
+        m_in = np.nansum(flow * cin * dt)
+        m_out = np.nansum(flow[valid] * cout[valid] * dt[valid])
+        np.testing.assert_allclose(m_out, m_in, rtol=1e-10)
+
     def test_constant_cin_varying_flow_gives_constant_cout(self):
         """Constant cin with varying flow must produce constant cout."""
         tedges = pd.date_range("2020-01-01", periods=61, freq="D")
@@ -1654,9 +1691,8 @@ class TestFlowWeightedDiffusion:
         cum_cin = np.array([0.0, 50.0, 130.0, 220.0, 330.0, 500.0])
         tedges_days = np.array([0.0, 0.5, 1.4, 2.3, 3.4, 5.0])  # variable Q
 
-        r_vpv = 200.0
+        r_vpv = 200.0  # = R * V_pore; R = 1 here (no retardation), so v_s == v_fluid
         sl = 50.0
-        v_pore = 200.0  # = r_vpv when R = 1 (no retardation in this test)
 
         # Several narrow cout cells: pre, around, and post breakthrough for j=0
         cum_cout = np.array([60.0, 130.0, 200.0, 260.0, 330.0, 420.0, 480.0])
@@ -1673,12 +1709,11 @@ class TestFlowWeightedDiffusion:
             longitudinal_dispersivity=alpha_l,
             r_vpv=r_vpv,
             streamline_len=sl,
-            aquifer_pore_volume=v_pore,
         )
 
-        # Fluid velocity per flow bin
+        # Solute-front velocity per flow bin (v_pore == r_vpv here, i.e. R = 1, so v_s == v_fluid)
         q_per_bin = np.diff(cum_cin) / np.diff(tedges_days)
-        v_per_bin = q_per_bin * sl / v_pore
+        v_per_bin = q_per_bin * sl / r_vpv
 
         def _make_integrand(v_j_, t_j_):
             def integrand(v):

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -10,7 +10,6 @@ from gwtransport._diffusion_shared import (
     _DT_FLOOR,
     _breakthrough_antideriv,
     _cout_cumulative_volume,
-    _retardation_excess_density,
 )
 from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport.advection import infiltration_to_extraction as advection_i2e
@@ -2405,8 +2404,10 @@ def _dense_closed_form_w(*, flow, tedges, cout_tedges, pv, length, d_m, alpha_l,
 
     Reference for the banded build -- it shares the antiderivative kernel and the volume/tau setup,
     so on the breakthrough band the two are computed from identical floating-point inputs (bit-exact
-    for R=1; the R != 1 erfcx retardation tail is far below machine epsilon). Outside the band the
-    closed form saturates to exactly 0 or 1 in the cin-edge difference, which the banded build drops.
+    for any regime). Outside the band the closed form saturates to exactly 0 or 1 in the cin-edge
+    difference, which the banded build drops. The antiderivative's slope ``dD_t/dx = D_s/v_s`` is the
+    Kreft-Zuber flux coefficient at the solute-front velocity, so differencing it gives ``C_F``
+    natively for R > 1 with D_m > 0 -- no explicit retardation correction term.
     """
     nb = len(pv)
     streamline_length = np.full(nb, length)
@@ -2429,10 +2430,6 @@ def _dense_closed_form_w(*, flow, tedges, cout_tedges, pv, length, d_m, alpha_l,
         cumulative_volume_at_cin=v_cin,
     )
     tau = np.maximum(cout_tedges_days[:, None] - tedges_days[None, :], 0.0)
-    dv_cout = np.diff(v_cout)
-    dt_cout = np.diff(cout_tedges_days)
-    with np.errstate(divide="ignore", invalid="ignore"):
-        q_cout = np.where(dt_cout > 0, dv_cout / dt_cout, 0.0)
 
     n_cout = len(cout_tedges) - 1
     n_cin = len(flow)
@@ -2442,7 +2439,6 @@ def _dense_closed_form_w(*, flow, tedges, cout_tedges, pv, length, d_m, alpha_l,
         ell = float(streamline_length[i_pv])
         dm = float(molecular_diffusivity[i_pv])
         al = float(longitudinal_dispersivity[i_pv])
-        velocity = q_cout * ell / v_pore
         step_widths = (v_cout[:, None] - v_cin[None, :] - r_vpv) * ell / r_vpv
         x_lo, x_hi = step_widths[:-1], step_widths[1:]
         dx = x_hi - x_lo
@@ -2453,36 +2449,21 @@ def _dense_closed_form_w(*, flow, tedges, cout_tedges, pv, length, d_m, alpha_l,
         else:
             xi = step_widths + ell
             dt_var = np.maximum(dm * tau + al * np.maximum(xi, 0.0), _DT_FLOOR)
-            antideriv, s, gaussian = _breakthrough_antideriv(step_widths, dt_var)
+            antideriv = _breakthrough_antideriv(step_widths, dt_var)
             with np.errstate(divide="ignore", invalid="ignore"):
                 frac = np.where(dx > 0.0, np.diff(antideriv, axis=0) / dx, 0.0)
-            if retardation != 1.0 and dm > 0.0:
-                density_binavg = _retardation_excess_density(
-                    x_lo=x_lo,
-                    x_hi=x_hi,
-                    dx=dx,
-                    d_lo=dt_var[:-1],
-                    d_hi=dt_var[1:],
-                    s_lo=s[:-1],
-                    s_hi=s[1:],
-                    g_lo=gaussian[:-1],
-                    g_hi=gaussian[1:],
-                )
-                excess = np.where(velocity > 0.0, (retardation - 1.0) * dm / velocity, 0.0)
-                frac -= excess[:, None] * density_binavg
         acc += frac[:, :-1] - frac[:, 1:]
     return np.nan_to_num(acc / len(pv), nan=0.0)
 
 
-def _assert_banded_matches_dense(w_banded, w_dense, retardation):
-    """R=1 is bit-identical; R!=1 carries an erfcx retardation-correction tail far below eps."""
-    if retardation == 1.0:
-        np.testing.assert_array_equal(w_banded, w_dense)
-    else:
-        # R != 1: the closed-form retardation correction's erfcx tail is not bitwise zero, but is
-        # far below machine epsilon. atol=1e-20 keeps margin while still catching any genuinely
-        # dropped coefficient (an under-sized band drops O(1e-2..1e-4)).
-        np.testing.assert_allclose(w_banded, w_dense, atol=1e-20, rtol=0.0)
+def _assert_banded_matches_dense(w_banded, w_dense, retardation):  # noqa: ARG001
+    """Banded build is bit-identical to the dense reference in every regime.
+
+    The flux concentration emerges natively from the antiderivative's ``D_s/v_s`` slope, so the
+    banded and dense paths compute the same ``frac`` from identical inputs for any R (no separate
+    retardation-correction term that could diverge in the last ulps).
+    """
+    np.testing.assert_array_equal(w_banded, w_dense)
 
 
 @pytest.mark.parametrize(
@@ -2579,8 +2560,8 @@ def test_banded_variable_flow_wandering_center():
 def test_banded_multipv_union_of_bands(retardation):
     """Each streamtube's band sits at a different cin offset; the accumulated band is their union.
 
-    The R != 1 case also guards the per-tube ``np.add.at`` accumulation of retardation-corrected
-    bands into the union buffer -- a per-tube offset error would corrupt the overlap.
+    The R != 1 case also guards the per-tube accumulation of the (natively flux-corrected) bands
+    into the union buffer -- a per-tube offset error would corrupt the overlap.
     """
     n = 120
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
@@ -2665,7 +2646,7 @@ def test_banded_variable_flow_step_equals_dense(d_m, pv, length, flow_lo, flow_h
 
 
 def test_banded_retardation_matches_diffusion_exact():
-    """Banded R != 1 build (with the erfcx retardation correction) matches the independent
+    """Banded R != 1 build (native solute-front flux coefficient) matches the independent
     ``gwtransport.diffusion`` quadrature -- an anchor that does not share the closed-form code.
 
     Geometry (pv=200, L=60) keeps the band narrow enough that banding engages rather than falling
@@ -2803,8 +2784,8 @@ def test_banded_band_sizing_misaligned_subbin_multipv(retardation):
 
     The cout grid is finer than -- and offset from -- the variable-flow cin grid, so each cout bin
     straddles cin bins and the per-row band must track a non-integer front across multiple
-    streamtubes. R=1 is bit-identical to the full-width dense closed form; the R=2 erfcx retardation
-    tail sits far below machine epsilon (atol 1e-20). An under-sized band would drop O(1e-2..1e-4).
+    streamtubes. Bit-identical to the full-width dense closed form for any R (the flux coefficient
+    emerges natively). An under-sized band would drop O(1e-2..1e-4).
     """
     n = 120
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
@@ -2824,10 +2805,7 @@ def test_banded_band_sizing_misaligned_subbin_multipv(retardation):
     }
     w_banded = _banded_dense(**common, flow_out=flow_out)
     w_dense = _dense_closed_form_w(**common, flow_out=flow_out)
-    if retardation == 1.0:
-        np.testing.assert_array_equal(w_banded, w_dense)
-    else:
-        np.testing.assert_allclose(w_banded, w_dense, atol=1e-20, rtol=0.0)
+    np.testing.assert_array_equal(w_banded, w_dense)
 
 
 def test_leading_zero_flow_forward_matches_diffusion_exact():


### PR DESCRIPTION
## Summary

**Confirmed physics bug — Kreft-Zuber flux mass conservation under retardation + molecular diffusion.** From the package-wide review; physics-derived and numerically verified.

`gwtransport.diffusion` (and the fast modules that match it to 1e-13) violated the documented invariant `∫Q·c_out dt = ∫Q·c_in dt` whenever `retardation_factor > 1` **and** `molecular_diffusivity > 0` under variable flow — by `O((R-1)·D_m)` (≈ −6e-4 at R=2.7, D_m=0.5; this is the core variable-flow heat-transport regime). `R=1` and `D_m=0` were exact, which hid the defect (constant-flow runs also cancel it, so existing tests never fired).

**Root cause (derived from the retarded ADE + Kreft & Zuber 1978).** The K-Z resident→flux transform `C_F = C_R − (D_s/v_s)·∂C_R/∂x` must use the **solute-front velocity** `v_s = Q·L/(R·V_pore)` — the advection speed of the retarded ADE that the resident profile `C_R` (variance `D_t = D_m·τ + α_L·ξ`, front `ξ = L(V−V_j)/(R·V_pore)`) actually solves. The code used the **fluid** velocity `Q·L/V_pore`, a hybrid that is the flux solution of no ADE. The correct coefficient is `D_s/v_s = D_m/v_s + α_L = R·D_m/v_fluid + α_L`.

**Fix.**
- `diffusion._cfrac_mean_volume`: divide by `r_vpv` (= R·V_pore) instead of `aquifer_pore_volume` (now removed as unused); docstring math updated to `v_s`/`D_s`.
- `diffusion_fast` + `_diffusion_shared`: the closed-form antiderivative already carries the correct coefficient natively, so the `_retardation_excess_density` subtraction (added to reproduce the old buggy coefficient) and all resulting dead code are deleted.
- `diffusion_fast_fast`: adapted to `_breakthrough_antideriv`'s single-value return (no physics change).
- New regression test asserts the conservation invariant for variable flow at R>1 ∧ D_m>0 (fails on baseline).

**Verification.** Mass conservation residual **8e-16** (R=2.7,D_m=0.5, variable flow, truncation-free window); dense↔fast equivalence **3.9e-14** (R=2.7,D_m=0.5) — the mirror is faithful; R=1 and D_m=0 outputs unchanged; **326 diffusion tests pass**; ty + ruff clean. Root cause proven to ratio 1.000000 vs an independent quadrature oracle; cross-checked against Kreft & Zuber (1978).

> The `latest dependencies` CI job will fail on `test_examples` (pandas-3.x `Mixed timezones`) until #259 is merged — that is the separate, pre-existing pandas-compat fix, unrelated to this change.

## Test plan

- `pytest tests/src/test_diffusion.py tests/src/test_diffusion_fast.py tests/src/test_diffusion_fast_fast.py` — 326 passed.
- `ty check` + `ruff` — clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
