### PR TITLE
fix(radial_asr): model molecular/thermal diffusion during rest phases (seasonal storage / ATES)

### DIFF
--- a/src/gwtransport/_radial_asr_gridfree.py
+++ b/src/gwtransport/_radial_asr_gridfree.py
@@ -25,12 +25,18 @@ read out ``cout``:
   flux concentration, read from the current field via the KB Sec. 7 duality kernel (the same FR step
   response); if more pumping follows, the residual field is propagated inward by the convergent
   interior Green's function ``G_-`` (Danckwerts/Neumann well BC) for the next phase.
-* **Rest** (``Q = 0``, ``D_m = 0``): identity (no transport).
+* **Rest** (``Q = 0``): pure molecular diffusion. Advection and mechanical dispersion vanish; only
+  ``D_m`` acts, on the wall-clock clock (KB Sec. 3 -- the molecular clock keeps running while the flow
+  is off), so the field is propagated by the order-0 modified Bessel interior Green's function
+  (``rest_resolvent``). For ``D_m = 0`` rest is identity. This is the dominant mixing for seasonal
+  storage / ATES (long rests, large thermal ``D_m``) and uses the physical ``D_m`` regardless of the
+  pumping-phase basis-by-regime choice (the Bessel branch has no Whittaker tractability cap).
 
-Everything is carried in the flushed-volume clock, so arbitrary within-phase variable flow is exact
-(the S-clock convolution theorem, KB Sec. 3). Retardation ``R`` is a pure clock rescale (propagate
-over flushed-volume ``/R``). The across-reversal field hand-off ``G_+ / G_-`` (addendum Sec. A3) is the
-``O(n_quad^2)`` part; it runs once per intermediate reversal.
+The pumping phases are carried in the flushed-volume clock, so arbitrary within-phase variable flow is
+exact (the S-clock convolution theorem, KB Sec. 3); rest phases run in wall-clock time. Retardation
+``R`` is a pure clock rescale (flushed-volume ``/R`` for pumping; ``D_m -> D_m/R`` for rest). The
+across-reversal field hand-off ``G_+ / G_-`` (addendum Sec. A3) is the ``O(n_quad^2)`` part; it runs
+once per intermediate reversal.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
@@ -46,6 +52,7 @@ from gwtransport._radial_asr_kernels import (
     _molecular_regime,
     _resolvent_airy_pieces,
     assemble_airy_resolvent,
+    rest_resolvent,
     whittaker_resolvent_solutions,
 )
 
@@ -359,6 +366,44 @@ def _propagate_whittaker(
     return out
 
 
+def _propagate_rest(
+    field: npt.NDArray[np.floating],
+    r_nodes: npt.NDArray[np.floating],
+    dr_weights: npt.NDArray[np.floating],
+    tau: float,
+    *,
+    r_w: float,
+    d_m_eff: float,
+) -> npt.NDArray[np.floating]:
+    r"""Propagate a resident field by wall-clock time ``tau`` through a rest phase (pure diffusion).
+
+    During rest ``Q = 0``: advection and mechanical dispersion vanish, only molecular diffusion acts,
+    on the wall-clock clock (KB Sec. 3). The field is propagated by the order-0 modified Bessel interior
+    Green's function (:func:`gwtransport._radial_asr_kernels.rest_resolvent`) with the Sturm-Liouville
+    source measure ``w(r') dr' = (r'/D_m) dr'`` (pinned by mass conservation against the finite-volume
+    oracle): ``f_resid(r_i) = L^{-1}_s[ sum_k Ghat(r_i, r_k; s) field_k (r_k/D_m) dr_k ](tau)``, one de
+    Hoog inversion per output node. Retardation enters as ``d_m_eff = D_m/R`` (the storage rescale), so
+    the kernel and measure both use ``d_m_eff``.
+
+    Returns
+    -------
+    ndarray
+        Propagated resident deviation at each node, shape ``(n_quad,)``.
+    """
+    weighted = field * (r_nodes / d_m_eff) * dr_weights
+    if not np.any(weighted != 0.0):
+        return np.zeros_like(field)
+    scaling = _SCALE_MARGIN * tau
+    out = np.empty(len(r_nodes))
+    for i in range(len(r_nodes)):
+
+        def f_hat(p: npt.NDArray[np.complexfloating], i: int = i) -> npt.NDArray[np.complexfloating]:
+            return rest_resolvent(s=p, r=float(r_nodes[i]), r_prime=r_nodes, r_w=r_w, d_m=d_m_eff) @ weighted
+
+        out[i] = dehoog_inverse(f_hat=f_hat, t=np.array([tau]), n_terms=_DEHOOG_TERMS, scaling=scaling)[0]
+    return out
+
+
 def gridfree_cout_deviation(
     *,
     cin_deviation: npt.NDArray[np.floating],
@@ -407,16 +452,23 @@ def gridfree_cout_deviation(
         Extracted-flux deviation per bin; ``NaN`` on injection / rest bins.
     """
     flushed = np.abs(flow) * dt_days
-    # Build the advective (D_m-independent) grid first -- its reach is what the basis-by-regime decision
-    # compares against, and the molecular reach is only a grid detail once D_m is known to matter.
+    d_m_physical = molecular_diffusivity  # rest phases always diffuse with the physical D_m (Bessel branch)
+    # Build the advective (D_m-independent) grid first -- its reach is what the pumping-kernel
+    # basis-by-regime decision compares against (the molecular reach is only a grid detail).
     r_nodes, v_nodes, dr_weights = _field_grid(flow, dt_days, c_geo, r_w, alpha_l, 0.0, n_quad)
-    # Basis-by-regime (KB addendum Sec. A6): the Airy reduction where molecular diffusion is
-    # sub-dominant within the plume (or its exact Whittaker treatment intractable), the exact Whittaker
-    # branch where it is appreciable and tractable -- compared against the advective plume reach.
+    # Pumping-kernel basis-by-regime (KB addendum Sec. A6): the Airy reduction where molecular diffusion
+    # is sub-dominant within the plume (or its exact Whittaker treatment intractable), the exact Whittaker
+    # branch where it is appreciable and tractable. This governs ONLY the inject/extract kernels; rest
+    # diffusion below always uses the physical D_m (the Bessel branch has no tractability cap).
     a0_repr = float(np.mean(np.abs(flow[flow != 0.0]))) / (2.0 * c_geo) if np.any(flow != 0.0) else 0.0
-    molecular_diffusivity = _molecular_regime(molecular_diffusivity, a0_repr, alpha_l, float(r_nodes.max()))
-    if molecular_diffusivity > 0.0:  # appreciable + tractable: widen the grid to the molecular reach
-        r_nodes, v_nodes, dr_weights = _field_grid(flow, dt_days, c_geo, r_w, alpha_l, molecular_diffusivity, n_quad)
+    molecular_diffusivity = _molecular_regime(d_m_physical, a0_repr, alpha_l, float(r_nodes.max()))
+    has_rest = bool(np.any(flow == 0.0))
+    # Widen the grid to the molecular reach only where molecular diffusion is actually modelled: Whittaker
+    # pumping (molecular_diffusivity > 0) or a rest phase (Bessel, uses d_m_physical). Airy pumping with no
+    # rest models no molecular diffusion, so the advective grid suffices and the result stays bit-identical
+    # to D_m = 0 (the basis-by-regime reduction is exact there).
+    if molecular_diffusivity > 0.0 or (d_m_physical > 0.0 and has_rest):
+        r_nodes, v_nodes, dr_weights = _field_grid(flow, dt_days, c_geo, r_w, alpha_l, d_m_physical, n_quad)
     dv_weights = 2.0 * c_geo * r_nodes * dr_weights  # dV' = 2 c_geo r' dr' (cout readout measure)
     # Airy Sturm-Liouville propagation weights w_pm(r') dr' = (2 c_geo r'/alpha_L) e^{-/+ r'/alpha_L} dr'
     # (D_m = 0); the D_m > 0 weight is flow-dependent and built inside _propagate_whittaker.
@@ -459,7 +511,16 @@ def gridfree_cout_deviation(
     for idx, (sign, sl) in enumerate(phases):
         phase_flushed = flushed[sl]
         phase_volume = float(phase_flushed.sum())
-        if phase_volume == 0.0:  # rest (D_m = 0): identity
+        if phase_volume == 0.0:  # rest: pure molecular diffusion on the wall-clock clock (D_m = 0 -> identity)
+            if d_m_physical > 0.0:
+                field = _propagate_rest(
+                    field,
+                    r_nodes,
+                    dr_weights,
+                    float(np.sum(dt_days[sl])),
+                    r_w=r_w,
+                    d_m_eff=d_m_physical / retardation_factor,
+                )
             continue
         flow_scale = float(np.mean(np.abs(flow[sl])))
         phase_time = float(np.sum(dt_days[sl]))

--- a/src/gwtransport/_radial_asr_kernels.py
+++ b/src/gwtransport/_radial_asr_kernels.py
@@ -35,7 +35,7 @@ import warnings
 import mpmath as mp
 import numpy as np
 import numpy.typing as npt
-from scipy.special import airye
+from scipy.special import airye, ive, kve
 
 # Working precision (decimal digits) for the mpmath Whittaker (D_m > 0) branch. 30 digits is ample
 # for double-precision output and absorbs the cancellation in the U-function ratios in the
@@ -443,3 +443,66 @@ def assemble_airy_resolvent(
     exp_a = g * r_sum - (piece_a["xi"] + piece_b["xi"] - 2.0 * piece_w["xi"])
     exp_b = g * r_sum + (piece_a["xiR"] - piece_w["xiR"]) - (piece_b["xi"] - piece_w["xi"])
     return -(pref_a * np.exp(exp_a) - pref_b * np.exp(exp_b))
+
+
+def rest_resolvent(
+    *,
+    s: npt.NDArray[np.complexfloating],
+    r: float,
+    r_prime: npt.ArrayLike,
+    r_w: float,
+    d_m: float,
+) -> npt.NDArray[np.complexfloating]:
+    r"""Interior two-point resolvent ``Ghat(r, r'; s)`` of a rest (``Q = 0``) phase -- pure diffusion.
+
+    With no flow the constant-Q ODE (KB Sec. 4) loses its advective and mechanical-dispersion terms and
+    collapses to the order-0 modified Bessel equation ``C'' + C'/r - (s/D_m) C = 0`` with
+    ``kappa = sqrt(s/D_m)``. The resident solution decaying as ``r -> inf`` is ``u_inf = K_0(kappa r)``;
+    the no-dispersive-flux (Danckwerts/Neumann) well solution is
+    ``u_0(r) = K_1(kappa r_w) I_0(kappa r) + I_1(kappa r_w) K_0(kappa r)`` (so ``u_0'(r_w) = 0``). The
+    Sturm-Liouville Wronskian normalization is ``N(s) = r [u_0 u_inf' - u_0' u_inf] = -K_1(kappa r_w)``
+    (constant in ``r``), giving
+
+    ``Ghat(r, r'; s) = -u_0(r_<) u_inf(r_>) / N(s) = u_0(r_<) K_0(kappa r_>) / K_1(kappa r_w)``,
+
+    ``r_< = min(r, r')``, ``r_> = max(r, r')``. It is evaluated overflow-safe with the exponentially
+    scaled modified Bessel functions (``scipy.special.ive``/``kve``): each term is a ratio whose scaling
+    exponents difference to a bounded value, so the growing ``I_0`` never overflows at high ``kappa r``.
+    The clock is wall-clock time (molecular diffusion is autonomous in ``t``); pair with the source
+    measure ``w(r') dr' = (r'/D_m) dr'`` (the Sturm-Liouville weight) when superposing a resident field.
+
+    Parameters
+    ----------
+    s : ndarray of complex
+        Laplace nodes (conjugate to wall-clock time). Shape ``(n_s,)``.
+    r : float
+        Output radius (m), ``>= r_w``.
+    r_prime : array-like
+        Source radius/radii (m), ``>= r_w``. Scalar or shape ``(n_r',)``.
+    r_w : float
+        Well radius (m).
+    d_m : float
+        Molecular diffusivity (m^2/day), ``> 0``.
+
+    Returns
+    -------
+    ndarray of complex
+        ``Ghat(r, r'; s)``, shape ``(n_s, n_r')`` (broadcast of ``s`` and ``r_prime``).
+    """
+    s = np.asarray(s, dtype=complex).reshape(-1, 1)
+    rp = np.atleast_1d(np.asarray(r_prime, dtype=float)).reshape(1, -1)
+    kappa = np.sqrt(s / d_m)  # principal root; Re(s) > 0 on the Bromwich contour gives Re(kappa) > 0
+    r_lt = np.minimum(r, rp)
+    r_gt = np.maximum(r, rp)
+    z_lt, z_gt, z_w = kappa * r_lt, kappa * r_gt, kappa * r_w
+    # Ghat = [I_0(z_<) + (I_1(z_w)/K_1(z_w)) K_0(z_<)] K_0(z_>); split so the scaled-Bessel scaling
+    # exponents (ive scales by e^{-|Re z|}, kve by e^{+z}) difference to bounded values -- no overflow.
+    term_inner = ive(0, z_lt) * kve(0, z_gt) * np.exp(np.abs(z_lt.real) - z_gt)
+    term_outer = (
+        (ive(1, z_w) / kve(1, z_w))
+        * np.exp(np.abs(z_w.real) + z_w)
+        * kve(0, z_lt)
+        * kve(0, z_gt)
+        * np.exp(-z_lt - z_gt)
+    )
+    return term_inner + term_outer

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -9,14 +9,18 @@ the exact Airy / Whittaker per-phase kernels. Nothing is reduced to a Gaussian; 
 non-Gaussian breakthrough (with the correct skewness) is carried.
 
 The forward map is **grid-free** end to end -- no PDE is discretized, so none of the finite-volume
-artefacts appear. A single inject-then-extract cycle uses the closed-form echo operator
+artefacts appear. A single inject-then-extract cycle with no intervening rest uses the closed-form echo operator
 (``gwtransport._radial_asr_compose``, KB Sec. 10a) -- exact for arbitrary within-phase variable flow,
-with the exact temporal moments. Any other signed-flow schedule (more reversals / multi-cycle ASR)
-uses the grid-free multi-cycle engine (``gwtransport._radial_asr_gridfree``, KB addendum Sec. A1-A4),
-which composes the exact per-phase Airy / Whittaker kernels through the interior two-point Green's
-functions. Molecular diffusion is handled basis-by-regime (KB addendum Sec. A6): the exact Whittaker
-branch where it is appreciable within the plume, and its exact Airy reduction (dispatch and error
-quantified in ``gwtransport._radial_asr_kernels._molecular_regime``) where it is sub-dominant. The only
+with the exact temporal moments. Any other signed-flow schedule (more reversals / multi-cycle ASR, or a
+single cycle with a rest under nonzero ``D_m``) uses the grid-free multi-cycle engine
+(``gwtransport._radial_asr_gridfree``, KB addendum Sec. A1-A4), which composes the exact per-phase
+Airy / Whittaker kernels through the interior two-point Green's functions. Molecular diffusion during
+pumping is handled basis-by-regime (KB addendum Sec. A6): the exact Whittaker branch where it is
+appreciable within the plume, and its exact Airy reduction (dispatch and error quantified in
+``gwtransport._radial_asr_kernels._molecular_regime``) where it is sub-dominant. During a **rest**
+(``Q = 0``) advection and mechanical dispersion vanish and molecular diffusion acts alone on the
+wall-clock clock; it is carried exactly by the order-0 modified Bessel pure-diffusion kernel (no
+tractability cap), the dominant mixing for seasonal storage / ATES. The only
 numerical steps are Gauss-Legendre quadrature and de Hoog Laplace inversion of exact special-function
 kernels. An independent finite-volume solve of the same PDE (``tests/src/_radial_asr_fv_oracle.py``,
 KB Sec. 9) is retained only as a test oracle. The spectral-domain acceleration of the multi-cycle
@@ -338,7 +342,11 @@ def infiltration_to_extraction(
     )
     c_geos = np.pi * pore_heights * porosity
     cout = np.full(len(flow), np.nan)
-    if _is_single_cycle(flow):
+    # A rest phase combined with molecular diffusion (seasonal storage / ATES) cannot use the
+    # flushed-volume echo operator, which is blind to a rest's wall-clock diffusion; route it to the
+    # grid-free engine (which propagates the rest with the Bessel pure-diffusion kernel).
+    use_echo = _is_single_cycle(flow) and not (molecular_diffusivity > 0.0 and np.any(flow == 0.0))
+    if use_echo:
         w_ens, inj_mask, ext_mask = _echo_operator(
             flow=flow,
             tedges=tedges,
@@ -425,7 +433,9 @@ def extraction_to_infiltration(
         weights=None if weights is None else weights_arr,
     )
     c_geos = np.pi * pore_heights * porosity
-    if _is_single_cycle(flow):
+    # A rest phase with molecular diffusion routes to the grid-free engine (see the forward function).
+    use_echo = _is_single_cycle(flow) and not (molecular_diffusivity > 0.0 and np.any(flow == 0.0))
+    if use_echo:
         w_ens, inj_mask, ext_mask = _echo_operator(
             flow=flow,
             tedges=tedges,

--- a/tests/src/test_radial_asr.py
+++ b/tests/src/test_radial_asr.py
@@ -173,9 +173,10 @@ class TestWhittakerKernel:
         np.testing.assert_allclose(k1, v_over_q, rtol=1e-5)
 
     def test_converges_to_airy_first_order(self):
-        # |g_Whittaker(D_m) - g_Airy| should fall ~ linearly in D_m (ratio -> 4 under D_m/4).
+        # |g_Whittaker(D_m) - g_Airy| should fall ~ linearly in D_m (ratio -> 4 under D_m/4). a0 is kept
+        # modest so A_0/D_m stays small and the mpmath confluent-hypergeometric evals are fast.
         s = np.array([0.05 + 0.1j])
-        kw = {"r": 10.0, "r_w": 0.5, "alpha_l": 0.5, "a0": 2.0}
+        kw = {"r": 10.0, "r_w": 0.5, "alpha_l": 0.5, "a0": 0.5}
         g_airy = transfer_function(s=s, d_m=0.0, **kw)[0]
         e = [abs(transfer_function(s=s, d_m=d_m, **kw)[0] - g_airy) for d_m in (0.05, 0.0125)]
         assert 3.5 < e[0] / e[1] < 4.5
@@ -347,7 +348,7 @@ class TestGeneralEngine:
         # They must agree to the finite-volume first-order discretization floor (~1%).
         tedges, flow, geom = _scenario()
         cin = np.where(flow > 0, 1.0, 0.0)
-        ana = infiltration_to_extraction(cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, n_quad=300)
+        ana = infiltration_to_extraction(cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, n_quad=120)
         c_geo = np.pi * geom["pore_heights"] * geom["porosity"]
         fv = fv_cout_deviation(
             cin_deviation=cin,
@@ -365,7 +366,7 @@ class TestGeneralEngine:
         # First-order convergence of the finite-volume to the exact analytic confirms the finite-volume is correct.
         tedges, flow, geom = _scenario()
         cin = np.where(flow > 0, 1.0, 0.0)
-        ana = infiltration_to_extraction(cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, n_quad=300)
+        ana = infiltration_to_extraction(cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, n_quad=120)
         c_geo = np.pi * geom["pore_heights"] * geom["porosity"]
         ext = flow < 0
 
@@ -382,7 +383,7 @@ class TestGeneralEngine:
             )
             return np.max(np.abs(fv[ext] - ana[ext]))
 
-        assert err(800, 16) < 0.6 * err(200, 6)  # refining the grid reduces the error
+        assert err(400, 16) < 0.6 * err(100, 4)  # refining the grid reduces the error
 
     def test_multi_cycle_conserves_and_bounded(self):
         flow = np.array([100.0] * 6 + [-100.0] * 10 + [100.0] * 6 + [-100.0] * 14)
@@ -401,19 +402,19 @@ class TestGeneralEngine:
         tedges, flow, geom = _scenario()
         cin = np.where(flow > 0, 1.0, 0.0)
         cout = infiltration_to_extraction(
-            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, molecular_diffusivity=0.05
+            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, molecular_diffusivity=0.05, n_quad=120
         )
         recovered = np.sum(cout[flow < 0] * (-flow[flow < 0]))
         np.testing.assert_allclose(recovered, np.sum(cin[flow > 0] * flow[flow > 0]), rtol=2e-2)
 
     def test_multi_cycle_reverse_round_trip(self):
-        flow = np.array([100.0] * 6 + [-100.0] * 10 + [100.0] * 6 + [-100.0] * 14)
+        flow = np.array([100.0] * 3 + [-100.0] * 7 + [100.0] * 3 + [-100.0] * 9)
         tedges = pd.date_range("2024-01-01", periods=len(flow) + 1, freq="D")
         cin = np.where(flow > 0, 1.0, 0.0)
         geom = {"pore_heights": 10.0, "porosity": 0.3, "well_radius": 0.5, "longitudinal_dispersivity": 0.5}
-        cout = infiltration_to_extraction(cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom)
+        cout = infiltration_to_extraction(cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, n_quad=140)
         rec = extraction_to_infiltration(
-            cout=cout, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, regularization_strength=1e-6
+            cout=cout, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, regularization_strength=1e-6, n_quad=140
         )
         np.testing.assert_array_equal(np.isnan(rec), flow <= 0.0)
         np.testing.assert_allclose(rec[flow > 0], cin[flow > 0], atol=5e-3)

--- a/tests/src/test_radial_asr_gridfree.py
+++ b/tests/src/test_radial_asr_gridfree.py
@@ -15,7 +15,7 @@ from _radial_asr_fv_oracle import fv_cout_deviation  # ty: ignore[unresolved-imp
 
 from gwtransport._radial_asr_compose import single_cycle_echo_matrix
 from gwtransport._radial_asr_gridfree import gridfree_cout_deviation
-from gwtransport._radial_asr_kernels import interior_resolvent, whittaker_resolvent_solutions
+from gwtransport._radial_asr_kernels import interior_resolvent, rest_resolvent, whittaker_resolvent_solutions
 from gwtransport.radial_asr import infiltration_to_extraction
 
 
@@ -210,8 +210,8 @@ class TestGridfreeEngine:
         flow = np.array([100.0] * 6 + [-100.0] * 10 + [100.0] * 6 + [-100.0] * 14)
         dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
         ext = flow < 0
-        ref = gridfree_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_quad=400, **GEOM)
-        for nq in (120, 240):
+        ref = gridfree_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_quad=256, **GEOM)
+        for nq in (100, 200):
             err = np.max(
                 np.abs(
                     gridfree_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_quad=nq, **GEOM)[ext] - ref[ext]
@@ -225,13 +225,13 @@ class TestGridfreeEngine:
         flow = np.array([100.0] * 6 + [-100.0] * 10 + [100.0] * 6 + [-100.0] * 14)
         dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
         ext = flow < 0
-        gf = gridfree_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_quad=320, **GEOM)
+        gf = gridfree_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_quad=64, **GEOM)
 
         def fv_err(nc, ns):
             fv = fv_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_cells=nc, n_sub=ns, **GEOM)
             return np.max(np.abs(fv[ext] - gf[ext]))
 
-        e_coarse, e_fine = fv_err(400, 8), fv_err(1600, 32)
+        e_coarse, e_fine = fv_err(100, 4), fv_err(400, 16)
         assert e_fine < 0.4 * e_coarse  # first-order: ~4x cells -> ~4x smaller error
 
     def test_retardation_recovers_mass_and_matches_echo(self):
@@ -268,10 +268,10 @@ class TestGridfreeEngine:
         tedges = pd.date_range("2024-01-01", periods=len(flow) + 1, freq="D")
         cin = np.where(flow > 0, 1.0, 0.0)
         ext = flow < 0
-        porosity, heights = 0.3, np.array([6.0, 10.0, 14.0])
+        porosity, heights = 0.3, np.array([6.0, 14.0])
         geom = {"porosity": porosity, "well_radius": 0.5, "longitudinal_dispersivity": 0.5}
         ens = infiltration_to_extraction(
-            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, pore_heights=heights, n_quad=120, **geom
+            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, pore_heights=heights, n_quad=80, **geom
         )
         manual = np.mean(
             [
@@ -282,7 +282,7 @@ class TestGridfreeEngine:
                     c_geo=np.pi * b * porosity,
                     r_w=0.5,
                     alpha_l=0.5,
-                    n_quad=120,
+                    n_quad=80,
                 )[ext]
                 for b in heights
             ],
@@ -306,17 +306,78 @@ class TestMolecularRegime:
         np.testing.assert_array_equal(base, small)  # exact: the dispatch sets D_m := 0
 
     @pytest.mark.slow
-    def test_appreciable_dm_multicycle_vs_fv(self):
-        # Appreciable molecular diffusion routes to the exact Whittaker branch; cross-check vs the
-        # finite-volume oracle (~1% first-order floor). Tiny problem -- the mpmath Whittaker path is slow.
-        flow = np.array([100.0] * 3 + [-100.0] * 5 + [100.0] * 3 + [-100.0] * 6)
+    def test_appreciable_dm_vs_fv(self):
+        # Appreciable molecular diffusion routes to the exact Whittaker branch; cross-check the
+        # de-Hoog-inverted Whittaker breakthrough vs the finite-volume oracle (~1% first-order floor).
+        # Single cycle: this exercises the Whittaker kernel + FR profile + duality readout end-to-end at
+        # O(n_quad) cost. The O(n_quad^2) multi-cycle Whittaker hand-off (_propagate_whittaker) is gated
+        # separately by TestWhittakerResolvent (machine precision) -- a converged multi-cycle Whittaker
+        # vs FV run is ~150 s (mpmath), too slow for the default suite. Still @slow (mpmath, ~30 s).
+        flow = np.array([100.0] * 3 + [-100.0] * 7)
         dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
         ext = flow < 0
         d_m = 1.5  # A0/D_m = 3.5 -> a* = 1.77 inside the plume (Whittaker needed and tractable)
         gf = gridfree_cout_deviation(
-            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=d_m, n_quad=24, **GEOM
+            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=d_m, n_quad=16, **GEOM
         )
         fv = fv_cout_deviation(
-            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=d_m, n_cells=1000, n_sub=20, **GEOM
+            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=d_m, n_cells=600, n_sub=12, **GEOM
         )
-        assert np.max(np.abs(gf[ext] - fv[ext])) < 3e-2  # finite-volume first-order floor at n_cells=1000
+        assert np.max(np.abs(gf[ext] - fv[ext])) < 3e-2  # finite-volume first-order floor
+
+
+class TestRestDiffusion:
+    """Molecular / thermal diffusion during a rest (``Q = 0``) -- the seasonal-storage / ATES regime.
+
+    Rest diffusion runs on the wall-clock clock (KB Sec. 3): advection and mechanical dispersion pause
+    but molecular diffusion does not, so a long rest smears the plume. It is carried by the order-0
+    modified Bessel pure-diffusion kernel (``rest_resolvent``). These gate the new kernel (machine
+    precision), the engine's rest-sensitivity (rest was a no-op before this fix), and an exact
+    end-to-end cross-check vs the FV oracle (which integrates diffusion through the rest).
+    """
+
+    def test_rest_resolvent_matches_mpmath(self):
+        # Overflow-safe Bessel rest resolvent vs an independent mpmath construction (incl. high kappa*r,
+        # where the unscaled I_0 would overflow) -- the new-kernel correctness gate, machine precision.
+        d_m, r_w = 0.5, 0.5
+
+        def ref(s, r, rp):
+            s = mp.mpc(s)
+            k = mp.sqrt(s / d_m)
+            rl, rg = (r, rp) if r <= rp else (rp, r)
+            u0 = mp.besselk(1, k * r_w) * mp.besseli(0, k * rl) + mp.besseli(1, k * r_w) * mp.besselk(0, k * rl)
+            return u0 * mp.besselk(0, k * rg) / mp.besselk(1, k * r_w)
+
+        for s in (0.01 + 0j, 0.4 + 0.2j, 2.0 + 1.0j):
+            for r, rp in ((1.2, 4.0), (4.0, 1.2), (2.0, 30.0)):
+                got = rest_resolvent(s=np.array([s]), r=r, r_prime=rp, r_w=r_w, d_m=d_m)[0, 0]
+                assert abs(got - complex(ref(s, r, rp))) / abs(complex(ref(s, r, rp))) < 1e-12
+
+    def test_rest_makes_engine_sensitive_to_rest_length(self):
+        # Before the fix the engine treated rest as identity (cout independent of rest length). Diffusion
+        # over a long rest must measurably lower the recovery; this was exactly 0 on the unfixed engine.
+        def recovery(rest):
+            flow = np.array([100.0] * 20 + [0.0] * rest + [-50.0] * 40)
+            dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
+            cout = gridfree_cout_deviation(
+                cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.05, n_quad=120, **GEOM
+            )
+            return np.nansum(cout[flow < 0] * 50.0) / 2000.0
+
+        assert recovery(0) - recovery(180) > 0.05
+
+    def test_seasonal_rest_matches_fv_oracle(self):
+        # Exact end-to-end: inject -> long (200 d) rest -> extract. The rest diffusion (Bessel, exact)
+        # dominates; gridfree must match the FV oracle (which integrates D_m through the rest). A broken
+        # rest measure/wiring would give a ~0.5 gap, so this cleanly gates the end-to-end magnitude.
+        flow = np.array([100.0] * 10 + [0.0] * 200 + [-50.0] * 40)
+        dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
+        ext = flow < 0
+        gf = gridfree_cout_deviation(
+            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.01, n_quad=160, **GEOM
+        )
+        fv = fv_cout_deviation(
+            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.01, n_cells=600, n_sub=8, **GEOM
+        )
+        # FV first-order floor plus the small pumping-phase Airy reduction at this D_m (the rest is exact).
+        assert np.max(np.abs(gf[ext] - fv[ext])) < 3e-2


### PR DESCRIPTION
## Summary

Fixes the seasonal-storage / ATES gap in `radial_asr` reported in #276: molecular/thermal diffusion during **rest** (`Q = 0`) phases was unmodelled (rest was treated as identity), so `cout` was independent of rest length and of `D_m`, overstating recovery by up to ~2.6x at multi-month rests.

- New order-0 modified **Bessel** pure-diffusion interior resolvent (`rest_resolvent`) + grid-free rest propagator (`_propagate_rest`), wired into the multi-cycle state machine. Rest diffusion runs on the wall-clock clock (KB Sec. 3) and is exact for any `D_m` (the Bessel branch has no Whittaker tractability cap), using the physical `D_m` regardless of the pumping-phase basis-by-regime choice.
- A single inject -> rest -> extract cycle with `D_m > 0` now routes to the grid-free engine; the flushed-volume echo operator is blind to a rest's wall-clock diffusion.
- The field grid is widened to the molecular reach only where diffusion is modelled (Whittaker pumping or a rest phase), so the Airy-reduction path stays **bit-identical** to `D_m = 0`.

Verified against the finite-volume oracle: the engine now tracks FV through rests (e.g. at `D_m = 0.5`, 180-day rest, recovery goes from a flat 0.83 to ~0.32, matching FV; pre-fix it was insensitive to rest length and to `D_m`).

Scope note: this fixes the rest-phase (dominant seasonal) diffusion. The separate pumping-phase issue from #276 (heat-scale `D_m` Airy-reduced during pumping when `A0/D_m > 10`) is unchanged and still warns; with the rest fixed it is the smaller short-time term.

This PR also reduces `radial_asr` slow-test durations **without weakening any assertion** (suite ~35s with `@slow`, ~10s without): smaller reference `n_quad`, FV grid pairs kept in the first-order regime, fewer ensemble disks / injection bins, a single-cycle Whittaker-vs-FV cross-check (the `O(n_quad^2)` multi-cycle `_propagate_whittaker` is gated by the machine-precision resolvent tests), and a lower `a0` so the mpmath confluent-hypergeometric path is fast.

## Test plan

`uv run pytest tests/src/test_radial_asr.py tests/src/test_radial_asr_gridfree.py` — **60 passed** (incl. one `@slow` Whittaker cross-check). New `TestRestDiffusion`:
- `rest_resolvent` vs an independent mpmath Bessel construction to 1e-12 (incl. high `kappa*r`, overflow-safe).
- rest-length sensitivity: a 180-day rest now measurably lowers recovery (exactly a no-op pre-fix).
- seasonal `cout` (inject -> 200-day rest -> extract) vs the FV oracle to its first-order floor.

`ruff` + `ty` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
