### PR TITLE
docs(ci): linkcheck_ignore the coverage badge + htmlcov self-links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -170,3 +170,13 @@ ogp_type = "website"
 ogp_custom_meta_tags = [
     '<meta name="keywords" content="groundwater, transport, solutes, temperature, residence times, pathogen removal, timeseries analysis">',
 ]
+
+# -- Options for linkcheck --------------------------------------------------
+# The coverage badge and HTML coverage report are build artifacts published to the site by the
+# coverage-deploy step; they exist only after a successful deploy, so a pre-deploy linkcheck (or a
+# run whose coverage deploy lagged behind a red test run) sees a 404. They are self-referential
+# build outputs, not stable external URLs to validate, so exclude them from linkcheck.
+linkcheck_ignore = [
+    r"https://gwtransport\.github\.io/gwtransport/coverage-badge\.svg",
+    r"https://gwtransport\.github\.io/gwtransport/htmlcov/?",
+]


### PR DESCRIPTION
## Summary
The `check-documentation-links` job 404s on the coverage badge (`coverage-badge.svg`) and `htmlcov/` self-links in `index.rst` — deploy-time coverage artifacts that only exist after a successful coverage deploy (a red test run left them stale). They are self-referential build outputs, not stable external URLs, so they are added to `linkcheck_ignore`. Other doc self-links (e.g. `concepts.html`) stay checked.

## Test plan
- HTML build: succeeded, 0 warnings/errors.
- Regex verified to match exactly the two 404 URLs and not other gwtransport.github.io doc links.

## Contributor License Agreement
- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.