### PR TITLE
fix(ci): clean Sphinx doc build + set test_b6 plateau tolerance to achieved precision

### DIFF
--- a/docs/source/examples/11_Percolation_Unsaturated_Zone.nblink
+++ b/docs/source/examples/11_Percolation_Unsaturated_Zone.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../examples/11_Percolation_Unsaturated_Zone.ipynb"
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -124,6 +124,7 @@ For an in-depth discussion of the core modeling approach, see :doc:`user_guide/c
    examples/04_Deposition_Analysis_Bank_Filtration.nblink
    examples/08_bank_filtration_timflow.nblink
    examples/10_Advection_with_non_linear_sorption.nblink
+   examples/11_Percolation_Unsaturated_Zone.nblink
    examples/12_Bank_Filtration_Rainwater_Fraction.nblink
 
 .. toctree::

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -167,11 +167,11 @@ def compute_deposition_weights(
     bounded by ``R * aquifer_pore_volume`` in volume (independent of record
     length ``n_cin``). The window is located by :func:`numpy.searchsorted` on the
     cumulative flow volume ``flow_cum``; the per-cell math reuses
-    :func:`~gwtransport.deposition_utils._clipped_linear_integral` restricted to
+    ``gwtransport.deposition_utils._clipped_linear_integral`` restricted to
     the band columns, so each row sums to
     ``r_k = residence_time_k / (porosity * thickness)``. Reconstruct the dense
     ``(n_cout, n_cin)`` matrix with
-    :func:`~gwtransport.advection_utils._densify_weights` when a dense operator
+    ``gwtransport.advection_utils._densify_weights`` when a dense operator
     is required (the nullspace inverse).
 
     Parameters
@@ -211,7 +211,7 @@ def compute_deposition_weights(
 
     See Also
     --------
-    gwtransport.advection_utils._densify_weights : Reconstruct the dense matrix.
+    ``gwtransport.advection_utils._densify_weights`` : Reconstruct the dense matrix.
     """
     t0 = tedges[0]
     tedges_days = tedges_to_days(tedges, ref=t0)

--- a/src/gwtransport/deposition_utils.py
+++ b/src/gwtransport/deposition_utils.py
@@ -1,8 +1,8 @@
 """
 Utility Functions for the Deposition Module.
 
-This module provides the clipped-trapezoid integral helpers (:func:`_clipped_linear_integral`
-and :func:`_positive_part_integral`) used by the deposition module's banded weight builder to
+This module provides the clipped-trapezoid integral helpers (``_clipped_linear_integral``
+and ``_positive_part_integral``) used by the deposition module's banded weight builder to
 integrate ``clip(y(x), y_lower, y_upper)`` over each cin bin of a streamtube's residence window.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Analytical solutions for 1D advection-dispersion transport.
 
 This module implements analytical solutions for solute transport in 1D aquifer
@@ -38,7 +38,7 @@ Reported outlet concentration: Kreft-Zuber (1978) flux concentration
 
 The outlet concentration reported by this module is the **flux concentration**
 
-    C_F(L, t) = C_R(L, t) - (D_s / v_s) * dC_R/dx |_{x=L}
+    C_F(L, t) = C_R(L, t) - (D_s / v_s) * dC_R/dx \|_{x=L}
 
 with the solute-front (retarded-frame) velocity v_s = Q L / (R V_pore) and the
 dispersion D_s = D_m + alpha_L * v_s, so the flux coefficient is
@@ -742,6 +742,7 @@ def infiltration_to_extraction(
     The algorithm constructs a coefficient matrix W where cout = W @ cin:
 
     1. For each pore volume, build a cell grid in cumulative volume space:
+
        - cells span ``(V_cout[i], V_cout[i+1]) x V_cin[j]`` for each
          (cout-bin i, cin-edge j)
        - delta_volume = V_cout - V_cin - r_vpv encodes the parcel's offset

--- a/src/gwtransport/diffusion_fast_fast.py
+++ b/src/gwtransport/diffusion_fast_fast.py
@@ -418,14 +418,14 @@ def _banded_forward_matrix(
     n_cin: int,
     sigma_bins: float,
 ) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.intp]]:
-    """Assemble ``W = G . M`` as a per-row contiguous band for :func:`_solve_reverse_banded`.
+    """Assemble ``W = G . M`` as a per-row contiguous band for ``_solve_reverse_banded``.
 
     ``M`` (advection + macro + microdispersion) is scattered from the native band onto the real cin
     axis, folding the warm-start virtual columns into the boundary bins
     (``clip(cin_bin - int(extend), 0, n_cin - 1)``, so ``M @ cin`` equals the forward's
     ``coeff @ cin_ext`` exactly). ``G`` is the molecular time-Gaussian along the output-bin axis (the
     same ``mode="nearest"`` kernel the forward applies with :func:`scipy.ndimage.gaussian_filter1d`).
-    The returned band carries the forward operator verbatim; :func:`_solve_reverse_banded` masks the
+    The returned band carries the forward operator verbatim; ``_solve_reverse_banded`` masks the
     spin-up rows/columns and normalizes, so a forward-then-inverse round trip is self-consistent.
 
     Returns
@@ -619,7 +619,7 @@ def extraction_to_infiltration(
 
     Inverts the **same** approximate operator the forward applies: it assembles ``W = G . M`` (the
     advection+macro+micro band ``M`` times the molecular time-Gaussian ``G``) directly in banded form
-    and deconvolves it with banded Tikhonov regularization (:func:`_solve_reverse_banded` -- banded
+    and deconvolves it with banded Tikhonov regularization (``_solve_reverse_banded`` -- banded
     Cholesky on the normal equations, ``O(n * band**2)``). It builds ``W`` from one ``Ibar`` gather
     plus a sparse ``G . M`` product -- no per-pore-volume closed-form loop and no dense
     ``(n_cout, n_cin)`` matrix -- so it is much faster than

--- a/src/gwtransport/examples.py
+++ b/src/gwtransport/examples.py
@@ -417,9 +417,6 @@ def generate_temperature_example_data(
     streamline_length : float, default 100.0
         Travel distance along the streamline [m].
 
-    All other parameters are forwarded unchanged to :func:`generate_example_data`;
-    see that function for their descriptions.
-
     Returns
     -------
     tuple
@@ -429,6 +426,11 @@ def generate_temperature_example_data(
     --------
     generate_example_data : Generic version with full parameter control.
     generate_ec_example_data : Wrapper with EC transport defaults.
+
+    Notes
+    -----
+    All other parameters are forwarded unchanged to :func:`generate_example_data`;
+    see that function for their descriptions.
     """
     return generate_example_data(
         date_start=date_start,
@@ -518,9 +520,6 @@ def generate_ec_example_data(
     streamline_length : float, default 100.0
         Travel distance along the streamline [m].
 
-    All other parameters are forwarded unchanged to :func:`generate_example_data`;
-    see that function for their descriptions.
-
     Returns
     -------
     tuple
@@ -530,6 +529,11 @@ def generate_ec_example_data(
     --------
     generate_example_data : Generic version with full parameter control.
     generate_temperature_example_data : Wrapper with thermal transport defaults.
+
+    Notes
+    -----
+    All other parameters are forwarded unchanged to :func:`generate_example_data`;
+    see that function for their descriptions.
     """
     return generate_example_data(
         date_start=date_start,

--- a/src/gwtransport/fronttracking/math.py
+++ b/src/gwtransport/fronttracking/math.py
@@ -2,6 +2,7 @@
 Mathematical Foundation for Front Tracking with Nonlinear Sorption.
 
 This module provides exact analytical computations for:
+
 - Freundlich, Langmuir, and constant retardation models
 - Brooks-Corey and van Genuchten-Mualem unsaturated conductivity models
   (for Kinematic-Wave percolation, see :mod:`gwtransport.percolation`)
@@ -257,10 +258,12 @@ class FreundlichSorption(NonlinearSorption):
         Compute retardation factor R(C).
 
         The retardation factor relates concentration speed to pore water speed in
-        (V, θ) coordinates:
+        (V, θ) coordinates::
+
             dV/dθ = 1 / R(C)
 
-        For Freundlich sorption:
+        For Freundlich sorption::
+
             R(C) = 1 + (rho_b*k_f)/(n_por*n) * C^((1/n)-1)
 
         Parameters
@@ -1202,7 +1205,7 @@ def compute_first_front_arrival_theta(
 
        For ``n<1`` with ``c_min > 0`` (default ``c_min = 1e-12`` in
        :class:`FreundlichSorption`), the actual wave emitted is a
-       :class:`RarefactionWave` whose head (``c = c_min ≈ 0``) reaches the
+       :class:`~gwtransport.fronttracking.waves.RarefactionWave` whose head (``c = c_min ≈ 0``) reaches the
        outlet at θ ≈ ``V·R(c_min) ≈ V`` — *much* earlier than the value this
        function returns (which is the *tail* arrival ``V·R(c_first)``).
        The function returns "tail arrival" semantics: the returned θ is a

--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -6,13 +6,15 @@ translate user-facing time t → θ at the API boundary via
 
 Functions
 ---------
-concentration_at_point(v, theta, waves, sorption)
-compute_breakthrough_curve(theta_array, v_outlet, waves, sorption)
-compute_bin_averaged_concentration_exact(theta_bin_edges, v_outlet, waves, sorption, *, cin=None, theta_edges_inlet=None)
-compute_domain_mass(theta, v_outlet, waves, sorption)
-compute_cumulative_inlet_mass(theta, cin, theta_edges)
-compute_cumulative_outlet_mass(theta, v_outlet, waves, sorption, *, cin, theta_edges)
-compute_total_outlet_mass(v_outlet, sorption, *, cin, theta_edges) -> float
+::
+
+    concentration_at_point(v, theta, waves, sorption)
+    compute_breakthrough_curve(theta_array, v_outlet, waves, sorption)
+    compute_bin_averaged_concentration_exact(theta_bin_edges, v_outlet, waves, sorption, *, cin=None, theta_edges_inlet=None)
+    compute_domain_mass(theta, v_outlet, waves, sorption)
+    compute_cumulative_inlet_mass(theta, cin, theta_edges)
+    compute_cumulative_outlet_mass(theta, v_outlet, waves, sorption, *, cin, theta_edges)
+    compute_total_outlet_mass(v_outlet, sorption, *, cin, theta_edges) -> float
 
 Outlet-mass functions use the PDE conservation identity
 ``m_out(θ) = m_in(θ) − m_dom(θ)`` (Bear & Cheng 2010, Ch. 3: mass
@@ -305,7 +307,7 @@ def identify_outlet_segments(
             Segment end θ [m³]
         - 'type' : str
             ``'constant'``, ``'rarefaction'``, or ``'decaying_fan'``.
-            ``'decaying_fan'`` is owned by a :class:`DecayingShockWave` after
+            ``'decaying_fan'`` is owned by a :class:`~gwtransport.fronttracking.waves.DecayingShockWave` after
             its head crosses ``v_outlet``; c at ``v_outlet`` then follows the
             wave's self-similar fan profile.
         - 'concentration' : float
@@ -632,8 +634,8 @@ def integrate_fan_exact(
     """Exact θ-integral ``∫ c(θ) dθ`` for any self-similar fan at the outlet.
 
     Decoupled from the wave object so the same closed-form math applies to
-    both :class:`RarefactionWave` (apex = ``theta_start, v_start``) and
-    :class:`DecayingShockWave` (apex = ``theta_origin, v_origin``).
+    both :class:`~gwtransport.fronttracking.waves.RarefactionWave` (apex = ``theta_start, v_start``) and
+    :class:`~gwtransport.fronttracking.waves.DecayingShockWave` (apex = ``theta_origin, v_origin``).
 
     Parameters
     ----------
@@ -1115,8 +1117,8 @@ def integrate_fan_spatial_exact(
     """Exact spatial integral ``∫ C_total(v, θ) dv`` for any self-similar fan.
 
     Decoupled from the wave object so the same closed-form math applies to
-    :class:`RarefactionWave` (apex = ``theta_start, v_start``) and
-    :class:`DecayingShockWave` (apex = ``theta_origin, v_origin``).
+    :class:`~gwtransport.fronttracking.waves.RarefactionWave` (apex = ``theta_start, v_start``) and
+    :class:`~gwtransport.fronttracking.waves.DecayingShockWave` (apex = ``theta_origin, v_origin``).
 
     In (V, θ) the self-similar fan satisfies ``R(C) = (θ - θ_origin)/(v - v_origin)``;
     define ``kappa = θ - θ_origin`` and ``u = v - v_origin``. The dissolved and

--- a/src/gwtransport/fronttracking/waves.py
+++ b/src/gwtransport/fronttracking/waves.py
@@ -522,20 +522,20 @@ class DecayingShockWave(Wave):
     ``α := ρ_b · k_f / n_por`` for Freundlich, and ``u_d := c_decay^(1/n)``:
 
     - Freundlich, ``c_fixed = 0`` (general ``n > 0``, ``n ≠ 1``) — closed form:
-        invariant ``θ_local · u_d^n = K · (n · u_d^(n-1) + α)``,
-        position ``V_s(θ) = v_origin + n · K / u_d(θ)``.
+      invariant ``θ_local · u_d^n = K · (n · u_d^(n-1) + α)``,
+      position ``V_s(θ) = v_origin + n · K / u_d(θ)``.
     - Freundlich, ``c_fixed > 0``, ``n = 2`` and ``c_decay_initial > c_fixed``
       — closed form: invariant ``(u_d - u_R)² · θ_local = K · (2 u_d + α)``
-        with ``u_R := c_fixed^(1/2)``,
-        position ``V_s(θ) = v_origin + 2 K · u_d(θ) / (u_d - u_R)²``.
-        (The ``c_decay_initial < c_fixed`` mirror falls through to numerical.)
+      with ``u_R := c_fixed^(1/2)``,
+      position ``V_s(θ) = v_origin + 2 K · u_d(θ) / (u_d - u_R)²``.
+      (The ``c_decay_initial < c_fixed`` mirror falls through to numerical.)
     - Langmuir, ``c_fixed = 0`` — closed form:
-        invariant ``θ_local · c_d² = K · ((K_L + c_d)² + a)`` with
-        ``a := ρ_b · s_max · K_L / n_por``,
-        position ``V_s(θ) = v_origin + K · (K_L + c_d)² / c_d²``.
+      invariant ``θ_local · c_d² = K · ((K_L + c_d)² + a)`` with
+      ``a := ρ_b · s_max · K_L / n_por``,
+      position ``V_s(θ) = v_origin + K · (K_L + c_d)² / c_d²``.
     - Brooks-Corey, ``c_fixed = 0`` — closed form:
-        invariant ``θ_local ∝ R(c_decay)^{a/(a−1)}`` (``R·S = 1/a`` constant),
-        so ``R(c_d) = R(c0)·(θ_local/θ_local_coll)^{(a−1)/a}``.
+      invariant ``θ_local ∝ R(c_decay)^{a/(a−1)}`` (``R·S = 1/a`` constant),
+      so ``R(c_d) = R(c0)·(θ_local/θ_local_coll)^{(a−1)/a}``.
     - Every other ``(isotherm, c_fixed)`` combination (Freundlich ``c_fixed>0,
       n≠2``, Langmuir/Brooks-Corey ``c_fixed>0``, any van Genuchten) —
       numerical solver ``_c_decay_numerical``: the decay-agnostic invariant
@@ -582,13 +582,6 @@ class DecayingShockWave(Wave):
     is_active : bool, optional
         Activity flag. Default True.
 
-    Attributes
-    ----------
-    K : float
-        Invariant constant set in ``__post_init__`` (closed-form Freundlich
-        ``c_fixed=0``/``n≈2`` and Langmuir ``c_fixed=0`` cases; ``nan`` for
-        every numerical case).
-
     See Also
     --------
     ShockWave : Linear-θ shock (no decaying side).
@@ -610,7 +603,8 @@ class DecayingShockWave(Wave):
     sorption: NonlinearSorption
     """Sorption model (any concentration-dependent isotherm)."""
     K: float = field(init=False)
-    """Invariant constant from collision IC; set in ``__post_init__``."""
+    """Invariant constant set in ``__post_init__`` (closed-form Freundlich ``c_fixed=0``/``n≈2`` and Langmuir
+    ``c_fixed=0`` cases; ``nan`` for every numerical case)."""
 
     def __post_init__(self) -> None:
         """Validate inputs and compute the closed-form invariant K when applicable."""

--- a/src/gwtransport/percolation.py
+++ b/src/gwtransport/percolation.py
@@ -25,14 +25,8 @@ water-table depth ``z_wt``, the conversion is ``V_out = θ_s · z_wt``.
 The docstring of :func:`root_zone_to_water_table_kinematic_wave`
 spells out the recovery rule and the layered-porosity generalisation.
 
-References
-----------
-.. [1] Olsthoorn, T.N. (2026). Percolation through thick unsaturated
-   zones — Munsflow vs. the Kinematic Wave. *Stromingen* 32(1).
-.. [2] Heinen, M., Bakker, G., Wösten, J.M.H. (2020). Waterretentie en
-   Doorlatendheidskarakteristieken van boven- en ondergronden in
-   Nederland: de Staringreeks. Update 2018. Wageningen Environmental
-   Research, Report 2978.
+The full Kinematic-Wave derivation and the constitutive-curve references
+are documented on :func:`root_zone_to_water_table_kinematic_wave`.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
@@ -77,11 +71,11 @@ def root_zone_to_water_table_kinematic_wave(
 
     exactly via :class:`gwtransport.fronttracking.solver.FrontTracker`,
     using either a Brooks-Corey or a van Genuchten-Mualem constitutive
-    curve. Implements the Kinematic-Wave method described in
-    Olsthoorn (2026). The capillary term ``∂ψ/∂z`` is dropped (gravity
-    drainage only); real fronts are slightly smoothed by capillarity, so
-    if smoothing matters use the Munsflow-style approach in
-    :mod:`gwtransport.diffusion` instead.
+    curve. Implements the Kinematic-Wave method (see [3]_ for the general
+    theory) described in Olsthoorn (2026) [1]_. The capillary term
+    ``∂ψ/∂z`` is dropped (gravity drainage only); real fronts are slightly
+    smoothed by capillarity, so if smoothing matters use the Munsflow-style
+    approach in :mod:`gwtransport.diffusion` instead.
 
     Parameters
     ----------
@@ -107,7 +101,7 @@ def root_zone_to_water_table_kinematic_wave(
         layered porosity, ``∫₀^{z_wt} n_p(z') dz'``. The geometric depth
         is recovered as ``z_wt = V_out / θ_s`` (uniform case). Array-like
         to support a distribution of column lengths in parallel
-        (analogous to :func:`gamma_infiltration_to_extraction`); each
+        (analogous to :func:`gwtransport.advection.gamma_infiltration_to_extraction`); each
         entry must be positive.
     theta_r : float
         Residual volumetric moisture content [-]. Must satisfy
@@ -120,6 +114,7 @@ def root_zone_to_water_table_kinematic_wave(
     brooks_corey_lambda : float or None, optional
         Brooks-Corey pore-size distribution index [-]. Set to use the
         Brooks-Corey branch. Mutually exclusive with ``van_genuchten_n``.
+        Tabulated soil values are available in the Staringreeks [2]_.
     van_genuchten_n : float or None, optional
         Van Genuchten shape parameter ``n_vG > 1``. Set to use the
         van Genuchten-Mualem branch (numerical inversion via brentq).
@@ -164,7 +159,7 @@ def root_zone_to_water_table_kinematic_wave(
           ``n_characteristics`` — counts.
         - ``theta_current`` — final cumulative effective time.
         - ``sorption`` — the sorption object.
-        - ``tracker_state`` — complete :class:`FrontTrackerState` for the
+        - ``tracker_state`` — complete :class:`~gwtransport.fronttracking.solver.FrontTrackerState` for the
           column (use ``state.t_at_theta`` to translate ``θ → t``).
         - ``cumulative_pore_volume_outlet`` — the V_out for this column.
 

--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -1078,10 +1078,12 @@ def freundlich_retardation(
     The Freundlich isotherm relates sorbed concentration s to aqueous concentration C using the
     heterogeneity-index convention (matching :class:`gwtransport.fronttracking.math.FreundlichSorption`
     and :func:`gwtransport.advection.infiltration_to_extraction_nonlinear_sorption`, so a fitted
-    ``freundlich_n`` is portable across the package):
-        s = k_f * C^(1/n)
+    ``freundlich_n`` is portable across the package)::
 
-    The retardation factor is computed as:
+        s = k_f * C ^ (1 / n)
+
+    The retardation factor is computed as::
+
         R = 1 + (rho_b/θ) * ds/dC = 1 + (rho_b/θ) * k_f * (1/n) * C^(1/n - 1)
 
     Parameters

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -225,7 +225,7 @@ def cumulative_flow_volume(
         Bin widths in days, length n (e.g. ``numpy.diff`` of edge days).
     strictly_monotone : bool, optional
         When ``True``, bump consecutive duplicates (plateaus from ``Q = 0``
-        bins) via :func:`_make_strictly_monotone` so the cumulative volume is
+        bins) via ``_make_strictly_monotone`` so the cumulative volume is
         strictly increasing. Required before a V → t inversion; leave ``False``
         when the plateaus must be preserved. Default is ``False``.
 
@@ -237,7 +237,7 @@ def cumulative_flow_volume(
 
     See Also
     --------
-    _make_strictly_monotone : Bump duplicates before V → t inversion.
+    ``_make_strictly_monotone`` : Bump duplicates before V → t inversion.
     """
     flow_cum = np.concatenate(([0.0], np.cumsum(np.asarray(flow) * np.asarray(dt_days))))
     return _make_strictly_monotone(flow_cum) if strictly_monotone else flow_cum
@@ -1752,7 +1752,7 @@ def solve_inverse_transport_banded(
     ----------
     band_vals : ndarray
         Banded forward weights of shape ``(n_obs, full_band)``. Rows the caller
-        considers invalid must already be zeroed (as :func:`_resolve_spinup_mask`
+        considers invalid must already be zeroed (as ``_resolve_spinup_mask``
         does); zero rows contribute nothing to the normal equations.
     col_start : ndarray of int
         First output-column index of each row's band, shape ``(n_obs,)``.
@@ -1782,7 +1782,7 @@ def solve_inverse_transport_banded(
     See Also
     --------
     solve_inverse_transport : Dense-matrix equivalent.
-    gwtransport.advection_utils._infiltration_to_extraction_weights : Banded builder.
+    ``gwtransport.advection_utils._infiltration_to_extraction_weights`` : Banded builder.
     """
     if regularization_strength <= 0:
         msg = "regularization_strength must be > 0 for the banded inverse (Tikhonov positive-definiteness)"

--- a/tests/src/test_percolation.py
+++ b/tests/src/test_percolation.py
@@ -428,7 +428,11 @@ class TestEndToEnd:
         assert partial.size == 1, f"expected exactly one partial bin in a clean 0→q0 step, got {partial.size}"
         k = int(partial[0])
         np.testing.assert_array_equal(q_wt[:k], np.zeros(k))
-        np.testing.assert_allclose(q_wt[k + 1 :], q0, rtol=1e-13)
+        # Plateau is cancellation-limited: the conservation-form bin average c=(m_in-m_dom)/Δθ amplifies
+        # ULP(m_in) by 1/(Δθ·q0) to an achieved floor ≈8e-14 that scatters cross-platform (BLAS/FMA) to
+        # ~1.2e-13. 1e-12 sits ~10x above the floor, matches the vG twin B7 below and the kernel's own
+        # 1e-12 clamp, and still fails a 1e-12 plateau bias (mutation-verified).
+        np.testing.assert_allclose(q_wt[k + 1 :], q0, rtol=1e-12)
 
     def test_b7_constant_flux_pure_shock_known_answer_vg(self):
         """B7 (vG): constant-flux pure-shock arrival for van Genuchten, own hardcoded literal.


### PR DESCRIPTION
## Summary

Fixes the two CI failures on `main` after the review-PR merge train:

**Documentation build** (`Build and Deploy Documentation` went red at #261 and stayed red): the review's docstring edits introduced docutils RST parse errors and unresolved cross-references. Fixed so the HTML build is **0 warnings / 0 errors**:
- `Unexpected indentation` / `Block quote` errors — list/equation blocks that lost a preceding blank line or had inconsistent indent (diffusion.py, fronttracking/math.py + waves.py, residence_time.py, examples.py); converted `:`-terminated equations to `::` literal blocks and fixed indents.
- diffusion.py:40 stray `|` (substitution_reference) — escaped + raw docstring.
- `:func:`/`:obj:` references to private (non-autodoc'd) functions (`_densify_weights`, `_solve_reverse_banded`, `_clipped_linear_integral`, `_positive_part_integral`, `_make_strictly_monotone`, …) — converted to inline literals; unqualified `:class:`/`:func:` targets fully-qualified.
- percolation footnote `[3]` unreferenced + duplicate `[1]`/`[2]` targets — cited inline, removed the redundant module-level References block.
- wired the existing `11_Percolation_Unsaturated_Zone` notebook into the docs toctree (`.nblink` + index).

**`test_percolation.py::test_b6` plateau tolerance** (CI Linux 3.12 + 3.14): `rtol=1e-13 → 1e-12`. The conservation-form bin average `c=(m_in−m_dom)/Δθ` amplifies `ULP(m_in)` by `1/(Δθ·q0)` to an achieved cancellation floor ≈8e-14 that scatters cross-platform (BLAS/FMA) to ~1.2e-13 — so 1e-13 passed on macOS but not CI Linux. 1e-12 is **set-to-achieved** (~10× the floor); it matches the identical vG twin B7 and the kernel's own `1e-12` clamp, and a 1e-12 plateau bias is still caught (mutation-verified). Not a last-bin bug (on macOS the worst-deviating plateau bin is interior).

Docstring-only + one test tolerance; **no code behaviour changed**.

## Test plan

- `sphinx-build -b html` → **build succeeded, 0 warnings, 0 errors**.
- `pytest tests/src tests/docs -n auto` → **1669 passed, 2 skipped**.
- `ruff` + CI-exact `ty check .` → clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
