### PR TITLE
feat(radial_asr): exact pumping-phase molecular/thermal diffusion via flint Whittaker (#276 Bug 2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
   "mpmath>=1.3.0",
   "numpy>=2.0.0",
   "pandas>=2.2.2",
+  "python-flint>=0.8.0",
   "requests>=2.19.0",
   "scipy>=1.13.0",
 ]

--- a/src/gwtransport/_radial_asr_gridfree.py
+++ b/src/gwtransport/_radial_asr_gridfree.py
@@ -7,7 +7,7 @@ artefacts (CFL/Courant limit, numerical dispersion, Crank-Nicolson ringing) appe
 operations are Gauss-Legendre quadrature over the resident profile and de Hoog Laplace inversion of the
 exact special-function kernels: the Airy interior Green's functions for ``D_m = 0`` (flushed-volume
 clock, vectorized) and the Whittaker interior Green's functions for appreciable ``D_m > 0`` (wall-clock
-time, mpmath -- the molecular-diffusion regime is chosen by :func:`_molecular_regime`, KB addendum
+time, flint/Arb -- the molecular-diffusion regime is chosen by :func:`_molecular_regime`, KB addendum
 Sec. A6). The spectral-domain acceleration of the composition (KB addendum Sec. A4-A7) is not
 implemented here.
 
@@ -42,22 +42,20 @@ This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """
 
-import mpmath as mp
 import numpy as np
 import numpy.typing as npt
+from flint import acb, ctx
 
 from gwtransport._radial_asr_compose import _fr_step_response
 from gwtransport._radial_asr_dehoog import dehoog_inverse
 from gwtransport._radial_asr_kernels import (
+    _WHITTAKER_PREC,
     _molecular_regime,
     _resolvent_airy_pieces,
     assemble_airy_resolvent,
     rest_resolvent,
     whittaker_resolvent_solutions,
 )
-
-# Working precision (decimal digits) for the mpmath Whittaker (D_m > 0) field propagation.
-_WHITTAKER_DPS = 30
 
 # de Hoog series length for the field-propagation inversion and the front-anchored scaling margin
 # (matched to the FR step response in _radial_asr_compose).
@@ -292,12 +290,12 @@ def _propagate_whittaker(
     Same superposition as :func:`_propagate` but with the Whittaker interior Green's function (KB
     Sec. 4 ``D_m > 0`` branch) and the wall-clock time clock (the volume clock is not autonomous when
     ``D_m > 0`` -- the no-go lemma). No vectorized complex Whittaker exists, so the solutions are
-    sampled in mpmath; the cost is contained by (a) evaluating them ONCE per de Hoog node and grid
+    sampled with flint (Arb); the cost is contained by (a) evaluating them ONCE per de Hoog node and grid
     radius and (b) assembling every output node from prefix/suffix sums of the source superposition
     ``F(s)_i = -[u_inf(r_i) sum_{j<=i} u_0(r_j) w_j + u_0(r_i) sum_{j>i} u_inf(r_j) w_j]/N(s)`` (using
-    the symmetric SL split at ``r_i``), keeping the whole build at ``O(n_nodes * n_quad)`` mpmath
-    evaluations. mpmath carries the growing-solution magnitude exactly, and only the bounded ``F(s)_i``
-    is cast to double. ``src_measure_k = w(r_k) dr_weights_k`` with the ``D_m > 0`` weight
+    the symmetric SL split at ``r_i``), keeping the whole build at ``O(n_nodes * n_quad)`` Arb
+    evaluations. Arb carries the divergent growing-solution magnitude exactly (the ``N = G^b`` gauge),
+    and only the bounded ``F(s)_i`` -- where it cancels -- is cast to double. ``src_measure_k = w(r_k) dr_weights_k`` with the ``D_m > 0`` weight
     ``w_pm(r) = r G(r)^{-/+ A_0/D_m}`` (``G = alpha_L A_0 + D_m r``).
 
     Returns
@@ -322,35 +320,36 @@ def _propagate_whittaker(
 
     def build(p: npt.NDArray[np.complexfloating]) -> npt.NDArray[np.complexfloating]:
         f_mat = np.empty((len(p), n), dtype=complex)
-        with mp.workdps(_WHITTAKER_DPS):
-            b_exp = 1 - sigma_a * a0_eff / d_m_eff
-            for k, pk in enumerate(p):
-                sk = complex(pk)
-                uiw, uiwp, urw, urwp = whittaker_resolvent_solutions(sk, r_w, alpha_l, a0_eff, d_m_eff, sigma_a)
-                if sigma_a < 0:  # extraction: Danckwerts/Neumann u_0'(r_w) = 0
-                    bc_reg, bc_inf = urwp, uiwp
-                else:  # injection: Robin F[u]=u-(G/A_0)u', F[u_0](r_w)=0
-                    fac = alpha_l + d_m_eff * r_w / a0_eff  # = G(r_w)/A_0
-                    bc_reg, bc_inf = urw - fac * urwp, uiw - fac * uiwp
-                u0w = bc_reg * uiw - bc_inf * urw
-                u0wp = bc_reg * uiwp - bc_inf * urwp
-                n_s = (alpha_l * a0_eff + d_m_eff * r_w) ** b_exp * (u0w * uiwp - u0wp * uiw)
-                u_inf_g, u0_g = [], []
-                for r in r_nodes:
-                    ui, _, ur, _ = whittaker_resolvent_solutions(sk, float(r), alpha_l, a0_eff, d_m_eff, sigma_a)
-                    u_inf_g.append(ui)
-                    u0_g.append(bc_reg * ui - bc_inf * ur)
-                wj = [mp.mpc(complex(weighted[m])) for m in range(n)]
-                prefix, acc = [mp.mpc(0)] * n, mp.mpc(0)
-                for m in range(n):  # inclusive prefix sum_{j<=m} u_0(r_j) w_j
-                    acc += u0_g[m] * wj[m]
-                    prefix[m] = acc
-                suffix, acc = [mp.mpc(0)] * n, mp.mpc(0)
-                for m in range(n - 1, -1, -1):  # exclusive suffix sum_{j>m} u_inf(r_j) w_j
-                    suffix[m] = acc
-                    acc += u_inf_g[m] * wj[m]
-                for i in range(n):
-                    f_mat[k, i] = complex(-(u_inf_g[i] * prefix[i] + u0_g[i] * suffix[i]) / n_s)
+        ctx.prec = _WHITTAKER_PREC
+        b_exp = 1 - sigma_a * a0_eff / d_m_eff
+        g_well = acb(alpha_l * a0_eff + d_m_eff * r_w) ** acb(b_exp)  # divergent N gauge; cancels in F(s)_i
+        for k, pk in enumerate(p):
+            sk = complex(pk)
+            uiw, uiwp, urw, urwp = whittaker_resolvent_solutions(sk, r_w, alpha_l, a0_eff, d_m_eff, sigma_a)
+            if sigma_a < 0:  # extraction: Danckwerts/Neumann u_0'(r_w) = 0
+                bc_reg, bc_inf = urwp, uiwp
+            else:  # injection: Robin F[u]=u-(G/A_0)u', F[u_0](r_w)=0
+                fac = alpha_l + d_m_eff * r_w / a0_eff  # = G(r_w)/A_0
+                bc_reg, bc_inf = urw - fac * urwp, uiw - fac * uiwp
+            u0w = bc_reg * uiw - bc_inf * urw
+            u0wp = bc_reg * uiwp - bc_inf * urwp
+            n_s = g_well * (u0w * uiwp - u0wp * uiw)
+            u_inf_g, u0_g = [], []
+            for r in r_nodes:
+                ui, _, ur, _ = whittaker_resolvent_solutions(sk, float(r), alpha_l, a0_eff, d_m_eff, sigma_a)
+                u_inf_g.append(ui)
+                u0_g.append(bc_reg * ui - bc_inf * ur)
+            wj = [acb(float(weighted[m].real), float(weighted[m].imag)) for m in range(n)]
+            prefix, acc = [acb(0)] * n, acb(0)
+            for m in range(n):  # inclusive prefix sum_{j<=m} u_0(r_j) w_j
+                acc += u0_g[m] * wj[m]
+                prefix[m] = acc
+            suffix, acc = [acb(0)] * n, acb(0)
+            for m in range(n - 1, -1, -1):  # exclusive suffix sum_{j>m} u_inf(r_j) w_j
+                suffix[m] = acc
+                acc += u_inf_g[m] * wj[m]
+            for i in range(n):
+                f_mat[k, i] = complex(-(u_inf_g[i] * prefix[i] + u0_g[i] * suffix[i]) / n_s)
         return f_mat
 
     out = np.empty(n)
@@ -420,7 +419,7 @@ def gridfree_cout_deviation(
 
     Composes the exact per-phase kernels through the multi-cycle state machine (see the module
     docstring): the Airy branch for ``D_m = 0`` (vectorized, flushed-volume clock) and the Whittaker
-    branch for ``D_m > 0`` (mpmath, wall-clock time -- the volume clock is not autonomous when
+    branch for ``D_m > 0`` (flint/Arb, wall-clock time -- the volume clock is not autonomous when
     ``D_m > 0``). Returns the flow-weighted bin average of the well-face flux concentration deviation
     on extraction bins, ``NaN`` on injection / rest bins.
 

--- a/src/gwtransport/_radial_asr_kernels.py
+++ b/src/gwtransport/_radial_asr_kernels.py
@@ -16,10 +16,12 @@ Two evaluation regimes
   Peclet ``r/alpha_L`` beyond ~200 (the prefactor overflows while ``Ai`` underflows). All transfer
   functions are *ratios* of ``phi_s`` / ``F[phi_s]`` at ``r`` and ``r_w``; evaluating them with the
   Airy scaling factored into a single bounded log-amplitude keeps the ratio finite at any Peclet.
-* ``D_m > 0`` (molecular diffusion present): the confluent-hypergeometric (Whittaker) branch,
-  sampled exactly with ``mpmath.whitw`` at the Laplace nodes. No library provides a vectorized
-  complex double-precision Whittaker, so this path is slower; it is used only where molecular
-  diffusion is appreciable (basis-by-regime -- elsewhere the Airy form is exact to O(D_m/alpha_L|u|)).
+* ``D_m > 0`` (molecular diffusion present): the confluent-hypergeometric (Tricomi-U / Whittaker)
+  branch, sampled exactly with ``flint.acb.hypgeom_u`` (python-flint / Arb compiled arbitrary-precision
+  ball arithmetic) at the Laplace nodes -- exact and ~1e3x faster than mpmath, with a rigorous error
+  enclosure. It is sampled per node (no vectorized complex Whittaker exists) but evaluated only where
+  molecular diffusion is appreciable within the plume and ``A_0/D_m`` is below the tractability cap
+  (basis-by-regime -- elsewhere the Airy form is exact to O(D_m/alpha_L|u|)).
 
 Retardation enters by the standard linear-sorption rescaling of the constant-Q operator: dividing the
 retarded equation ``R d_t C + ... `` by ``R`` is the unretarded equation with ``A_0 -> A_0/R`` and
@@ -32,21 +34,22 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 
 import warnings
 
-import mpmath as mp
 import numpy as np
 import numpy.typing as npt
+from flint import acb, ctx
 from scipy.special import airye, ive, kve
 
-# Working precision (decimal digits) for the mpmath Whittaker (D_m > 0) branch. 30 digits is ample
-# for double-precision output and absorbs the cancellation in the U-function ratios in the
-# physically relevant (appreciable-diffusion) regime.
-_WHITTAKER_DPS = 30
+# Working precision (bits) for the flint (python-flint / Arb) Whittaker (D_m > 0) branch. 512 bits keeps
+# the confluent-hypergeometric values exact (Arb's error ball stays below the double-precision floor) and
+# the divergent-normalization cancellation clean up to A_0/D_m ~ 200. Arb returns a rigorous enclosure, so
+# any precision loss is detectable rather than silent.
+_WHITTAKER_PREC = 512
 
-# Tractability cap for the Whittaker (D_m > 0) branch. Its confluent-hypergeometric parameter is
-# b = 1 +/- A_0/D_m and its argument scales with a* = alpha_L A_0/D_m; for A_0/D_m beyond this the
-# mpmath evaluation (especially the near-well de Hoog nodes) becomes impractically slow. Above the cap
-# the Airy reduction is used with a warning (see _molecular_regime).
-_WHITTAKER_MAX_RATIO = 10.0
+# Tractability cap for the Whittaker (D_m > 0) branch. b = 1 +/- A_0/D_m and the argument scales with
+# a* = alpha_L A_0/D_m; the Arb confluent-hypergeometric evaluation returns non-finite balls once |b| is
+# extreme (A_0/D_m beyond ~250-300, independent of precision). The cap is set safely below that; above it
+# the Airy reduction is used (its O(D_m/alpha_L|u|) error is < 1% there and keeps shrinking with A_0/D_m).
+_WHITTAKER_MAX_RATIO = 150.0
 
 
 def _molecular_regime(molecular_diffusivity: float, a0: float, alpha_l: float, plume_reach: float) -> float:
@@ -60,10 +63,11 @@ def _molecular_regime(molecular_diffusivity: float, a0: float, alpha_l: float, p
       ``< ~4%`` at the boundary ``a* ~ plume_reach``, falling below ``1%`` for ``a* > 4 plume_reach`` and
       to ``~1e-5`` for realistic groundwater ``D_m`` (where ``a*`` is orders of magnitude past the plume).
     * ``a* < plume_reach`` and ``A_0/D_m <= _WHITTAKER_MAX_RATIO`` -- molecular diffusion is appreciable
-      and the Whittaker branch is tractable; keep ``D_m`` (exact, slow).
-    * ``a* < plume_reach`` and ``A_0/D_m > _WHITTAKER_MAX_RATIO`` -- molecular diffusion is appreciable
-      but the large-parameter Whittaker branch is intractable; fall back to the Airy reduction and warn
-      (it neglects an appreciable molecular term -- the relative error grows with ``plume_reach/a*``).
+      within the plume and the flint (Arb) Whittaker branch is exact and tractable; keep ``D_m`` (exact).
+    * ``a* < plume_reach`` and ``A_0/D_m > _WHITTAKER_MAX_RATIO`` -- molecular diffusion is appreciable but
+      the Arb confluent-hypergeometric evaluation returns non-finite balls (``b = 1 - A_0/D_m`` too extreme
+      for the evaluator); fall back to the Airy reduction and warn (relative error grows with
+      ``plume_reach/a*``).
 
     Returns
     -------
@@ -78,10 +82,10 @@ def _molecular_regime(molecular_diffusivity: float, a0: float, alpha_l: float, p
     if a0 / molecular_diffusivity > _WHITTAKER_MAX_RATIO:
         warnings.warn(
             f"Molecular diffusion is appreciable (crossover a*={a_star:.1f} m is within the plume reach "
-            f"{plume_reach:.1f} m) but the exact Whittaker branch is intractable for A_0/D_m="
-            f"{a0 / molecular_diffusivity:.0f} (> {_WHITTAKER_MAX_RATIO:.0f}). Falling back to the Airy "
-            f"reduction, which neglects molecular diffusion; the relative error grows with "
-            f"plume_reach/a* = {plume_reach / a_star:.1f}. Reduce D_m if physically justified.",
+            f"{plume_reach:.1f} m) but the exact flint Whittaker is non-finite for A_0/D_m="
+            f"{a0 / molecular_diffusivity:.0f} (> {_WHITTAKER_MAX_RATIO:.0f}; b too extreme for Arb). "
+            f"Falling back to the Airy reduction, which neglects molecular diffusion; the relative error "
+            f"grows with plume_reach/a* = {plume_reach / a_star:.1f}. Reduce D_m if physically justified.",
             stacklevel=2,
         )
         return 0.0
@@ -139,8 +143,8 @@ def _airy_amplitudes(
 
 def _whittaker_phi_and_flux(
     s: complex, r: float, alpha_l: float, a0_eff: float, d_m_eff: float, sigma_a: int
-) -> tuple[mp.mpc, mp.mpc]:
-    r"""``(phi_s(r), F[phi_s](r))`` for the ``D_m > 0`` branch, in mpmath at scalar ``s``.
+) -> tuple[acb, acb]:
+    r"""``(phi_s(r), F[phi_s](r))`` for the ``D_m > 0`` branch, as flint ``acb`` at scalar ``s``.
 
     With ``x = r + a*``, ``a* = alpha_L A_0/D_m``, ``kappa = sqrt(s/D_m)``, the decaying resident
     solution is ``phi_s = e^{-kappa x} U(a, b, 2 kappa x)`` (Tricomi U -- regular through the
@@ -150,22 +154,27 @@ def _whittaker_phi_and_flux(
     ``F[phi_s] = phi_s - (alpha_L + D_m r/A_0) phi_s'`` is evaluated analytically (no numerical
     differentiation). All quantities use the retardation-effective ``A_0``/``D_m``.
 
+    ``U`` is evaluated with ``flint.acb.hypgeom_u`` (Arb arbitrary-precision ball arithmetic) at
+    ``_WHITTAKER_PREC`` bits. ``phi`` and ``flux`` are returned as ``acb`` (not cast to ``complex``)
+    so the caller can take their ratio -- where the divergent gauge factors cancel -- before rounding.
+
     Returns
     -------
-    phi : mpmath.mpc
+    phi : flint.acb
         Resident solution ``phi_s(r)``.
-    flux : mpmath.mpc
+    flux : flint.acb
         Flux-operator image ``F[phi_s](r)``.
     """
-    kappa = mp.sqrt(s / d_m_eff)
+    ctx.prec = _WHITTAKER_PREC
+    kappa = (acb(s.real, s.imag) / d_m_eff).sqrt()
     astar = alpha_l * a0_eff / d_m_eff
     b = 1 - sigma_a * a0_eff / d_m_eff
     a = b / 2 - kappa * astar / 2
     x = r + astar
     z = 2 * kappa * x
-    u = mp.hyperu(a, b, z)
-    u1 = mp.hyperu(a + 1, b + 1, z)  # U(a+1, b+1, z) for dU/dz = -a U(a+1,b+1,z)
-    expf = mp.e ** (-kappa * x)
+    u = z.hypgeom_u(a, acb(b))
+    u1 = z.hypgeom_u(a + 1, acb(b + 1))  # U(a+1, b+1, z) for dU/dz = -a U(a+1,b+1,z)
+    expf = (-(kappa * x)).exp()
     phi = expf * u
     dphi = -kappa * expf * (u + 2 * a * u1)
     flux = phi - (alpha_l + d_m_eff * r / a0_eff) * dphi
@@ -174,7 +183,7 @@ def _whittaker_phi_and_flux(
 
 def whittaker_resolvent_solutions(
     s: complex, r: float, alpha_l: float, a0_eff: float, d_m_eff: float, sigma_a: int
-) -> tuple[mp.mpc, mp.mpc, mp.mpc, mp.mpc]:
+) -> tuple[acb, acb, acb, acb]:
     r"""Return the two homogeneous solutions and their ``r``-derivatives for the ``D_m > 0`` resolvent.
 
     The constant-Q ODE ``G C'' + (D_m - sigma_A A_0) C' - s r C = 0`` (KB Sec. 4) has, with
@@ -190,29 +199,31 @@ def whittaker_resolvent_solutions(
 
     Returns
     -------
-    tuple of mpmath.mpc
+    tuple of flint.acb
         ``(u_inf, u_inf', u_reg, u_reg')`` -- the decaying and growing solutions and their
-        ``r``-derivatives, at scalar ``s`` and ``r``.
+        ``r``-derivatives, at scalar ``s`` and ``r`` (as ``acb`` so the caller's divergent-normalization
+        cancellation runs in Arb extended precision before rounding).
     """
-    kappa = mp.sqrt(s / d_m_eff)
+    ctx.prec = _WHITTAKER_PREC
+    kappa = (acb(s.real, s.imag) / d_m_eff).sqrt()
     astar = alpha_l * a0_eff / d_m_eff
     b = 1 - sigma_a * a0_eff / d_m_eff
     a = b / 2 - kappa * astar / 2
     x = r + astar
     z = 2 * kappa * x
-    expf = mp.e ** (-kappa * x)
+    expf = (-(kappa * x)).exp()
     # decaying branch (Tricomi U), dU/dz = -a U(a+1, b+1, z)
-    u = mp.hyperu(a, b, z)
-    u1 = mp.hyperu(a + 1, b + 1, z)
+    u = z.hypgeom_u(a, acb(b))
+    u1 = z.hypgeom_u(a + 1, acb(b + 1))
     u_inf = expf * u
     u_inf_p = -kappa * expf * (u + 2 * a * u1)
     # growing branch: z^{c} M(ap, bp, z), c = 1-b, ap = a-b+1, bp = 2-b;
     # d/dz[z^c M] = c z^{c-1} M + z^c (ap/bp) M(ap+1, bp+1)
     c, ap, bp = 1 - b, a - b + 1, 2 - b
-    m = mp.hyp1f1(ap, bp, z)
-    m1 = mp.hyp1f1(ap + 1, bp + 1, z)
-    w_z = z**c * m
-    dw_z = c * z ** (c - 1) * m + z**c * (ap / bp) * m1
+    m = z.hypgeom_1f1(ap, acb(bp))
+    m1 = z.hypgeom_1f1(ap + 1, acb(bp + 1))
+    w_z = z ** acb(c) * m
+    dw_z = c * z ** acb(c - 1) * m + z ** acb(c) * (ap / bp) * m1
     u_reg = expf * w_z
     u_reg_p = -kappa * expf * w_z + expf * dw_z * (2 * kappa)
     return u_inf, u_inf_p, u_reg, u_reg_p
@@ -284,16 +295,16 @@ def transfer_function(
         denom = flux_w if inject == _FLUX else res_w
         return np.exp(log_r - log_w) * (numer / denom)
 
-    # Whittaker branch (D_m > 0): exact mpmath sampling per node (divergent orientation sigma_A = +1).
+    # Whittaker branch (D_m > 0): exact flint (Arb) sampling per node (divergent orientation sigma_A = +1).
+    # phi/flux are returned as acb; the detect/inject ratio cancels the divergent gauge before rounding.
     out = np.empty(s.shape, dtype=complex)
     flat = out.reshape(-1)
-    with mp.workdps(_WHITTAKER_DPS):
-        for i, sv in enumerate(s.reshape(-1)):
-            phi_r, flux_r = _whittaker_phi_and_flux(complex(sv), r, alpha_l, a0_eff, d_m_eff, +1)
-            phi_w, flux_w = _whittaker_phi_and_flux(complex(sv), r_w, alpha_l, a0_eff, d_m_eff, +1)
-            numer = flux_r if detect == _FLUX else phi_r
-            denom = flux_w if inject == _FLUX else phi_w
-            flat[i] = complex(numer / denom)
+    for i, sv in enumerate(s.reshape(-1)):
+        phi_r, flux_r = _whittaker_phi_and_flux(complex(sv), r, alpha_l, a0_eff, d_m_eff, +1)
+        phi_w, flux_w = _whittaker_phi_and_flux(complex(sv), r_w, alpha_l, a0_eff, d_m_eff, +1)
+        numer = flux_r if detect == _FLUX else phi_r
+        denom = flux_w if inject == _FLUX else phi_w
+        flat[i] = complex(numer / denom)
     return out
 
 

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -307,7 +307,7 @@ def infiltration_to_extraction(
     molecular_diffusivity : float, optional
         Molecular diffusivity ``D_m`` [m^2/day]. Default 0. ``D_m > 0`` is carried exactly by the
         Whittaker branch where molecular diffusion is appreciable, and by its exact Airy reduction
-        where it is sub-dominant within the plume (basis-by-regime; the Whittaker path is slow).
+        where it is sub-dominant within the plume (basis-by-regime; the Whittaker branch uses flint/Arb).
     retardation_factor : float, optional
         Linear retardation ``R >= 1``. Default 1.
     weights : array-like, optional

--- a/tests/src/test_radial_asr.py
+++ b/tests/src/test_radial_asr.py
@@ -16,7 +16,7 @@ from _radial_asr_fv_oracle import fv_cout_deviation  # ty: ignore[unresolved-imp
 from scipy.special import erfc
 
 from gwtransport._radial_asr_dehoog import dehoog_inverse
-from gwtransport._radial_asr_kernels import _whittaker_phi_and_flux, transfer_function
+from gwtransport._radial_asr_kernels import transfer_function
 from gwtransport.radial_asr import (
     extraction_to_infiltration,
     gamma_infiltration_to_extraction,
@@ -159,18 +159,29 @@ class TestWhittakerKernel:
             np.testing.assert_allclose(g.real, 1.0, atol=1e-3)
 
     def test_mean_is_v_over_q(self):
+        # Whittaker FF mean = V/Q (KB Sec. 6). Fit the cumulants of an INDEPENDENT mpmath Whittaker
+        # reference (the production kernel is now flint), then confirm the production flint kernel matches
+        # that reference to machine precision -- so the production mean is V/Q too.
         r, r_w, a_l, a0, d_m = 10.0, 0.5, 0.5, 2.0, 0.2  # A0/Dm = 10 (variance exists, fit well-conditioned)
         v_over_q = (r**2 - r_w**2) / (2 * a0)
 
-        def ghat(s):
-            a0e, dme = a0, d_m
-            return (
-                _whittaker_phi_and_flux(s, r, a_l, a0e, dme, +1)[1]
-                / _whittaker_phi_and_flux(s, r_w, a_l, a0e, dme, +1)[1]
-            )
+        def ghat_mp(s):  # independent mpmath Whittaker flux-flux transfer function
+            def flux(rr):
+                kappa = mp.sqrt(mp.mpc(s) / d_m)
+                astar = a_l * a0 / d_m
+                b = 1 - a0 / d_m
+                a = b / 2 - kappa * astar / 2
+                z = 2 * kappa * (rr + astar)
+                u, u1 = mp.hyperu(a, b, z), mp.hyperu(a + 1, b + 1, z)
+                expf = mp.e ** (-kappa * (rr + astar))
+                return expf * u - (a_l + d_m * rr / a0) * (-kappa * expf * (u + 2 * a * u1))
 
-        k1, _, _ = _cumulants_mp(ghat, mp.mpf(v_over_q))
+            return flux(r) / flux(r_w)
+
+        k1, _, _ = _cumulants_mp(ghat_mp, mp.mpf(v_over_q))
         np.testing.assert_allclose(k1, v_over_q, rtol=1e-5)
+        g_prod = transfer_function(s=np.array([0.05 + 0.1j]), r=r, r_w=r_w, alpha_l=a_l, a0=a0, d_m=d_m)[0]
+        np.testing.assert_allclose(g_prod, complex(ghat_mp(0.05 + 0.1j)), rtol=1e-12)
 
     def test_converges_to_airy_first_order(self):
         # |g_Whittaker(D_m) - g_Airy| should fall ~ linearly in D_m (ratio -> 4 under D_m/4). a0 is kept

--- a/tests/src/test_radial_asr_gridfree.py
+++ b/tests/src/test_radial_asr_gridfree.py
@@ -12,10 +12,17 @@ import numpy as np
 import pandas as pd
 import pytest
 from _radial_asr_fv_oracle import fv_cout_deviation  # ty: ignore[unresolved-import]  # tests/src on path via conftest
+from flint import acb
 
 from gwtransport._radial_asr_compose import single_cycle_echo_matrix
 from gwtransport._radial_asr_gridfree import gridfree_cout_deviation
-from gwtransport._radial_asr_kernels import interior_resolvent, rest_resolvent, whittaker_resolvent_solutions
+from gwtransport._radial_asr_kernels import (
+    _WHITTAKER_MAX_RATIO,
+    _molecular_regime,
+    interior_resolvent,
+    rest_resolvent,
+    whittaker_resolvent_solutions,
+)
 from gwtransport.radial_asr import infiltration_to_extraction
 
 
@@ -122,11 +129,10 @@ class TestLaplaceMassBalance:
 class TestWhittakerResolvent:
     """D_m > 0 interior Green's function: SL constancy and the KB Sec. 7 duality.
 
-    ``whittaker_resolvent_solutions`` takes float (double) parameters -- the engine passes doubles --
-    so although it evaluates the confluent-hypergeometric functions in mpmath, the arguments ``a, b, z``
-    are double-precision, and these high-precision identities therefore hold only to the double floor
-    (~1e-13), not mpmath's ~1e-36 (which holds for the underlying math, checked with mpmath parameters
-    during development). The double floor is the honest accuracy of the production function.
+    ``whittaker_resolvent_solutions`` returns flint ``acb`` (Arb) values at ``_WHITTAKER_PREC`` bits. The
+    divergent normalization ``N`` is carried in ``acb`` and only the bounded ratios are cast to double, so
+    these identities hold to the double floor (~1e-13, achieved ~1e-16) -- the honest accuracy of the
+    double-precision production output.
     """
 
     def _greens(self, s, r, rp, r_w, alpha_l, a0, d_m, sigma_a):
@@ -140,7 +146,8 @@ class TestWhittakerResolvent:
         u0 = bc_reg * u_inf - bc_inf * u_reg
         u0p = bc_reg * u_inf_p - bc_inf * u_reg_p
         b = 1 - sigma_a * a0 / d_m
-        n_s = (alpha_l * a0 + d_m * r) ** b * (u0 * u_inf_p - u0p * u_inf)
+        # N carries the divergent G^b gauge -- keep it in acb (cast only the bounded ratios below).
+        n_s = acb(alpha_l * a0 + d_m * r) ** acb(b) * (u0 * u_inf_p - u0p * u_inf)
         ui_rp = whittaker_resolvent_solutions(s, rp, alpha_l, a0, d_m, sigma_a)[0]
         u0_rp = bc_reg * ui_rp - bc_inf * whittaker_resolvent_solutions(s, rp, alpha_l, a0, d_m, sigma_a)[2]
         u0_lt = u0 if r <= rp else u0_rp
@@ -149,28 +156,24 @@ class TestWhittakerResolvent:
 
     @pytest.mark.parametrize("sigma_a", [-1, 1])
     def test_sl_constancy(self, sigma_a):
-        # N(s) = P W is constant in r (SL Abel identity).
+        # N(s) = P W is constant in r (SL Abel identity); the divergent N is compared via bounded ratios.
         a0, d_m, alpha_l, r_w = 2.0, 0.6, 0.5, 0.5
-        ns = [
-            self._greens(mp.mpc("0.1", "0.05"), mp.mpf(r), mp.mpf("3.0"), r_w, alpha_l, a0, d_m, sigma_a)[1]
-            for r in ("1.0", "8.0", "25.0")
-        ]
-        spread = max(abs(n - ns[0]) for n in ns) / abs(ns[0])
-        assert float(spread) < 1e-13  # double-precision floor of the float-parameter resolvent (achieved ~1e-16)
+        ns = [self._greens(0.1 + 0.05j, r, 3.0, r_w, alpha_l, a0, d_m, sigma_a)[1] for r in (1.0, 8.0, 25.0)]
+        spread = max(abs(complex((n - ns[0]) / ns[0])) for n in ns)
+        assert spread < 1e-13  # double-precision floor of the float-parameter resolvent (achieved ~1e-16)
 
     def test_duality_normalization(self):
         # Well-face trace matches the KB Sec. 7 duality cout-readout kernel (pins the normalization).
         a0, d_m, alpha_l, r_w, c_geo = 2.0, 0.6, 0.5, 0.5, np.pi * 10 * 0.3
-        for rp in (mp.mpf("2.0"), mp.mpf("12.0")):
-            s = mp.mpc("0.08", "0.04")
+        for rp in (2.0, 12.0):
+            s = 0.08 + 0.04j
             ghat_wf = self._greens(s, r_w, rp, r_w, alpha_l, a0, d_m, -1)[0]
             w_minus = rp * (alpha_l * a0 + d_m * rp) ** (a0 / d_m)
-            phi, _, _, _phi_p = whittaker_resolvent_solutions(s, rp, alpha_l, a0, d_m, 1)
-            phi_w, phi_w_p, _, _ = whittaker_resolvent_solutions(s, r_w, alpha_l, a0, d_m, 1)
+            phi = whittaker_resolvent_solutions(s, rp, alpha_l, a0, d_m, 1)[0]
+            phi_w, phi_w_p = whittaker_resolvent_solutions(s, r_w, alpha_l, a0, d_m, 1)[:2]
             flux_w = phi_w - (alpha_l + d_m * r_w / a0) * phi_w_p
-            qmag = 2 * c_geo * a0
-            rhs = phi * (2 * c_geo * rp) / (qmag * flux_w)
-            assert float(abs(ghat_wf * w_minus - rhs) / abs(rhs)) < 1e-13  # double-precision floor (achieved ~1e-16)
+            rhs = phi * (2 * c_geo * rp) / (2 * c_geo * a0 * flux_w)
+            assert float(abs(complex(ghat_wf * w_minus - rhs)) / abs(complex(rhs))) < 1e-13
 
 
 # --- engine-level gates -------------------------------------------------------------------------
@@ -293,8 +296,8 @@ class TestGridfreeEngine:
 
 class TestMolecularRegime:
     def test_small_dm_uses_airy_reduction(self):
-        # Negligible molecular diffusion (crossover a* beyond the plume) drops to the exact O(D_m)
-        # Airy reduction: identical to D_m = 0 and fast (the Whittaker branch would be intractable). A
+        # Negligible molecular diffusion (crossover a* far beyond the plume) drops to the exact O(D_m)
+        # Airy reduction: identical to D_m = 0 (the reduction is exact to O(D_m/alpha_L|u|) here). A
         # MULTI-CYCLE schedule routes through the grid-free engine's own dispatch (not the echo path).
         flow = np.array([100.0] * 4 + [-100.0] * 8 + [100.0] * 4 + [-100.0] * 10)
         tedges = pd.date_range("2024-01-01", periods=len(flow) + 1, freq="D")
@@ -311,8 +314,8 @@ class TestMolecularRegime:
         # de-Hoog-inverted Whittaker breakthrough vs the finite-volume oracle (~1% first-order floor).
         # Single cycle: this exercises the Whittaker kernel + FR profile + duality readout end-to-end at
         # O(n_quad) cost. The O(n_quad^2) multi-cycle Whittaker hand-off (_propagate_whittaker) is gated
-        # separately by TestWhittakerResolvent (machine precision) -- a converged multi-cycle Whittaker
-        # vs FV run is ~150 s (mpmath), too slow for the default suite. Still @slow (mpmath, ~30 s).
+        # separately by TestWhittakerResolvent (machine precision). Still @slow (~6 s) -- the flint
+        # confluent-hypergeometric is evaluated per node (a converged multi-cycle Whittaker-vs-FV is ~20 s).
         flow = np.array([100.0] * 3 + [-100.0] * 7)
         dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
         ext = flow < 0
@@ -324,6 +327,35 @@ class TestMolecularRegime:
             cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=d_m, n_cells=600, n_sub=12, **GEOM
         )
         assert np.max(np.abs(gf[ext] - fv[ext])) < 3e-2  # finite-volume first-order floor
+
+    def test_cap_extends_whittaker_to_heat_regime(self):
+        # The flint cap (_WHITTAKER_MAX_RATIO=150) keeps the exact Whittaker kernel for heat-scale A0/D_m
+        # up to 150, where the old mpmath cap (10) dropped molecular diffusion. a* < reach & ratio <= cap
+        # -> keep D_m exact; ratio > cap -> Airy + warn (flint non-finite); a* >= reach -> Airy.
+        a0, alpha_l, reach = 5.3, 0.1, 40.0
+        d_m_heat = a0 / 100.0  # ratio 100 (a* = 5.3 m < reach): dropped at the old cap of 10, now kept
+        assert _WHITTAKER_MAX_RATIO >= 100.0
+        assert _molecular_regime(d_m_heat, a0, alpha_l, reach) == d_m_heat  # exact flint Whittaker kept
+        assert _molecular_regime(0.1, a0, alpha_l, 2.0) == 0.0  # a* >= reach -> Airy (molecular sub-dominant)
+        with pytest.warns(UserWarning, match="non-finite"):
+            assert _molecular_regime(a0 / 300.0, a0, alpha_l, reach) == 0.0  # ratio 300 > cap -> Airy
+
+    @pytest.mark.slow
+    def test_heat_pumping_diffusion_is_modeled(self):
+        # End-to-end Bug-2 fix: at A0/D_m ~ 100 (heat; a* inside the plume) the pumping-phase D_m was a
+        # no-op at the old cap (cout identical to D_m=0); the flint Whittaker kernel now carries it, so
+        # cout depends on D_m. (alpha_l small so a* < plume reach; the FV cross-check is the test above.)
+        geom = {"c_geo": np.pi * 10 * 0.3, "r_w": 0.5, "alpha_l": 0.1}
+        flow = np.array([100.0] * 20 + [-100.0] * 40)
+        dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
+        ext = flow < 0
+        dry = gridfree_cout_deviation(
+            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.0, n_quad=16, **geom
+        )
+        wet = gridfree_cout_deviation(
+            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=5.3 / 100.0, n_quad=16, **geom
+        )
+        assert np.max(np.abs(wet[ext] - dry[ext])) > 1e-2  # pumping molecular diffusion now modeled (was 0)
 
 
 class TestRestDiffusion:
@@ -356,15 +388,17 @@ class TestRestDiffusion:
     def test_rest_makes_engine_sensitive_to_rest_length(self):
         # Before the fix the engine treated rest as identity (cout independent of rest length). Diffusion
         # over a long rest must measurably lower the recovery; this was exactly 0 on the unfixed engine.
+        # D_m = 0.02 keeps pumping in the Airy regime (a* > plume reach), isolating the rest Bessel
+        # propagator (Bug 1) from the pumping Whittaker path -- so this stays fast.
         def recovery(rest):
             flow = np.array([100.0] * 20 + [0.0] * rest + [-50.0] * 40)
             dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
             cout = gridfree_cout_deviation(
-                cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.05, n_quad=120, **GEOM
+                cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.02, n_quad=80, **GEOM
             )
             return np.nansum(cout[flow < 0] * 50.0) / 2000.0
 
-        assert recovery(0) - recovery(180) > 0.05
+        assert recovery(0) - recovery(365) > 0.05
 
     def test_seasonal_rest_matches_fv_oracle(self):
         # Exact end-to-end: inject -> long (200 d) rest -> extract. The rest diffusion (Bessel, exact)


### PR DESCRIPTION
## Summary

Fixes Bug 2 of #276 — exact **pumping-phase** molecular/thermal diffusion. The Whittaker (`D_m>0`) confluent-hypergeometric kernels were evaluated with mpmath, so slow that `_molecular_regime` dropped molecular diffusion during pumping for `A0/D_m > 10` (the Airy reduction), under-dispersing heat / appreciable-`D_m` breakthroughs by up to ~21% in slow-flow regimes.

- Replace mpmath with **python-flint (Arb)** `acb.hypgeom_u` / `hypgeom_1f1` in the Whittaker transfer function, the interior resolvent solutions, and the multi-cycle field-propagation assembly. flint is **exact** (machine precision vs mpmath, rel err 0 at `A0/D_m` 5–150) and **~1000–6000× faster** (~1–6 ms/node, flat), with a rigorous error ball. The divergent normalization (`G^b`, large `b`) is carried in `acb`; only the bounded ratios cast to double.
- Raise `_WHITTAKER_MAX_RATIO` from 10 to **150** (flint is exact to `A0/D_m ~ 200` at 512 bits; beyond ~300 the Arb evaluator is non-finite, so 150 has margin and the Airy reduction < 1% covers larger ratios). The `D_m=0` Airy path is unchanged (Whittaker is singular at `D_m=0`).
- Dependency: `python-flint>=0.8.0` (cp312–cp314 wheels).

## Test plan

`uv run pytest tests/src/test_radial_asr.py tests/src/test_radial_asr_gridfree.py` — **62 passed in ~14 s** (the flint Whittaker tests dropped from minutes to seconds). New: a `_molecular_regime` cap check and an end-to-end heat-regime (`A0/D_m≈100`) `D_m`-sensitivity test; the high-precision Whittaker tests (mean=V/Q, SL-constancy, duality) ported to flint/`acb`. `ruff` + `ty` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
