### PR TITLE
fix(ci): exclude coverage badge + htmlcov from the lychee README link check

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -69,7 +69,9 @@ jobs:
       - name: Check links in README.md, pyproject.toml, and FUNDING.yml
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress README.md pyproject.toml .github/FUNDING.yml
+          # Exclude the coverage badge + htmlcov report: deploy-time artifacts that 404 until the
+          # coverage deploy publishes them (also listed in .lycheeignore for local runs).
+          args: --verbose --no-progress --exclude 'gwtransport\.github\.io/gwtransport/(coverage-badge\.svg|htmlcov)' README.md pyproject.toml .github/FUNDING.yml
 
   deploy-documentation:
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,0 +1,5 @@
+# Coverage badge + HTML coverage report: build artifacts published to the site by the coverage
+# deploy step. They exist only after a successful deploy, so a run whose coverage deploy lagged
+# (e.g. behind a red test run) sees a 404. Self-referential build outputs, not stable URLs.
+https://gwtransport\.github\.io/gwtransport/coverage-badge\.svg
+https://gwtransport\.github\.io/gwtransport/htmlcov/?


### PR DESCRIPTION
## Summary
The `check-documentation-links` job has a SECOND step — a lychee action checking `README.md` — that 404s on the same coverage badge (`coverage-badge.svg`) + `htmlcov/` self-links in the README badge row. #269 only fixed the Sphinx linkcheck. This excludes them from lychee too, via `.lycheeignore` (lychee reads it by default; also helps local runs) and an explicit `--exclude` regex in the workflow args. Other doc/example self-links stay checked.

## Test plan
- Prettier: docs.yml passes.
- Regex verified to exclude exactly the badge + htmlcov URLs and not other gwtransport.github.io links.

## Contributor License Agreement
- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.