### PR TITLE
fix(docs): repair interactive JupyterLite examples and theme the buttons

### DIFF
--- a/docs/source/_static/css/try-examples.css
+++ b/docs/source/_static/css/try-examples.css
@@ -1,0 +1,46 @@
+/* jupyterlite-sphinx ships no CSS for the interactive-example buttons
+   (.try_examples_button: "Try it live", "Go Back", "Open In Tab"), so they fall
+   back to raw browser button styling that clashes with the sphinx-book-theme.
+   Style them with the theme's pydata CSS variables so they match the theme and
+   follow light/dark mode automatically. */
+
+.try_examples_button_container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.try_examples_button {
+  display: inline-block;
+  padding: 0.3rem 0.85rem;
+  font-family: var(--pst-font-family-base);
+  font-size: var(--pst-font-size-milli, 0.85rem);
+  font-weight: 600;
+  line-height: 1.5;
+  color: var(--pst-color-primary-text, #fff);
+  background-color: var(--pst-color-primary);
+  border: 1px solid var(--pst-color-primary);
+  border-radius: 0.25rem;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background-color 0.15s ease-in-out,
+    box-shadow 0.15s ease-in-out;
+}
+
+.try_examples_button:hover,
+.try_examples_button:focus {
+  background-color: var(
+    --pst-color-primary-highlight,
+    var(--pst-color-primary)
+  );
+  border-color: var(--pst-color-primary-highlight, var(--pst-color-primary));
+  color: var(--pst-color-primary-highlight-text, #fff);
+  box-shadow: 0 0.125rem 0.35rem rgba(0, 0, 0, 0.25);
+}
+
+.try_examples_button:focus-visible {
+  outline: 2px solid var(--pst-color-accent, currentColor);
+  outline-offset: 2px;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,10 +9,11 @@ from pathlib import Path
 
 import nbformat
 
-try:
-    from jupyterlite_pyodide_kernel.constants import PYODIDE_VERSION
-except ImportError:  # pragma: no cover - fallback if the constant moves upstream
-    PYODIDE_VERSION = "0.27.6"
+# PYODIDE_VERSION tracks the installed (unpinned) jupyterlite-pyodide-kernel; conf.py runs
+# only under sphinx-build with the docs extras, so a direct import is safe and a future
+# upstream rename fails loudly here instead of silently prefetching a stale Pyodide for the
+# CDN prewarm. (ty lints conf.py without the docs extras; see [tool.ty.overrides].)
+from jupyterlite_pyodide_kernel.constants import PYODIDE_VERSION
 
 # nbsphinx-link 1.3.1 imports SafeString/ErrorString from
 # docutils.utils.error_reporting, which was removed in docutils 0.22 (required
@@ -217,6 +218,10 @@ try_examples_preamble = _jupyterlite_install
 pyodide_cdn_base = f"https://cdn.jsdelivr.net/pyodide/v{PYODIDE_VERSION}/full/"
 # Config (generated, sets window.gwtPrewarmConfig) must load before the prefetch logic.
 html_js_files = ["js/pyodide-prewarm-config.js", "js/pyodide-prewarm.js"]
+
+# jupyterlite-sphinx ships no CSS for the interactive-example buttons; this styles
+# them to match the sphinx-book-theme (see _static/css/try-examples.css).
+html_css_files = ["css/try-examples.css"]
 
 # -- Options for nbsphinx ---------------------------------------------------
 nbsphinx_execute = "never"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,20 @@ test = [
   "validate-pyproject[all,store]",
 ]
 docs = [
-  "jupyter",
+  # Do NOT add the "jupyter" metapackage (or "notebook"/"jupyterlab") here. The docs
+  # build does not need the JupyterLab/Notebook apps: nbsphinx renders with
+  # nbsphinx_execute="never", and the in-browser examples use the JupyterLite app
+  # bundled by jupyterlite-core. The hazard: "jupyter lite build" federates EVERY
+  # labextension present in the env, so an externally-installed lab-extension built
+  # against a different JupyterLab than the JupyterLite app (jupyterlite-core and
+  # jupyterlite-pyodide-kernel ship as a version-matched pair providing one JupyterLab
+  # base) can request a shared @jupyterlab/* singleton the app cannot satisfy, breaking
+  # the interactive examples with a module-federation error (RUNTIME-012, "getter for
+  # the shared module is not a function"). That is exactly what "jupyter" caused: it
+  # pulls in notebook, whose @jupyter-notebook/lab-extension targets a newer JupyterLab
+  # than the bundled app. Keeping these apps out of the env avoids it.
   "jupyterlite-core>=0.6",
-  "jupyterlite-pyodide-kernel>=0.6,<0.7",
+  "jupyterlite-pyodide-kernel>=0.6",
   "jupyterlite-sphinx>=0.22",
   "nbsphinx",
   "nbsphinx-link",
@@ -125,8 +136,8 @@ unresolved-reference = "ignore"
 include = ["docs/source/conf.py"]
 
 [tool.ty.overrides.rules]
-# conf.py imports docs-only packages (e.g. jupyterlite_pyodide_kernel) behind a
-# try/except; the linting env installs only --extra test, so they don't resolve.
+# conf.py imports docs-only packages (e.g. jupyterlite_pyodide_kernel); the linting
+# env installs only --extra test, so they don't resolve here.
 unresolved-import = "ignore"
 
 [tool.coverage.report]


### PR DESCRIPTION
## Summary

The in-browser (JupyterLite/Pyodide) interactive examples were broken on the published docs:

- **Module-federation error (the real break):** `Uncaught Error: The getter for the shared module is not a function … #RUNTIME-012 {"shareKey":"@jupyterlab/docregistry"}`. Root cause: the `docs` optional-dependency group pulled the `jupyter` metapackage → `notebook>=7.6` → `jupyterlab 4.6`. `jupyter lite build` federates **every** labextension present in the env, so `@jupyter-notebook/lab-extension` (built against JupyterLab 4.6, requesting a shared `@jupyterlab/docregistry ~4.6.0`) was bundled into the JupyterLite app, which provides the 4.4-based JupyterLab — an unsatisfiable shared singleton. (`uv.lock` is gitignored, so a fresh CI resolution silently upgraded into this once notebook 7.6 / jupyterlab 4.6 released.)
- **`try_examples.json` 404 — not a bug:** jupyterlite-sphinx fetches that file as *optional* runtime config and explicitly treats 404 as "use defaults". Red herring.
- **Buttons clashed with the theme:** jupyterlite-sphinx ships **no** CSS for the `.try_examples_button` chips ("Try it live" / "Go Back" / "Open In Tab"), so they rendered as raw browser buttons.

### Changes

- **Drop the `jupyter` metapackage from the `docs` extra.** The JupyterLab/Notebook apps aren't needed: `nbsphinx_execute="never"` and the examples run on the JupyterLite app bundled by `jupyterlite-core`. This removes the federation-breaking 4.6 extension entirely.
- **Remove the `<0.7` cap on `jupyterlite-pyodide-kernel`** so the lite stack tracks the latest release. Fresh resolution now lands on the **version-matched 0.7 line** (`jupyterlite-core 0.7.6` / `jupyterlite-pyodide-kernel 0.7.2`); core and kernel ship as a matched pair, so the cross-version skew cannot recur from this axis.
- **Add `docs/source/_static/css/try-examples.css`** (registered via `html_css_files`) styling the buttons with the theme's pydata CSS variables, so they match sphinx-book-theme and follow light/dark mode automatically.
- **Read `PYODIDE_VERSION` via a direct import** (dropped the stale `try/except`/`0.27.6` fallback). It tracks the installed (unpinned) kernel; an upstream rename now fails the build loudly instead of silently prefetching a stale Pyodide for the CDN prewarm.

### Accepted risk

With the cap removed and `uv.lock` gitignored, a future `jupyterlite-*` major (0.8+) could resolve fresh on a deploy without an upper bound to freeze it. This is the deliberate "always track latest" choice; the matched core+kernel pair keeps each resolution internally consistent.

## Test plan

- Built the docs locally with the final config — resolves to `jupyterlite-core 0.7.6` / `jupyterlite-pyodide-kernel 0.7.2`, **no** `jupyter`/`notebook`/`jupyterlab` installed; `sphinx-build -b html` exits 0.
- Verified the built JupyterLite app (`docs/build/html/lite/jupyter-lite.json`) federates exactly `@jupyterlite/pyodide-kernel-extension` (the kernel), `jupyterlab-jupytext`, `jupyterlab_pygments` — **`@jupyter-notebook/lab-extension` is gone**. No federated extension declares a strict (`!0`) shared `@jupyterlab/docregistry` singleton, so RUNTIME-012 cannot recur.
- Confirmed the new CSS deploys and links after the theme/jupyterlite CSS (wins equal-specificity ties), all referenced pydata variables exist in both light and dark scopes, and no theme rule out-specifies `.try_examples_button`.
- `ruff format` / `ruff check` clean; `ty check docs/source/conf.py` passes; `validate-pyproject` passes.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.