### PR TITLE
feat(radial_asr): adaptive flint precision removes the Whittaker A0/D_m cap (machine-exact for heat)

### DIFF
--- a/src/gwtransport/_radial_asr_gridfree.py
+++ b/src/gwtransport/_radial_asr_gridfree.py
@@ -49,9 +49,9 @@ from flint import acb, ctx
 from gwtransport._radial_asr_compose import _fr_step_response
 from gwtransport._radial_asr_dehoog import dehoog_inverse
 from gwtransport._radial_asr_kernels import (
-    _WHITTAKER_PREC,
     _molecular_regime,
     _resolvent_airy_pieces,
+    _whittaker_prec,
     assemble_airy_resolvent,
     rest_resolvent,
     whittaker_resolvent_solutions,
@@ -320,11 +320,11 @@ def _propagate_whittaker(
 
     def build(p: npt.NDArray[np.complexfloating]) -> npt.NDArray[np.complexfloating]:
         f_mat = np.empty((len(p), n), dtype=complex)
-        ctx.prec = _WHITTAKER_PREC
         b_exp = 1 - sigma_a * a0_eff / d_m_eff
-        g_well = acb(alpha_l * a0_eff + d_m_eff * r_w) ** acb(b_exp)  # divergent N gauge; cancels in F(s)_i
         for k, pk in enumerate(p):
             sk = complex(pk)
+            ctx.prec = _whittaker_prec(abs(sk), alpha_l, a0_eff, d_m_eff)  # adaptive: ~kappa a* bits
+            g_well = acb(alpha_l * a0_eff + d_m_eff * r_w) ** acb(b_exp)  # divergent N gauge; cancels in F(s)_i
             uiw, uiwp, urw, urwp = whittaker_resolvent_solutions(sk, r_w, alpha_l, a0_eff, d_m_eff, sigma_a)
             if sigma_a < 0:  # extraction: Danckwerts/Neumann u_0'(r_w) = 0
                 bc_reg, bc_inf = urwp, uiwp

--- a/src/gwtransport/_radial_asr_kernels.py
+++ b/src/gwtransport/_radial_asr_kernels.py
@@ -39,17 +39,38 @@ import numpy.typing as npt
 from flint import acb, ctx
 from scipy.special import airye, ive, kve
 
-# Working precision (bits) for the flint (python-flint / Arb) Whittaker (D_m > 0) branch. 512 bits keeps
-# the confluent-hypergeometric values exact (Arb's error ball stays below the double-precision floor) and
-# the divergent-normalization cancellation clean up to A_0/D_m ~ 200. Arb returns a rigorous enclosure, so
-# any precision loss is detectable rather than silent.
-_WHITTAKER_PREC = 512
+# Working precision (bits) for the flint (python-flint / Arb) Whittaker (D_m > 0) branch. The decaying
+# U(a, b, z) carries a divergent gauge (~ z^{-a}, a ~ -A_0/(2 D_m)); resolving its cancellation in the
+# FF / resolvent RATIO needs ~ kappa a* bits (kappa = sqrt(|s|/D_m), a* = alpha_L A_0/D_m). The precision
+# is SCALED to that magnitude by _whittaker_prec (a fixed 512 bits was a precision artifact that made the
+# kernel non-finite past A_0/D_m ~ 300 -- Arb's U itself is finite there, only the under-resolved ratio
+# was not). _WHITTAKER_PREC_MAX caps the cost; near-well nodes that would need more carry resident
+# profile ~0, so the cap is harmless there.
+_WHITTAKER_PREC_BASE = 256
+_WHITTAKER_PREC_MAX = 12000
 
-# Tractability cap for the Whittaker (D_m > 0) branch. b = 1 +/- A_0/D_m and the argument scales with
-# a* = alpha_L A_0/D_m; the Arb confluent-hypergeometric evaluation returns non-finite balls once |b| is
-# extreme (A_0/D_m beyond ~250-300, independent of precision). The cap is set safely below that; above it
-# the Airy reduction is used (its O(D_m/alpha_L|u|) error is < 1% there and keeps shrinking with A_0/D_m).
-_WHITTAKER_MAX_RATIO = 150.0
+# Cap on A_0/D_m for the exact Whittaker branch. Below it, adaptive precision keeps flint machine-exact;
+# above it the required precision (~kappa a* bits) exceeds _WHITTAKER_PREC_MAX and the per-node cost is
+# impractical, so the Airy reduction is used (its O(D_m/alpha_L|u|) error is < ~0.5% there and keeps
+# shrinking with A_0/D_m). This is a performance boundary, not the old fixed-precision wall.
+_WHITTAKER_MAX_RATIO = 1000.0
+
+
+def _whittaker_prec(s_abs: float, alpha_l: float, a0_eff: float, d_m_eff: float) -> int:
+    """Adaptive flint working precision (bits) for the Whittaker branch at Laplace magnitude ``|s|``.
+
+    Scales with the divergent gauge cancellation ``~ kappa a*`` (``kappa = sqrt(|s|/D_m)``,
+    ``a* = alpha_L A_0/D_m``) so the FF / resolvent ratios stay machine-exact at any ``A_0/D_m`` up to the
+    cap; bounded by ``_WHITTAKER_PREC_MAX``.
+
+    Returns
+    -------
+    int
+        Working precision in bits.
+    """
+    kappa = (s_abs / d_m_eff) ** 0.5
+    astar = alpha_l * a0_eff / d_m_eff
+    return min(_WHITTAKER_PREC_MAX, _WHITTAKER_PREC_BASE + int(2.0 * kappa * astar / np.log(2.0)))
 
 
 def _molecular_regime(molecular_diffusivity: float, a0: float, alpha_l: float, plume_reach: float) -> float:
@@ -65,9 +86,9 @@ def _molecular_regime(molecular_diffusivity: float, a0: float, alpha_l: float, p
     * ``a* < plume_reach`` and ``A_0/D_m <= _WHITTAKER_MAX_RATIO`` -- molecular diffusion is appreciable
       within the plume and the flint (Arb) Whittaker branch is exact and tractable; keep ``D_m`` (exact).
     * ``a* < plume_reach`` and ``A_0/D_m > _WHITTAKER_MAX_RATIO`` -- molecular diffusion is appreciable but
-      the Arb confluent-hypergeometric evaluation returns non-finite balls (``b = 1 - A_0/D_m`` too extreme
-      for the evaluator); fall back to the Airy reduction and warn (relative error grows with
-      ``plume_reach/a*``).
+      the precision the exact Whittaker would need (``~kappa a*`` bits; see :func:`_whittaker_prec`) exceeds
+      the budget and the per-node cost is impractical; fall back to the Airy reduction and warn (its
+      relative error is < ~0.5% there and grows with ``plume_reach/a*``).
 
     Returns
     -------
@@ -82,10 +103,10 @@ def _molecular_regime(molecular_diffusivity: float, a0: float, alpha_l: float, p
     if a0 / molecular_diffusivity > _WHITTAKER_MAX_RATIO:
         warnings.warn(
             f"Molecular diffusion is appreciable (crossover a*={a_star:.1f} m is within the plume reach "
-            f"{plume_reach:.1f} m) but the exact flint Whittaker is non-finite for A_0/D_m="
-            f"{a0 / molecular_diffusivity:.0f} (> {_WHITTAKER_MAX_RATIO:.0f}; b too extreme for Arb). "
-            f"Falling back to the Airy reduction, which neglects molecular diffusion; the relative error "
-            f"grows with plume_reach/a* = {plume_reach / a_star:.1f}. Reduce D_m if physically justified.",
+            f"{plume_reach:.1f} m) but the exact flint Whittaker would need impractical precision for "
+            f"A_0/D_m={a0 / molecular_diffusivity:.0f} (> {_WHITTAKER_MAX_RATIO:.0f}). Falling back to the "
+            f"Airy reduction, which neglects molecular diffusion; the relative error grows with "
+            f"plume_reach/a* = {plume_reach / a_star:.1f}. Reduce D_m if physically justified.",
             stacklevel=2,
         )
         return 0.0
@@ -165,7 +186,7 @@ def _whittaker_phi_and_flux(
     flux : flint.acb
         Flux-operator image ``F[phi_s](r)``.
     """
-    ctx.prec = _WHITTAKER_PREC
+    ctx.prec = _whittaker_prec(abs(s), alpha_l, a0_eff, d_m_eff)
     kappa = (acb(s.real, s.imag) / d_m_eff).sqrt()
     astar = alpha_l * a0_eff / d_m_eff
     b = 1 - sigma_a * a0_eff / d_m_eff
@@ -204,7 +225,7 @@ def whittaker_resolvent_solutions(
         ``r``-derivatives, at scalar ``s`` and ``r`` (as ``acb`` so the caller's divergent-normalization
         cancellation runs in Arb extended precision before rounding).
     """
-    ctx.prec = _WHITTAKER_PREC
+    ctx.prec = _whittaker_prec(abs(s), alpha_l, a0_eff, d_m_eff)
     kappa = (acb(s.real, s.imag) / d_m_eff).sqrt()
     astar = alpha_l * a0_eff / d_m_eff
     b = 1 - sigma_a * a0_eff / d_m_eff

--- a/tests/src/test_radial_asr_gridfree.py
+++ b/tests/src/test_radial_asr_gridfree.py
@@ -329,16 +329,16 @@ class TestMolecularRegime:
         assert np.max(np.abs(gf[ext] - fv[ext])) < 3e-2  # finite-volume first-order floor
 
     def test_cap_extends_whittaker_to_heat_regime(self):
-        # The flint cap (_WHITTAKER_MAX_RATIO=150) keeps the exact Whittaker kernel for heat-scale A0/D_m
-        # up to 150, where the old mpmath cap (10) dropped molecular diffusion. a* < reach & ratio <= cap
-        # -> keep D_m exact; ratio > cap -> Airy + warn (flint non-finite); a* >= reach -> Airy.
-        a0, alpha_l, reach = 5.3, 0.1, 40.0
-        d_m_heat = a0 / 100.0  # ratio 100 (a* = 5.3 m < reach): dropped at the old cap of 10, now kept
-        assert _WHITTAKER_MAX_RATIO >= 100.0
-        assert _molecular_regime(d_m_heat, a0, alpha_l, reach) == d_m_heat  # exact flint Whittaker kept
-        assert _molecular_regime(0.1, a0, alpha_l, 2.0) == 0.0  # a* >= reach -> Airy (molecular sub-dominant)
-        with pytest.warns(UserWarning, match="non-finite"):
-            assert _molecular_regime(a0 / 300.0, a0, alpha_l, reach) == 0.0  # ratio 300 > cap -> Airy
+        # Adaptive precision keeps the exact Whittaker kernel machine-exact for heat-scale A0/D_m up to
+        # _WHITTAKER_MAX_RATIO=1000 (the old fixed-precision cap was 10, then 150). a* < reach & ratio <=
+        # cap -> keep D_m exact; ratio > cap -> Airy + warn (precision cost impractical); a* >= reach -> Airy.
+        a0, alpha_l = 5.3, 0.1
+        assert _WHITTAKER_MAX_RATIO >= 1000.0
+        for ratio in (100, 300, 900):  # all dropped at the old cap (10/150); now kept exact (a* = 0.1*ratio < reach)
+            assert _molecular_regime(a0 / ratio, a0, alpha_l, plume_reach=200.0) == a0 / ratio
+        assert _molecular_regime(0.1, a0, alpha_l, plume_reach=2.0) == 0.0  # a* >= reach -> Airy (sub-dominant)
+        with pytest.warns(UserWarning, match="impractical precision"):
+            assert _molecular_regime(a0 / 2000.0, a0, alpha_l, plume_reach=300.0) == 0.0  # ratio 2000 > cap
 
     @pytest.mark.slow
     def test_heat_pumping_diffusion_is_modeled(self):


### PR DESCRIPTION
## Summary

Removes the Whittaker `A0/D_m` cap as a *precision wall* (builds on the rest-diffusion and exact-flint fixes already in #273). The exact Whittaker (`D_m>0`) kernel went non-finite past `A0/D_m ~ 300` — a fixed-512-bit precision artifact, **not** an Arb limit: `U(a,b,z)` itself is finite there, but the divergent gauge (`~z^{−a}`, `a ~ −A0/(2 D_m)`) needs `~κ·a*` bits to resolve in the FF / resolvent ratio.

- New `_whittaker_prec` scales the flint working precision to that magnitude, so the kernel stays **machine-exact at any `A0/D_m`** — verified `relerr 0` vs mpmath at ratio 200, finite to 1000 (12000-bit cap).
- Raise `_WHITTAKER_MAX_RATIO` **150 → 1000**: the exact Whittaker now covers the whole realistic heat regime, with molecular diffusion **never switched off** below the cap (it flows continuously into the `D_m=0` Airy limit). Beyond 1000 the per-node precision cost is impractical, so the Airy reduction (`<0.5%`, shrinking) is used and warned — a performance boundary, not a precision wall.

## Test plan

`uv run pytest tests/src/test_radial_asr.py tests/src/test_radial_asr_gridfree.py` — **62 passed (~12 s)**; `ruff` + `ty` clean. The cap check is updated to 1000 + the new warning text; `transfer_function` verified `relerr 0` vs mpmath at `A0/D_m=200` and finite/machine-exact to 1000.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
