### PR TITLE
fix(lint): narrow ty unresolved-import override to docs/source/conf.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ include = ["tests/notebooks/**/*.ipynb"]
 unresolved-reference = "ignore"
 
 [[tool.ty.overrides]]
-include = ["docs/**"]
+include = ["docs/source/conf.py"]
 
 [tool.ty.overrides.rules]
 # conf.py imports docs-only packages (e.g. jupyterlite_pyodide_kernel) behind a


### PR DESCRIPTION
## Summary

Follow-up to #282. The ty `unresolved-import` override added there matched all of `docs/**`, which is broader than necessary. `docs/source/conf.py` is the only Python file under `docs/` that carries intentionally optional, docs-only imports (e.g. `jupyterlite_pyodide_kernel`, guarded by `try/except`), so the override is now scoped to that exact file. Any genuine unresolved import elsewhere under `docs/` is again caught.

## Test plan

- `ty check . --ignore unused-ignore-comment` against a `--extra test`-only env → All checks passed.
- `validate-pyproject pyproject.toml` → Valid.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.