### PR TITLE
fix(docs): correct interactive docstring examples and notebook launch UX

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,7 +63,12 @@ napoleon_numpy_docstring = True
 napoleon_include_init_with_doc = False
 napoleon_include_private_with_doc = False
 napoleon_include_special_with_doc = True
-napoleon_use_admonition_for_examples = True
+# MUST stay False. With True, napoleon emits ".. admonition:: Examples" and indents the
+# example body 3 spaces; jupyterlite-sphinx's try_examples parser only treats lines that
+# literally start with ">>>" as code, so the indented block collapses into a single inert
+# markdown cell instead of runnable code cells. Rubric output (False) keeps ">>>" at column
+# 0 and converts correctly.
+napoleon_use_admonition_for_examples = False
 napoleon_use_admonition_for_notes = True
 napoleon_use_admonition_for_references = True
 napoleon_use_ivar = False
@@ -205,10 +210,9 @@ jupyterlite_silence = True
 # "Try it live" button on every NumPy-style Examples block.
 global_enable_try_examples = True
 try_examples_global_button_text = "Try it live"
-try_examples_global_warning_text = (
-    "The scientific Python stack (tens of MB) is preloaded in the background while you read; "
-    "the first run may still take a few seconds to finish loading, and is cached afterwards."
-)
+# No warning banner cell at the top of the interactive frame (try_examples_global_warning_text
+# defaults to None -> no banner). The Pyodide stack is still prefetched in the background; see
+# the prewarm config below.
 try_examples_preamble = _jupyterlite_install
 
 # Background preloading: on pages that expose interactive examples, a small generated script
@@ -228,8 +232,10 @@ nbsphinx_execute = "never"
 nbsphinx_allow_errors = True
 nbsphinx_kernel_name = "python3"
 # Jinja2 template (nbsphinx exposes ``env``). Every notebook keeps the location note;
-# the four Pyodide-compatible notebooks additionally get a lazy "Launch interactive
-# notebook" button pointing at their generated _interactive/ copy.
+# the Pyodide-compatible notebooks additionally get a button that opens their generated
+# _interactive/ copy in a new browser tab (`:new_tab:`), rather than embedding a live
+# iframe at the top of the static page. The button reuses jupyterlite-sphinx's
+# `try_examples_button` class, so it matches the "Try it live" docstring buttons.
 nbsphinx_prolog = (
     "{% set nbname = env.docname.split('/')|last %}\n"
     "\n"
@@ -238,8 +244,8 @@ nbsphinx_prolog = (
     "\n"
     "{% if nbname in " + repr(jupyterlite_interactive_notebooks) + " %}\n"
     ".. notebooklite:: /_interactive/{{ nbname }}.ipynb\n"
-    "   :prompt: Launch interactive notebook (runs in your browser)\n"
-    "   :height: 800px\n"
+    "   :new_tab: true\n"
+    "   :new_tab_button_text: Open this notebook live in a new tab\n"
     "{% endif %}\n"
 )
 

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -1270,6 +1270,8 @@ def infiltration_to_extraction_nonlinear_sorption(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         cout, structures = infiltration_to_extraction_nonlinear_sorption(

--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -256,6 +256,8 @@ def compute_breakthrough_curve(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         theta_array = np.linspace(0.0, tracker.state.theta_edges[-1], 1000)
@@ -940,6 +942,8 @@ def compute_domain_mass(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         mass = compute_domain_mass(
@@ -1265,6 +1269,8 @@ def compute_cumulative_inlet_mass(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         mass_in = compute_cumulative_inlet_mass(
@@ -1321,6 +1327,8 @@ def compute_cumulative_outlet_mass(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         mass_out = compute_cumulative_outlet_mass(

--- a/src/gwtransport/fronttracking/plot.py
+++ b/src/gwtransport/fronttracking/plot.py
@@ -150,6 +150,8 @@ def plot_vt_diagram(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         from gwtransport.fronttracking.solver import FrontTracker
@@ -368,6 +370,8 @@ def plot_breakthrough_curve(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         from gwtransport.fronttracking.solver import FrontTracker
@@ -486,6 +490,8 @@ def plot_wave_interactions(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         from gwtransport.fronttracking.solver import FrontTracker

--- a/src/gwtransport/fronttracking/validation.py
+++ b/src/gwtransport/fronttracking/validation.py
@@ -147,6 +147,8 @@ def verify_physics(
 
     Examples
     --------
+    .. disable_try_examples
+
     ::
 
         results = verify_physics(structure, cout, cout_tedges, cin, verbose=False)

--- a/src/gwtransport/percolation.py
+++ b/src/gwtransport/percolation.py
@@ -248,6 +248,8 @@ def root_zone_to_water_table_kinematic_wave(
 
     Examples
     --------
+    .. disable_try_examples
+
     Reproduce a 10-year step-response for the article's soil O05
     (coarse sand, Brooks-Corey)::
 


### PR DESCRIPTION
## Summary

Follow-up to #285. Fixes how the interactive docs present examples.

- **Docstring examples now convert to runnable cells.** `napoleon_use_admonition_for_examples` was `True`, so napoleon emitted `.. admonition:: Examples` and indented the example body 3 spaces. jupyterlite-sphinx's `try_examples` parser only treats lines that *literally* start with `>>>` as code, so every example collapsed into a single inert markdown cell. Flipping to `False` (rubric output) keeps `>>>` at column 0, so the doctest-format examples now split into proper code/markdown cells.
- **Example notebooks open in a new tab.** Replaced the embedded `notebooklite` iframe (a frame at the top of the static page) with `:new_tab: true`, which renders a button that `window.open()`s the full interactive notebook in a new tab. The button reuses jupyterlite-sphinx's `try_examples_button` class, so it matches the docstring "Try it live" buttons styled in #285.
- **Disabled the live button on 10 non-runnable examples.** `advection.py`, `percolation.py`, and `fronttracking/{plot,output,validation}.py` have Examples written as rST `::` literal blocks that reference undefined objects (`tracker`, `sorption`, …) and aren't doctests, so they can't run — the button only produced an inert markdown notebook. Added `.. disable_try_examples` (an rST comment, invisible in rendered docs) so no button appears; the static code block still renders.
- **Removed the warning banner** at the top of the interactive frame (dropped `try_examples_global_warning_text`, which defaults to `None`). The background Pyodide preloading is unchanged.

## Test plan

- `sphinx-build -b html` exits 0; build warnings dropped 170 → 117.
- Generated `try_examples` notebooks: **0 inert/no-code** remain (was 10); a doctest example (`gamma_infiltration_to_extraction`) now yields `['markdown','code','code','markdown','code','markdown','code']`.
- "Try it live" buttons: 53 → 43 (the 10 illustrative examples disabled); the `.. disable_try_examples` marker appears only in `_modules/` "[source]" listings, not in rendered API docs.
- Notebook example pages render `<button class="try_examples_button" onclick="window.open('.../notebooks/index.html?path=<nb>.ipynb')">` and no iframe.
- Warning banner: 0 banner cells in generated notebooks; `pyodide-prewarm.js` still loaded (preloading kept).
- `pytest --doctest-modules` passes on all 5 edited modules; `ruff format`/`ruff check`/`ty check` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.