### PR TITLE
feat(radial_asr): reused-propagator-matrix multi-cycle engine

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -64,6 +64,7 @@ convention = "numpy"
     "DOC201",  # Test functions returning None don't need Returns docs
     "DOC501",  # Test functions don't need Raises docs
     "DOC502",  # Test helpers may document exceptions not directly raised
+    "PLC2701",  # Test code (incl. oracle helpers) may import package internals
 ]
 "src/gwtransport/deposition.py" = [
     "DOC502",  # Public entry points document ValueError; the raises happen inside _validate_deposition_inputs
@@ -93,7 +94,6 @@ convention = "numpy"
     "PLR2004",
     "PLR6301",  # Tests may be grouped in classes for clarity
     "INP001",  # __init__.py is not needed for the test folders
-    "PLC2701",  # Private functions may also be tested
     "RUF002",  # Greek / math unicode in physics-module test docstrings (matches fronttracking source ignore)
     "RUF003",  # Same rationale in comments
 ]

--- a/src/gwtransport/_radial_asr_compose.py
+++ b/src/gwtransport/_radial_asr_compose.py
@@ -38,9 +38,9 @@ import numpy.typing as npt
 from gwtransport._radial_asr_dehoog import dehoog_inverse
 from gwtransport._radial_asr_kernels import transfer_function
 
-# de Hoog series length and the front-anchored scaling margin for the FR step response. The half-period
-# is set per V' to ~ the FR arrival-volume mean (where the breakthrough front sits), which keeps the
-# front well-resolved regardless of how far the corner volumes extend (KB / de Hoog scaling note).
+# Default de Hoog series length and front-anchored scaling margin for the radial-ASR inversions: the FR
+# step response (here) and the field propagators (_radial_asr_reuse) both import these so the two never
+# silently desync on de Hoog resolution.
 _DEHOOG_TERMS = 44
 _SCALE_MARGIN = 1.3
 

--- a/src/gwtransport/_radial_asr_dehoog.py
+++ b/src/gwtransport/_radial_asr_dehoog.py
@@ -55,18 +55,20 @@ def dehoog_inverse(
     alpha: float = 0.0,
     tol: float = 1e-9,
 ) -> npt.NDArray[np.floating]:
-    r"""Invert a single Laplace transform at an array of times via the de Hoog method.
+    r"""Invert a Laplace transform -- optionally a whole batch of them -- at an array of times.
 
     The transform ``f_hat`` is sampled once on ``2 * n_terms + 1`` complex Bromwich nodes; the
-    continued-fraction acceleration and its evaluation are vectorized over ``t``. Only ``t > 0`` is
-    meaningful; ``t <= 0`` returns ``0`` (the inverse of a one-sided transform vanishes for negative
-    time, and the series is undefined at ``t = 0``).
+    continued-fraction acceleration and its evaluation are vectorized over ``t`` and over any trailing
+    batch axes ``f_hat`` carries, so one call inverts every entry of a propagator matrix in a single
+    QD/continued-fraction pass. Only ``t > 0`` is meaningful; ``t <= 0`` returns ``0`` (the inverse of a
+    one-sided transform vanishes for negative time, and the series is undefined at ``t = 0``).
 
     Parameters
     ----------
     f_hat : callable
         Vectorized Laplace transform :math:`\bar f(s)`. Receives a complex ``ndarray`` of shape
-        ``(2 * n_terms + 1,)`` and must return a complex ``ndarray`` of the same shape.
+        ``(2 * n_terms + 1,)`` and returns a complex ``ndarray`` whose leading axis is ``2 * n_terms + 1``,
+        optionally with trailing batch axes (e.g. all ``n_quad**2`` entries of a propagator matrix).
     t : array-like
         Evaluation times (same clock as the inverse, e.g. flushed volume). 1-D or scalar.
     n_terms : int, optional
@@ -86,12 +88,13 @@ def dehoog_inverse(
     Returns
     -------
     ndarray
-        Real inverse ``f(t)``, same shape as ``t`` (0-d input yields a 0-d array).
+        Real inverse ``f(t)``, shape ``t.shape + batch`` where ``batch`` is the trailing shape of
+        ``f_hat``'s output (a scalar ``t`` with no batch yields a 0-d array).
 
     Raises
     ------
     ValueError
-        If ``f_hat`` does not return an array of shape ``(2 * n_terms + 1,)``.
+        If ``f_hat``'s returned array does not have leading axis ``2 * n_terms + 1``.
 
     Notes
     -----
@@ -109,29 +112,39 @@ def dehoog_inverse(
     t_arr = np.asarray(t, dtype=float)
     scalar_input = t_arr.ndim == 0
     t_flat = np.atleast_1d(t_arr)
+    n_t = t_flat.size
 
     m = int(n_terms)
     n_nodes = 2 * m + 1
     t_max = float(np.max(t_flat)) if t_flat.size else 1.0
-    if t_max <= 0.0:
-        # No positive evaluation times: the one-sided inverse is identically zero there.
-        out = np.zeros_like(t_flat)
-        return out.reshape(t_arr.shape) if not scalar_input else out[0]
     big_t = float(scaling) if scaling is not None else 2.0 * t_max
+    if big_t <= 0.0:
+        big_t = 1.0  # all t <= 0: the result is masked to 0 below, this only keeps the nodes finite
     gamma = alpha - np.log(tol) / (2.0 * big_t)
 
-    # Sample the transform on the Bromwich nodes s_k = gamma + i k pi / T, k = 0 .. 2M.
+    # Sample the transform on the Bromwich nodes s_k = gamma + i k pi / T, k = 0 .. 2M. ``f_hat`` may
+    # carry a trailing batch shape; the QD/continued-fraction pass below broadcasts over it, so one call
+    # inverts a whole batch (e.g. every entry of a propagator matrix) at once.
     k = np.arange(n_nodes)
     s = gamma + 1j * k * np.pi / big_t
     a = np.asarray(f_hat(s), dtype=complex)
-    if a.shape != (n_nodes,):
-        msg = f"f_hat must return shape ({n_nodes},), got {a.shape}"
+    if a.shape[0] != n_nodes:
+        msg = f"f_hat must return leading axis {n_nodes}, got {a.shape}"
         raise ValueError(msg)
+    batch = a.shape[1:]
+    nb = len(batch)
+    if t_max <= 0.0:
+        # No positive evaluation times: the one-sided inverse is identically zero there.
+        out = np.zeros((n_t, *batch))
+        if scalar_input:
+            return out[0]
+        return out.reshape(t_arr.shape + batch)
     a = a.copy()
     a[0] *= 0.5
 
-    # Quotient-difference algorithm -> continued-fraction coefficients d[0 .. 2M].
-    d = np.empty(n_nodes, dtype=complex)
+    # Quotient-difference algorithm -> continued-fraction coefficients d[0 .. 2M] (per batch entry; the
+    # rhombus rules slice the leading node axis and broadcast over the trailing batch).
+    d = np.empty((n_nodes, *batch), dtype=complex)
     d[0] = a[0]
     q = a[1:] / a[:-1]  # q_1^{(i)}, length 2M
     d[1] = -q[0]
@@ -143,18 +156,19 @@ def dehoog_inverse(
         e = e[1:-1] + q[1:] - q[:-1]  # e_r^{(i)}, length 2M-2r+1
         d[2 * r] = -e[0]
 
-    # Evaluate the continued fraction at z = exp(i pi t / T), vectorized over t, by the three-term
-    # recurrence A_n = A_{n-1} + d_n z A_{n-2}, B_n = B_{n-1} + d_n z B_{n-2}. The loop stops one
-    # coefficient early (n up to 2M-1) so the de Hoog tail remainder can replace the bare last
-    # coefficient d_{2M} in the final convergent -- the "improved" estimate of the truncated
-    # continued-fraction tail. Keeping the two trailing convergents avoids any division when forming it.
-    z = np.exp(1j * np.pi * t_flat / big_t)
-    a_pp = np.zeros_like(z)  # A_{-1}
-    b_pp = np.ones_like(z)  # B_{-1}
-    a_p = np.full_like(z, d[0])  # A_0
-    b_p = np.ones_like(z)  # B_0
+    # Evaluate the continued fraction at z = exp(i pi t / T) by the three-term recurrence
+    # A_n = A_{n-1} + d_n z A_{n-2}, B_n = B_{n-1} + d_n z B_{n-2}, broadcasting time (leading axis) against
+    # the batch (trailing axes). The loop stops one coefficient early (n up to 2M-1) so the de Hoog tail
+    # remainder can replace the bare last coefficient d_{2M} in the final convergent -- the "improved"
+    # estimate of the truncated tail. Keeping the two trailing convergents avoids any division forming it.
+    time_shape = (n_t, *([1] * nb))  # broadcast the leading time axis against the trailing batch
+    z = np.exp(1j * np.pi * t_flat / big_t).reshape(time_shape)  # (n_t, 1..1)
+    a_pp = np.zeros((n_t, *batch), dtype=complex)  # A_{-1}
+    b_pp = np.ones((n_t, *batch), dtype=complex)  # B_{-1}
+    a_p = np.broadcast_to(d[0], (n_t, *batch)).astype(complex).copy()  # A_0
+    b_p = np.ones((n_t, *batch), dtype=complex)  # B_0
     for n in range(1, n_nodes - 1):
-        dz = d[n] * z
+        dz = d[n] * z  # d[n] (batch) broadcasts against z (time, 1..1) -> (n_t, *batch)
         a_pp, a_p = a_p, a_p + dz * a_pp
         b_pp, b_p = b_p, b_p + dz * b_pp
     # a_p, b_p hold the (2M-1) convergent; a_pp, b_pp the (2M-2) convergent.
@@ -163,6 +177,8 @@ def dehoog_inverse(
     a_final = a_p + rem * a_pp
     b_final = b_p + rem * b_pp
 
-    result = (np.exp(gamma * t_flat) / big_t) * np.real(a_final / b_final)
-    result = np.where(t_flat > 0.0, result, 0.0)
-    return result.reshape(t_arr.shape) if scalar_input else result
+    result = (np.exp(gamma * t_flat).reshape(time_shape) / big_t) * np.real(a_final / b_final)
+    result = np.where(t_flat.reshape(time_shape) > 0.0, result, 0.0)
+    if scalar_input:
+        return result[0]
+    return result.reshape(t_arr.shape + batch)

--- a/src/gwtransport/_radial_asr_reuse.py
+++ b/src/gwtransport/_radial_asr_reuse.py
@@ -1,0 +1,463 @@
+r"""Reused-propagator-matrix acceleration of the multi-cycle radial advection-dispersion engine.
+
+For a signed-flow schedule with ``K`` flow reversals, the per-reversal grid-free composition performs one
+de Hoog inversion of the interior resolvent per intermediate reversal to hand the resident field across
+the reversal -- the ``O(n_quad^2)`` per-reversal
+cost. That hand-off is a *linear* operator on the resident field: the propagated field is
+``f_out(r_i) = L^{-1}_s[ sum_j Ghat(r_i, r_j; s) w(r_j) f(r_j) ](tau)``, i.e. ``f_out = P @ f`` with the
+propagator matrix
+
+``P_{dir,tau}[i, j] = L^{-1}_s[ Ghat(r_i, r_j; s) w_dir(r_j) ](tau)``.
+
+For a schedule with repeated phase volumes (periodic ASR / SWIW) the same ``(direction, tau)`` recurs every
+cycle, so ``P`` is identical across cycles. This module builds each distinct ``P`` *once* (one batched de
+Hoog inversion over all ``n_quad^2`` source/output entries, reusing the exact Airy interior Green's
+function) and reuses it as a bounded matrix-multiply at every reversal -- the special-function + de Hoog
+cost becomes ``O(number of distinct phase volumes)`` instead of ``O(K)``.
+
+The matrix is assembled on the Bromwich contour (``Re s > 0``), where the Airy exponent is growing-real
+and tames the divergent injection gauge ``e^{+r/alpha_L}`` (carried in log space by
+:func:`gwtransport._radial_asr_kernels.assemble_airy_resolvent`), so ``P`` is well-conditioned at any
+Peclet (``|P| ~ O(1)``, the same bounded physical operator the per-reversal engine applies). ``P @ f``
+equals the per-reversal engine's ``_propagate(f)`` to the de Hoog floor; the only difference is the de Hoog
+Pade acceleration's mild nonlinearity (``invert-then-sum`` vs ``sum-then-invert``), which vanishes as the
+de Hoog ``n_terms``/``tol`` tighten.
+
+This file is part of gwtransport which is released under AGPL-3.0 license.
+See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
+"""
+
+import numpy as np
+import numpy.typing as npt
+
+from gwtransport._radial_asr_compose import _fr_step_response
+from gwtransport._radial_asr_dehoog import dehoog_inverse
+from gwtransport._radial_asr_kernels import (
+    _integrate_logderiv,
+    _resolvent_airy_pieces,
+    assemble_airy_resolvent,
+    rest_resolvent,
+)
+
+_INJECTION = "injection"
+
+# de Hoog series length for the field-propagation inversion and the front-anchored scaling margin
+# (matched to the FR step response in _radial_asr_compose).
+_DEHOOG_TERMS = 44
+_SCALE_MARGIN = 1.3
+
+
+def _phase_slices(flow: npt.NDArray[np.floating]) -> list[tuple[int, slice]]:
+    """Group the schedule into maximal one-signed phases.
+
+    Returns
+    -------
+    list of (sign, slice)
+        ``sign`` in ``{+1, -1, 0}`` (injection / extraction / rest) and the contiguous bin slice.
+    """
+    signs = np.sign(flow).astype(int)
+    edges = np.flatnonzero(np.diff(signs) != 0) + 1
+    starts = np.concatenate(([0], edges))
+    stops = np.concatenate((edges, [len(flow)]))
+    return [(int(signs[a]), slice(a, b)) for a, b in zip(starts, stops, strict=True)]
+
+
+def _field_grid(
+    flow: npt.NDArray[np.floating],
+    dt_days: npt.NDArray[np.floating],
+    c_geo: float,
+    r_w: float,
+    alpha_l: float,
+    molecular_diffusivity: float,
+    n_quad: int,
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+    """Radial Gauss-Legendre quadrature grid spanning the plume front plus its dispersive tail.
+
+    The grid is kept **tight**: it covers the advective front radius ``r_front`` (where the plume
+    volume ``V(r) = peak net injected volume``) plus a margin of breakthrough widths (radial std
+    ``~ sqrt(alpha_L r_front)``) and a molecular reach, and no further. An over-extended grid would
+    push the Peclet so high that the divergent (injection) interior Green's function, which grows as
+    ``e^{+r/alpha_L}`` before its ``e^{-r/alpha_L}`` Sturm-Liouville weight tames the product, overflows
+    double precision; the resident profile is ``~0`` beyond the tail anyway (verified by mass
+    conservation). Retardation rescales the clock, not the radius, so it does not enter ``r_max``.
+
+    Returns
+    -------
+    r_nodes : ndarray
+        Radial nodes (m), shape ``(n_quad,)``.
+    v_nodes : ndarray
+        Volume coordinate ``V(r) = c_geo (r^2 - r_w^2)`` at the nodes.
+    dr_weights : ndarray
+        Gauss-Legendre weights in ``r`` (so ``int g dr ~ sum g(r_k) dr_weights_k``).
+    """
+    net_volume = np.concatenate(([0.0], np.cumsum(flow * dt_days)))
+    peak_volume = max(float(net_volume.max()), 0.0)
+    r_front = np.sqrt(r_w**2 + peak_volume / c_geo)  # advective plume-front radius
+    total_time = float(np.sum(dt_days))
+    reach = 12.0 * np.sqrt(alpha_l * r_front + alpha_l**2) + 6.0 * np.sqrt(molecular_diffusivity * total_time)
+    r_max = r_front + reach + r_w
+    nodes, weights = np.polynomial.legendre.leggauss(n_quad)
+    r_nodes = 0.5 * (r_max - r_w) * (nodes + 1.0) + r_w
+    dr_weights = 0.5 * (r_max - r_w) * weights
+    v_nodes = c_geo * (r_nodes**2 - r_w**2)
+    return r_nodes, v_nodes, dr_weights
+
+
+def _airy_propagator_matrix(
+    direction: str,
+    tau: float,
+    r_nodes: npt.NDArray[np.floating],
+    dr_weights: npt.NDArray[np.floating],
+    *,
+    r_w: float,
+    alpha_l: float,
+    c_geo: float,
+    flow_scale: float,
+    n_terms: int,
+    tol: float,
+) -> npt.NDArray[np.floating]:
+    r"""Field-propagator matrix ``P[i, j]`` for one constant-Q phase (``D_m = 0`` Airy branch).
+
+    ``f_out = P @ f`` with ``P[i, j] = L^{-1}_s[ Ghat(r_i, r_j; s) w(r_j) ](tau)`` -- the same Airy interior
+    resolvent and flushed-volume clock as the per-reversal ``_propagate``, assembled for
+    every output/source pair and inverted in a single batched de Hoog pass instead of contracting against a
+    specific field. The Airy pieces are evaluated once on the grid per de Hoog node (as in ``_propagate``)
+    and every output row is assembled by prefix selection (``O(n_quad)`` Airy evaluations).
+
+    The Sturm-Liouville source weight is ``w(r') = (2 c_geo r'/alpha_L) e^{-gauge_sign r'/alpha_L} dr'``
+    (``gauge_sign = +1`` injection / ``-1`` extraction); the flushed-volume clock is set by ``s =
+    flow_scale * p`` with ``a0 = flow_scale/(2 c_geo)`` so ``beta = 2 c_geo p/alpha_L`` is flow-magnitude
+    independent (the autonomy of the S-clock).
+
+    Returns
+    -------
+    ndarray
+        Propagator matrix ``P``, shape ``(n_quad, n_quad)``.
+    """
+    a0 = flow_scale / (2.0 * c_geo)
+    gauge_sign = 1.0 if direction == _INJECTION else -1.0
+    n = r_nodes.size
+    sl_weight = (2.0 * c_geo * r_nodes / alpha_l) * np.exp(-gauge_sign * r_nodes / alpha_l) * dr_weights
+    mu = c_geo * ((float(r_nodes.max()) + alpha_l) ** 2 + alpha_l**2 - r_w**2)
+    scaling = _SCALE_MARGIN * max(mu, tau)
+    below = r_nodes[None, :] < r_nodes[:, None]  # below[i, j] = r_j < r_i
+
+    def f_hat(p: npt.NDArray[np.complexfloating]) -> npt.NDArray[np.complexfloating]:
+        s = (flow_scale * p).reshape(-1, 1)
+        grid_p = _resolvent_airy_pieces(s, r_nodes.reshape(1, -1), alpha_l, a0, gauge_sign)
+        piece_w = _resolvent_airy_pieces(s, np.array([[r_w]]), alpha_l, a0, gauge_sign)
+        ghat = np.empty((p.size, n, n), dtype=complex)
+        for i in range(n):
+            # r_< / r_> selection at output i (the SL kernel is symmetric; radii enter only via r_i + r_j).
+            mask = below[i][None, :]
+            piece_a = {f: np.where(mask, grid_p[f], grid_p[f][:, i : i + 1]) for f in grid_p}
+            piece_b = {f: np.where(mask, grid_p[f][:, i : i + 1], grid_p[f]) for f in grid_p}
+            r_sum = (r_nodes[i] + r_nodes)[None, :]
+            ghat[:, i, :] = assemble_airy_resolvent(piece_a, piece_b, piece_w, r_sum, alpha_l, gauge_sign)
+        ghat *= sl_weight[None, None, :]  # apply the Sturm-Liouville source weight in place (stays complex)
+        return ghat
+
+    return dehoog_inverse(f_hat=f_hat, t=tau, n_terms=n_terms, scaling=scaling, tol=tol)
+
+
+def _riccati_propagator_matrix(
+    direction: str,
+    tau: float,
+    r_nodes: npt.NDArray[np.floating],
+    dr_weights: npt.NDArray[np.floating],
+    *,
+    r_w: float,
+    alpha_l: float,
+    c_geo: float,
+    flow_scale: float,
+    molecular_diffusivity: float,
+    retardation_factor: float,
+    n_terms: int,
+    tol: float,
+) -> npt.NDArray[np.floating]:
+    r"""Field-propagator matrix ``P[i, j]`` for one constant-Q phase (``D_m > 0`` Riccati branch).
+
+    The matrix form of the per-reversal ``_propagate_diffusive``: instead of contracting
+    the interior resolvent against a specific field by the prefix/suffix cumsums of
+    :func:`gwtransport._radial_asr_kernels.resolvent_riccati`, the full Sturm-Liouville Green's function is
+    assembled as the triangular outer product of the field-independent log-derivative integrals,
+
+    ``Ghat(r_i, r_j) w_j = -[exp(J_-(r_i) + J_+(r_j) + LG_j) if j <= i else exp(J_+(r_i) + J_-(r_j) + LG_j)]
+    / (L_-(r_w) - L_+(r_w)) * r_j dr_j``,
+
+    with ``J_-`` / ``J_+`` the inward (decaying) and outward (well-regular) running integrals of the
+    log-derivative (:func:`_integrate_logderiv`) and ``LG_j = b ln(G_j/G_w) - ln G_j`` the divergent gauge
+    carried in log space (``b = 1 - sigma_A A_0/D_m``). Wall-clock time ``tau`` (the volume clock is not
+    autonomous when ``D_m > 0``); retardation rescales ``A_0 -> A_0/R``, ``D_m -> D_m/R``.
+
+    Returns
+    -------
+    ndarray
+        Propagator matrix ``P``, shape ``(n_quad, n_quad)``.
+    """
+    a0_eff = (flow_scale / (2.0 * c_geo)) / retardation_factor
+    d_m_eff = molecular_diffusivity / retardation_factor
+    sigma_a = 1 if direction == _INJECTION else -1
+    n = r_nodes.size
+    mu_t = c_geo * ((float(r_nodes.max()) + alpha_l) ** 2 + alpha_l**2 - r_w**2) / flow_scale
+    scaling = _SCALE_MARGIN * max(mu_t, tau)
+    b = 1.0 - sigma_a * a0_eff / d_m_eff
+    rad = np.concatenate(([r_w], r_nodes))
+    g_nodes = alpha_l * a0_eff + d_m_eff * r_nodes
+    g_w = alpha_l * a0_eff + d_m_eff * r_w
+    lg = b * np.log(g_nodes / g_w) - np.log(g_nodes)  # bounded divergent gauge in log space
+    lp_w = a0_eff / (alpha_l * a0_eff + d_m_eff * r_w) if sigma_a > 0 else 0.0
+    lower = np.tril(np.ones((n, n)))[None]  # lower[i, j] = (j <= i)
+    weight = (r_nodes * dr_weights)[None, None, :]
+
+    def f_hat(s: npt.NDArray[np.complexfloating]) -> npt.NDArray[np.complexfloating]:
+        ld_m, jj_m = _integrate_logderiv(s, rad, r_w, alpha_l, a0_eff, d_m_eff, sigma_a, "decaying")
+        lm_w = ld_m[:, 0]  # L_-(r_w)
+        jm = jj_m[:, 1:]  # int_{r_w}^{r_i} L_-  (n_s, n)
+        _, jp = _integrate_logderiv(s, r_nodes, r_w, alpha_l, a0_eff, d_m_eff, sigma_a, "regular")  # int L_+
+        denom = (lm_w - lp_w)[:, None, None]
+        em_i = np.exp(jm)[:, :, None]
+        ep_jl = np.exp(jp + lg[None, :])[:, None, :]
+        ep_i = np.exp(jp)[:, :, None]
+        em_jl = np.exp(jm + lg[None, :])[:, None, :]
+        return -np.where(lower > 0, em_i * ep_jl, ep_i * em_jl) / denom * weight
+
+    return dehoog_inverse(f_hat=f_hat, t=tau, n_terms=n_terms, scaling=scaling, tol=tol)
+
+
+def _rest_propagator_matrix(
+    tau: float,
+    r_nodes: npt.NDArray[np.floating],
+    dr_weights: npt.NDArray[np.floating],
+    *,
+    r_w: float,
+    d_m_eff: float,
+    n_terms: int,
+    tol: float,
+) -> npt.NDArray[np.floating]:
+    r"""Field-propagator matrix ``P[i, j]`` for a rest (``Q = 0``) phase -- pure molecular diffusion.
+
+    The matrix form of the per-reversal ``_propagate_rest``: the order-0 modified Bessel
+    interior resolvent (:func:`gwtransport._radial_asr_kernels.rest_resolvent`) with the Sturm-Liouville rest
+    measure ``w(r') dr' = (r'/D_m) dr'``, on the wall-clock clock. Retardation enters as ``d_m_eff = D_m/R``.
+
+    Returns
+    -------
+    ndarray
+        Propagator matrix ``P``, shape ``(n_quad, n_quad)``.
+    """
+    n = r_nodes.size
+    scaling = _SCALE_MARGIN * tau
+    weight = (r_nodes / d_m_eff * dr_weights)[None, None, :]
+
+    def f_hat(s: npt.NDArray[np.complexfloating]) -> npt.NDArray[np.complexfloating]:
+        ghat = np.empty((s.size, n, n), dtype=complex)
+        for i in range(n):
+            ghat[:, i, :] = rest_resolvent(s=s, r=float(r_nodes[i]), r_prime=r_nodes, r_w=r_w, d_m=d_m_eff)
+        ghat *= weight
+        return ghat
+
+    return dehoog_inverse(f_hat=f_hat, t=tau, n_terms=n_terms, scaling=scaling, tol=tol)
+
+
+def _fr_source_matrix(
+    v_nodes: npt.NDArray[np.floating], edges: npt.NDArray[np.floating], **readout: float
+) -> npt.NDArray[np.floating]:
+    r"""Injection-source operator ``M[k, j]`` such that ``field_k += sum_j M[k, j] cin_dev_j`` over one phase.
+
+    Matrix form of the per-reversal ``_fr_profile``:
+    ``M[k, j] = G1_FR(S_inj - sigma_j; V'_k) - G1_FR(S_inj - sigma_{j+1}; V'_k)`` (the same FR step response,
+    KB Sec. 10a), built once per distinct injection phase and reused across recurring cycles.
+
+    Returns
+    -------
+    ndarray
+        Source operator, shape ``(n_quad, n_inj_bins)``.
+    """
+    # edges are phase-relative (edges[0] == 0 by caller construction); corners descend to 0 at the phase end
+    inj_corners = edges[-1] - edges  # descending within-phase cumulative volume corners, last is 0
+    g = np.array([_fr_step_response(v, inj_corners, **readout) for v in v_nodes])  # (n_quad, n_bins + 1)
+    return g[:, :-1] - g[:, 1:]
+
+
+def _cout_readout_matrix(
+    v_nodes: npt.NDArray[np.floating],
+    dv_weights: npt.NDArray[np.floating],
+    edges: npt.NDArray[np.floating],
+    **readout: float,
+) -> npt.NDArray[np.floating]:
+    r"""Cout-readout operator ``M[i, k]`` such that ``cout_i = sum_k M[i, k] field_k`` over one phase.
+
+    Matrix form of the per-reversal ``_cout_phase``:
+    ``M[i, k] = R dv_k [G1_FR(T_{i+1}; V'_k) - G1_FR(T_i; V'_k)] / dT_i`` (the KB Sec. 7 duality arrival
+    kernel, same FR step response; the ``R`` amplitude mobilises the sorbed companion), built once per
+    distinct extraction phase and reused.
+
+    Returns
+    -------
+    ndarray
+        Readout operator, shape ``(n_ext_bins, n_quad)``.
+    """
+    # edges are phase-relative (edges[0] == 0 by caller construction)
+    dt = np.diff(edges)
+    g = np.array([_fr_step_response(v, edges, **readout) for v in v_nodes])  # (n_quad, n_bins + 1)
+    diffs = (g[:, 1:] - g[:, :-1]) / dt[None, :]
+    return (readout["retardation_factor"] * dv_weights[:, None] * diffs).T
+
+
+def cout_deviation(
+    *,
+    cin_deviation: npt.NDArray[np.floating],
+    flow: npt.NDArray[np.floating],
+    dt_days: npt.NDArray[np.floating],
+    c_geo: float,
+    r_w: float,
+    alpha_l: float,
+    molecular_diffusivity: float = 0.0,
+    retardation_factor: float = 1.0,
+    n_quad: int = 240,
+    n_terms: int = _DEHOOG_TERMS,
+    tol: float = 1e-9,
+) -> npt.NDArray[np.floating]:
+    r"""Multi-cycle extracted-flux deviation via reused per-phase propagator matrices (any ``D_m``).
+
+    Drop-in for the per-reversal ``gridfree_cout_deviation`` reference: every per-phase linear
+    operator -- the across-reversal field hand-off (``field = P @ field``), the injection source
+    (:func:`_fr_source_matrix`, ``field += M_fr @ cin``), and the cout readout (:func:`_cout_readout_matrix`,
+    ``cout = M_cout @ field``) -- is built once per distinct phase and reused as a matrix-multiply whenever
+    that phase recurs, instead of recomputing the de Hoog inversion / FR step response each cycle. The
+    propagator hand-off uses the Airy branch (:func:`_airy_propagator_matrix`,
+    flushed-volume clock) for ``D_m = 0``, the Riccati branch (:func:`_riccati_propagator_matrix`,
+    wall-clock) for ``D_m > 0``, and the Bessel rest branch (:func:`_rest_propagator_matrix`) for ``Q = 0``
+    phases when ``D_m > 0`` -- so the special-function + de Hoog cost is ``O(number of distinct phases)``
+    rather than ``O(K)`` reversals. Equal to the per-reversal grid-free engine to the de Hoog floor at
+    matched ``n_terms``/``tol``; tighten both for machine precision (the de Hoog Pade nonlinearity, dominant
+    at low Peclet / high retardation).
+
+    Parameters
+    ----------
+    cin_deviation : ndarray, shape (n,)
+        Injected concentration deviation per bin (used on injection bins, ``flow > 0``).
+    flow : ndarray, shape (n,)
+        Signed flow per bin [m^3/day]: ``> 0`` injection, ``< 0`` extraction, ``0`` rest.
+    dt_days : ndarray, shape (n,)
+        Bin widths [day].
+    c_geo : float
+        Geometry constant ``pi b n`` (``V = c_geo (r^2 - r_w^2)``).
+    r_w : float
+        Well radius [m].
+    alpha_l : float
+        Longitudinal dispersivity [m].
+    molecular_diffusivity : float, optional
+        Molecular diffusivity [m^2/day]. ``0`` selects the Airy branch (flushed-volume clock); ``> 0`` the
+        Riccati log-derivative pumping branch and the order-0 Bessel rest branch (both wall-clock). Default 0.
+    retardation_factor : float, optional
+        Linear retardation ``R >= 1`` (rescales the flushed-volume clock). Default 1.
+    n_quad : int, optional
+        Number of radial Gauss-Legendre nodes. Default 240.
+    n_terms : int, optional
+        de Hoog series length for the matrix build. Default ``_DEHOOG_TERMS``.
+    tol : float, optional
+        de Hoog target accuracy for the matrix build. Default ``1e-9``. Tighten (e.g.
+        ``tol=1e-13, n_terms=64``) for machine precision at low Peclet / high retardation.
+
+    Returns
+    -------
+    ndarray, shape (n,)
+        Extracted-flux deviation per bin; ``NaN`` on injection / rest bins.
+    """
+    flow = np.asarray(flow, dtype=float)
+    flushed = np.abs(flow) * dt_days
+    # D_m = 0 keeps the advective grid; D_m > 0 widens it to the molecular reach (the diffusive pumping and
+    # rest kernels both spread beyond the advective front), matching gridfree_cout_deviation.
+    r_nodes, v_nodes, dr_weights = _field_grid(flow, dt_days, c_geo, r_w, alpha_l, molecular_diffusivity, n_quad)
+    dv_weights = 2.0 * c_geo * r_nodes * dr_weights
+
+    phases = _phase_slices(flow)
+    matrices: dict[tuple, npt.NDArray[np.floating]] = {}
+
+    def propagate(field, direction, flow_scale, phase_volume, phase_time):
+        if molecular_diffusivity == 0.0:  # Airy: flushed-volume clock, retardation rescales the clock
+            tau = phase_volume / retardation_factor
+            key = ("airy", direction, round(tau, 9), round(flow_scale, 9))
+            if key not in matrices:
+                matrices[key] = _airy_propagator_matrix(
+                    direction,
+                    tau,
+                    r_nodes,
+                    dr_weights,
+                    r_w=r_w,
+                    alpha_l=alpha_l,
+                    c_geo=c_geo,
+                    flow_scale=flow_scale,
+                    n_terms=n_terms,
+                    tol=tol,
+                )
+            return matrices[key] @ field
+        key = ("riccati", direction, round(phase_time, 9), round(flow_scale, 9))  # D_m > 0: wall-clock time
+        if key not in matrices:
+            matrices[key] = _riccati_propagator_matrix(
+                direction,
+                phase_time,
+                r_nodes,
+                dr_weights,
+                r_w=r_w,
+                alpha_l=alpha_l,
+                c_geo=c_geo,
+                flow_scale=flow_scale,
+                molecular_diffusivity=molecular_diffusivity,
+                retardation_factor=retardation_factor,
+                n_terms=n_terms,
+                tol=tol,
+            )
+        return matrices[key] @ field
+
+    field = np.zeros(n_quad)
+    cout = np.full(len(flow), np.nan)
+    for idx, (sign, sl) in enumerate(phases):
+        phase_volume = float(flushed[sl].sum())
+        if phase_volume == 0.0:  # rest: pure molecular diffusion on the wall-clock clock (D_m = 0 -> identity)
+            if molecular_diffusivity > 0.0:
+                tau = float(np.sum(dt_days[sl]))
+                key = ("rest", round(tau, 9))
+                if key not in matrices:
+                    matrices[key] = _rest_propagator_matrix(
+                        tau,
+                        r_nodes,
+                        dr_weights,
+                        r_w=r_w,
+                        d_m_eff=molecular_diffusivity / retardation_factor,
+                        n_terms=n_terms,
+                        tol=tol,
+                    )
+                field = matrices[key] @ field
+            continue
+        flow_scale = float(np.mean(np.abs(flow[sl])))
+        phase_time = float(np.sum(dt_days[sl]))
+        edges = np.concatenate(([0.0], np.cumsum(flushed[sl])))
+        readout = {
+            "c_geo": c_geo,
+            "r_w": r_w,
+            "alpha_l": alpha_l,
+            "retardation_factor": retardation_factor,
+            "flow_scale": flow_scale,
+            "molecular_diffusivity": molecular_diffusivity,
+        }
+        # The injection-source and cout-readout operators are also linear and phase-structure-determined, so
+        # they are matrix-cached and reused across recurring cycles too (retardation R and D_m are fixed for
+        # the whole call, so the cache key is the within-phase volume edges + the flow scale).
+        ekey = (tuple(np.round(edges, 9)), round(flow_scale, 9))
+        if sign > 0:  # injection: propagate the buffer, then add the new injected resident profile
+            field = propagate(field, _INJECTION, flow_scale, phase_volume, phase_time)
+            mkey = ("fr", *ekey)
+            if mkey not in matrices:
+                matrices[mkey] = _fr_source_matrix(v_nodes, edges, **readout)
+            field += matrices[mkey] @ cin_deviation[sl]
+        else:  # extraction: read cout, then propagate the residual if more pumping follows
+            mkey = ("cout", *ekey)
+            if mkey not in matrices:
+                matrices[mkey] = _cout_readout_matrix(v_nodes, dv_weights, edges, **readout)
+            cout[sl] = matrices[mkey] @ field
+            if idx != len(phases) - 1:
+                field = propagate(field, "extraction", flow_scale, phase_volume, phase_time)
+    return cout

--- a/src/gwtransport/_radial_asr_reuse.py
+++ b/src/gwtransport/_radial_asr_reuse.py
@@ -30,7 +30,7 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 import numpy as np
 import numpy.typing as npt
 
-from gwtransport._radial_asr_compose import _fr_step_response
+from gwtransport._radial_asr_compose import _DEHOOG_TERMS, _SCALE_MARGIN, _fr_step_response
 from gwtransport._radial_asr_dehoog import dehoog_inverse
 from gwtransport._radial_asr_kernels import (
     _integrate_logderiv,
@@ -40,11 +40,6 @@ from gwtransport._radial_asr_kernels import (
 )
 
 _INJECTION = "injection"
-
-# de Hoog series length for the field-propagation inversion and the front-anchored scaling margin
-# (matched to the FR step response in _radial_asr_compose).
-_DEHOOG_TERMS = 44
-_SCALE_MARGIN = 1.3
 
 
 def _phase_slices(flow: npt.NDArray[np.floating]) -> list[tuple[int, slice]]:

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -13,9 +13,13 @@ The forward map is **grid-free** end to end -- no PDE is discretized, so none of
 artefacts appear. A single inject-then-extract cycle with no intervening rest uses the closed-form echo operator
 (``gwtransport._radial_asr_compose``, KB Sec. 10a) -- exact for arbitrary within-phase variable flow,
 with the exact temporal moments. Any other signed-flow schedule (more reversals / multi-cycle ASR, or a
-single cycle with a rest under nonzero ``D_m``) uses the grid-free multi-cycle engine
-(``gwtransport._radial_asr_gridfree``, KB addendum Sec. A1-A4), which composes the exact per-phase
-kernels (Airy / Riccati) through the interior two-point Green's functions. Molecular diffusion during
+single cycle with a rest under nonzero ``D_m``) uses the reused-propagator-matrix engine
+(``gwtransport._radial_asr_reuse``, KB addendum Sec. A1-A7), which composes the exact per-phase kernels
+(Airy / Riccati / Bessel) through the interior two-point Green's functions. Each per-reversal field
+hand-off ``f_out = P @ f`` is a bounded linear operator; its matrix ``P`` is built once per distinct
+``(direction, phase volume)`` from a single batched de Hoog inversion and reused at every recurrence, so
+the special-function + inversion cost is ``O(distinct phase volumes)`` rather than ``O(reversals)``. It is
+bit-equivalent, to the de Hoog floor, to the per-reversal grid-free composition. Molecular diffusion during
 pumping (the ``D_m > 0`` Whittaker kernel) is evaluated through the log-derivative Riccati ODE
 (``gwtransport._radial_asr_kernels.resolvent_riccati``) -- exact to the de Hoog inversion floor at any
 ``A_0/D_m``, with no special-function precision cap, and reducing continuously to the Airy branch as
@@ -24,10 +28,10 @@ diffusion acts alone on the wall-clock clock; it is carried exactly by the order
 pure-diffusion kernel, the dominant mixing for seasonal storage / ATES. The only
 numerical steps are Gauss-Legendre quadrature and de Hoog Laplace inversion of exact special-function
 kernels. An independent finite-volume solve of the same PDE (``tests/src/_radial_asr_fv_oracle.py``,
-KB Sec. 9) is retained only as a test oracle. The spectral-domain acceleration of the multi-cycle
-composition (precomputed connection matrices, KB addendum Sec. A4-A7 "Route B") is a documented future
-optimization, not implemented here. The engine is chosen automatically; cycles are expressed through
-the flow sign pattern, not an argument.
+KB Sec. 9) is used only as a test oracle. The propagator matrices are assembled on the Bromwich
+contour (``Re s > 0``), where the field hand-off is well-conditioned at any Peclet. The engine is chosen
+automatically; cycles are expressed through the flow sign pattern, not
+an argument.
 
 The reported ``cout`` is the flow-weighted average over each output bin -- defined on extraction bins
 (``flow < 0``) and ``NaN`` on injection / rest bins (nothing is recovered there).
@@ -100,7 +104,7 @@ import pandas as pd
 
 from gwtransport import gamma
 from gwtransport._radial_asr_compose import single_cycle_echo_matrix
-from gwtransport._radial_asr_gridfree import gridfree_cout_deviation
+from gwtransport._radial_asr_reuse import cout_deviation
 from gwtransport._time import dt_to_days
 
 
@@ -108,7 +112,7 @@ def _is_single_cycle(flow: npt.NDArray[np.floating]) -> bool:
     """Return True if the schedule is a single injection block followed by a single extraction block.
 
     Such schedules (one flow reversal, injection first) use the exact closed-form echo operator; any
-    other signed-flow pattern (more reversals, extraction first) uses the grid-free multi-cycle engine.
+    other signed-flow pattern (more reversals, extraction first) uses the reused-propagator-matrix engine.
 
     Returns
     -------
@@ -225,7 +229,7 @@ def _echo_operator(
     return w_ens / np.sum(weights), inj_mask, ext_mask
 
 
-def _gridfree_ensemble(
+def _reuse_ensemble(
     cin_deviation: npt.NDArray[np.floating],
     *,
     flow: npt.NDArray[np.floating],
@@ -238,10 +242,11 @@ def _gridfree_ensemble(
     weights: npt.NDArray[np.floating],
     n_quad: int,
 ) -> npt.NDArray[np.floating]:
-    """Weight-averaged multi-cycle grid-free extracted-flux deviation over the streamtubes.
+    """Weight-averaged multi-cycle extracted-flux deviation over the streamtubes.
 
-    Runs the grid-free multi-cycle engine once per streamtube (geometry constant ``c_geo = pi b n``)
-    and averages by ``weights``. Used by the forward (with ``cin``) and the reverse (with unit pulses).
+    Runs the reused-propagator-matrix multi-cycle engine once per streamtube (geometry constant
+    ``c_geo = pi b n``) and averages by ``weights``. Used by the forward (with ``cin``) and the reverse
+    (with unit pulses).
 
     Returns
     -------
@@ -251,7 +256,7 @@ def _gridfree_ensemble(
     acc = np.zeros(len(flow))
     for c_geo, w_i in zip(c_geos, weights, strict=True):
         acc += w_i * np.nan_to_num(
-            gridfree_cout_deviation(
+            cout_deviation(
                 cin_deviation=cin_deviation,
                 flow=flow,
                 dt_days=dt_days,
@@ -345,7 +350,7 @@ def infiltration_to_extraction(
     cout = np.full(len(flow), np.nan)
     # A rest phase combined with molecular diffusion (seasonal storage / ATES) cannot use the
     # flushed-volume echo operator, which is blind to a rest's wall-clock diffusion; route it to the
-    # grid-free engine (which propagates the rest with the Bessel pure-diffusion kernel).
+    # reuse engine (which propagates the rest with the Bessel pure-diffusion kernel).
     use_echo = _is_single_cycle(flow) and not (molecular_diffusivity > 0.0 and np.any(flow == 0.0))
     if use_echo:
         w_ens, inj_mask, ext_mask = _echo_operator(
@@ -362,7 +367,7 @@ def infiltration_to_extraction(
         cout[ext_mask] = background + w_ens @ (cin[inj_mask] - background)
         return cout
     ext_mask = flow < 0.0
-    cout_dev = _gridfree_ensemble(
+    cout_dev = _reuse_ensemble(
         cin - background,
         flow=flow,
         dt_days=dt_to_days(tedges),
@@ -434,7 +439,7 @@ def extraction_to_infiltration(
         weights=None if weights is None else weights_arr,
     )
     c_geos = np.pi * pore_heights * porosity
-    # A rest phase with molecular diffusion routes to the grid-free engine (see the forward function).
+    # A rest phase with molecular diffusion routes to the reuse engine (see the forward function).
     use_echo = _is_single_cycle(flow) and not (molecular_diffusivity > 0.0 and np.any(flow == 0.0))
     if use_echo:
         w_ens, inj_mask, ext_mask = _echo_operator(
@@ -449,7 +454,7 @@ def extraction_to_infiltration(
             n_quad=n_quad,
         )
     else:
-        # Build the dense forward operator W by grid-free unit-pulse columns (one ensemble solve per
+        # Build the dense forward operator W by reuse-engine unit-pulse columns (one ensemble solve per
         # injection bin); the reverse cannot reuse the cheap single-solve forward path.
         inj_mask, ext_mask = flow > 0.0, flow < 0.0
         inj_idx = np.flatnonzero(inj_mask)
@@ -458,7 +463,7 @@ def extraction_to_infiltration(
         for j, idx in enumerate(inj_idx):
             pulse = np.zeros(len(flow))
             pulse[idx] = 1.0
-            col = _gridfree_ensemble(
+            col = _reuse_ensemble(
                 pulse,
                 flow=flow,
                 dt_days=dt_days,
@@ -472,7 +477,7 @@ def extraction_to_infiltration(
             )
             w_ens[:, j] = col[ext_mask]
     # Tikhonov least-squares min ||W x - (cout-bg)||^2 + lambda ||x||^2 via the stable augmented
-    # system [W; sqrt(lambda) I] x = [cout-bg; 0]. The echo / grid-free operator has column sums ~1
+    # system [W; sqrt(lambda) I] x = [cout-bg; 0]. The echo / reuse operator has column sums ~1
     # (mass conservation per injection bin) and overdetermined rows, so a direct Tikhonov fit is used.
     n_inj = w_ens.shape[1]
     augmented = np.vstack([w_ens, np.sqrt(regularization_strength) * np.eye(n_inj)])

--- a/tests/src/_radial_asr_fv_oracle.py
+++ b/tests/src/_radial_asr_fv_oracle.py
@@ -1,9 +1,9 @@
 r"""Independent finite-volume oracle for the radial advection-dispersion engine (tests only).
 
 This is the **test oracle**, not a production engine: an independent PDE discretization used to
-cross-check the grid-free engine (:mod:`gwtransport._radial_asr_gridfree`). It deliberately reintroduces
-discretization choices the grid-free engine avoids, so it carries a first-order (``~1%``, ``O(1/n_cells)``)
-error -- the grid-free engine is the reference, and this solver is expected to *converge to it* under
+cross-check the radial advection-dispersion engine (:mod:`gwtransport._radial_asr_reuse`). It deliberately
+reintroduces discretization choices the grid-free engine avoids, so it carries a first-order (``~1%``,
+``O(1/n_cells)``) error -- the grid-free engine is the reference, and this solver is expected to *converge to it* under
 refinement. It integrates the exact conservative V-coordinate PDE
 
     d_t C + Q d_V C = d_V(D_V d_V C),   D_V = 2 alpha_L |Q| sqrt(pi b n (V+V_w)) + 4 pi b n D_m (V+V_w),

--- a/tests/src/_radial_asr_gridfree_oracle.py
+++ b/tests/src/_radial_asr_gridfree_oracle.py
@@ -1,15 +1,21 @@
-r"""Grid-free multi-cycle / general signed-flow radial advection-dispersion engine (any ``D_m``).
+r"""Per-reversal grid-free radial advection-dispersion reference -- the test oracle for the reuse engine.
 
-This is the exact, mesh-free engine for signed-flow schedules with more than one flow reversal
-(multi-cycle ASR / SWIW). It composes the per-phase closed-form pieces of the radial ASR knowledge
-base (KB Sec. 4-7, addendum Sec. A1-A4) -- no PDE is discretized, so none of the finite-volume
-artefacts (CFL/Courant limit, numerical dispersion, Crank-Nicolson ringing) appear. The only numerical
-operations are Gauss-Legendre quadrature over the resident profile and de Hoog Laplace inversion of the
-exact special-function kernels: the Airy interior Green's functions for ``D_m = 0`` (flushed-volume
-clock, vectorized) and the ``D_m > 0`` molecular-diffusion Green's functions (wall-clock time),
-evaluated through the log-derivative Riccati ODE (:func:`gwtransport._radial_asr_kernels.resolvent_riccati`) -- exact at any ``A_0/D_m``
-with no special-function precision cap. The spectral-domain acceleration of the composition (KB
-addendum Sec. A4-A7) is not implemented here.
+This is the exact, mesh-free per-reversal composition for signed-flow schedules with more than one flow
+reversal (multi-cycle ASR / SWIW): it performs one de Hoog inversion of the interior resolvent at each
+reversal. It composes the per-phase closed-form pieces of the radial ASR knowledge base (KB Sec. 4-7,
+addendum Sec. A1-A4) -- no PDE is discretized, so none of the finite-volume artefacts (CFL/Courant limit,
+numerical dispersion, Crank-Nicolson ringing) appear. The only numerical operations are Gauss-Legendre
+quadrature over the resident profile and de Hoog Laplace inversion of the exact special-function kernels:
+the Airy interior Green's functions for ``D_m = 0`` (flushed-volume clock, vectorized) and the ``D_m > 0``
+molecular-diffusion Green's functions (wall-clock time), evaluated through the log-derivative Riccati ODE
+(:func:`gwtransport._radial_asr_kernels.resolvent_riccati`) -- exact at any ``A_0/D_m`` with no
+special-function precision cap.
+
+The production dispatch (:mod:`gwtransport.radial_asr`) runs the bit-equivalent reused-propagator-matrix
+accelerator (:mod:`gwtransport._radial_asr_reuse`), which caches and reuses each per-reversal field
+propagator as a Bromwich-contour matrix. This per-reversal composition is retained here, in the test suite,
+as the reference oracle that accelerator is validated against (alongside the finite-volume and Whittaker
+oracles), and is not part of the shipped package.
 
 State machine (deviation ``c' = c - c_bg``, initial condition 0)
 ---------------------------------------------------------------
@@ -53,67 +59,7 @@ from gwtransport._radial_asr_kernels import (
     resolvent_riccati,
     rest_resolvent,
 )
-
-# de Hoog series length for the field-propagation inversion and the front-anchored scaling margin
-# (matched to the FR step response in _radial_asr_compose).
-_DEHOOG_TERMS = 44
-_SCALE_MARGIN = 1.3
-
-
-def _phase_slices(flow: npt.NDArray[np.floating]) -> list[tuple[int, slice]]:
-    """Group the schedule into maximal one-signed phases.
-
-    Returns
-    -------
-    list of (sign, slice)
-        ``sign`` in ``{+1, -1, 0}`` (injection / extraction / rest) and the contiguous bin slice.
-    """
-    signs = np.sign(flow).astype(int)
-    edges = np.flatnonzero(np.diff(signs) != 0) + 1
-    starts = np.concatenate(([0], edges))
-    stops = np.concatenate((edges, [len(flow)]))
-    return [(int(signs[a]), slice(a, b)) for a, b in zip(starts, stops, strict=True)]
-
-
-def _field_grid(
-    flow: npt.NDArray[np.floating],
-    dt_days: npt.NDArray[np.floating],
-    c_geo: float,
-    r_w: float,
-    alpha_l: float,
-    molecular_diffusivity: float,
-    n_quad: int,
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    """Radial Gauss-Legendre quadrature grid spanning the plume front plus its dispersive tail.
-
-    The grid is kept **tight**: it covers the advective front radius ``r_front`` (where the plume
-    volume ``V(r) = peak net injected volume``) plus a margin of breakthrough widths (radial std
-    ``~ sqrt(alpha_L r_front)``) and a molecular reach, and no further. An over-extended grid would
-    push the Peclet so high that the divergent (injection) interior Green's function, which grows as
-    ``e^{+r/alpha_L}`` before its ``e^{-r/alpha_L}`` Sturm-Liouville weight tames the product, overflows
-    double precision; the resident profile is ``~0`` beyond the tail anyway (verified by mass
-    conservation). Retardation rescales the clock, not the radius, so it does not enter ``r_max``.
-
-    Returns
-    -------
-    r_nodes : ndarray
-        Radial nodes (m), shape ``(n_quad,)``.
-    v_nodes : ndarray
-        Volume coordinate ``V(r) = c_geo (r^2 - r_w^2)`` at the nodes.
-    dr_weights : ndarray
-        Gauss-Legendre weights in ``r`` (so ``int g dr ~ sum g(r_k) dr_weights_k``).
-    """
-    net_volume = np.concatenate(([0.0], np.cumsum(flow * dt_days)))
-    peak_volume = max(float(net_volume.max()), 0.0)
-    r_front = np.sqrt(r_w**2 + peak_volume / c_geo)  # advective plume-front radius
-    total_time = float(np.sum(dt_days))
-    reach = 12.0 * np.sqrt(alpha_l * r_front + alpha_l**2) + 6.0 * np.sqrt(molecular_diffusivity * total_time)
-    r_max = r_front + reach + r_w
-    nodes, weights = np.polynomial.legendre.leggauss(n_quad)
-    r_nodes = 0.5 * (r_max - r_w) * (nodes + 1.0) + r_w
-    dr_weights = 0.5 * (r_max - r_w) * weights
-    v_nodes = c_geo * (r_nodes**2 - r_w**2)
-    return r_nodes, v_nodes, dr_weights
+from gwtransport._radial_asr_reuse import _DEHOOG_TERMS, _SCALE_MARGIN, _field_grid, _phase_slices
 
 
 def _fr_profile(
@@ -286,14 +232,15 @@ def _propagate_diffusive(
 
     Same superposition as :func:`_propagate` but with the molecular-diffusion interior Green's function
     (KB Sec. 4 ``D_m > 0`` branch) and the wall-clock time clock (the volume clock is not autonomous
-    when ``D_m > 0`` -- the no-go lemma). The Green's function is assembled by :func:`gwtransport._radial_asr_kernels.resolvent_riccati`
-    from the log-derivatives of the decaying and well-regular solutions: every output node is built from
-    prefix/suffix sums of the source superposition
-    ``F(s)_i = -[u_inf(r_i) sum_{j<=i} u_0(r_j) w_j + u_0(r_i) sum_{j>i} u_inf(r_j) w_j]/N(s)`` (the
-    symmetric SL split at ``r_i``), with the divergent ``N = G^b`` gauge carried in log space so the
+    when ``D_m > 0`` -- the no-go lemma). The Green's function is assembled by
+    :func:`gwtransport._radial_asr_kernels.resolvent_riccati` from the log-derivatives of the decaying
+    and well-regular solutions: every output node is built from prefix/suffix sums of the source
+    superposition ``F(s)_i = -[u_inf(r_i) sum_{j<=i} u_0(r_j) w_j + u_0(r_i) sum_{j>i} u_inf(r_j) w_j]/N(s)``
+    (the symmetric SL split at ``r_i``), with the divergent ``N = G^b`` gauge carried in log space so the
     assembly stays in double precision at any ``A_0/D_m`` -- no special-function precision cap.
     ``src_measure_k = w(r_k) dr_weights_k`` with the ``D_m > 0`` weight ``w_pm(r) = r G(r)^{b-1}``
-    (``b = 1 - sigma_A A_0/D_m``, ``G = alpha_L A_0 + D_m r``), built inside :func:`gwtransport._radial_asr_kernels.resolvent_riccati`.
+    (``b = 1 - sigma_A A_0/D_m``, ``G = alpha_L A_0 + D_m r``), built inside
+    :func:`gwtransport._radial_asr_kernels.resolvent_riccati`.
 
     Returns
     -------

--- a/tests/src/_radial_asr_gridfree_oracle.py
+++ b/tests/src/_radial_asr_gridfree_oracle.py
@@ -51,7 +51,7 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 import numpy as np
 import numpy.typing as npt
 
-from gwtransport._radial_asr_compose import _fr_step_response
+from gwtransport._radial_asr_compose import _DEHOOG_TERMS, _SCALE_MARGIN, _fr_step_response
 from gwtransport._radial_asr_dehoog import dehoog_inverse
 from gwtransport._radial_asr_kernels import (
     _resolvent_airy_pieces,
@@ -59,7 +59,7 @@ from gwtransport._radial_asr_kernels import (
     resolvent_riccati,
     rest_resolvent,
 )
-from gwtransport._radial_asr_reuse import _DEHOOG_TERMS, _SCALE_MARGIN, _field_grid, _phase_slices
+from gwtransport._radial_asr_reuse import _field_grid, _phase_slices
 
 
 def _fr_profile(

--- a/tests/src/test_radial_asr.py
+++ b/tests/src/test_radial_asr.py
@@ -17,8 +17,11 @@ from scipy.special import erfc
 
 from gwtransport._radial_asr_dehoog import dehoog_inverse
 from gwtransport._radial_asr_kernels import transfer_function
+from gwtransport._radial_asr_reuse import cout_deviation
+from gwtransport._time import dt_to_days
 from gwtransport.radial_asr import (
     extraction_to_infiltration,
+    gamma_extraction_to_infiltration,
     gamma_infiltration_to_extraction,
     infiltration_to_extraction,
 )
@@ -93,6 +96,34 @@ class TestDeHoog:
         assert np.all(got >= -1e-6)
         assert np.all(got <= 1.0 + 1e-6)
         np.testing.assert_allclose(got, erfc(1.0 / (2.0 * np.sqrt(t))), atol=1e-5)
+
+    def test_batch_axis_equals_scalar_loop(self):
+        # The batch generalization (f_hat may return (n_nodes, *batch)) must invert every batch entry in one
+        # QD/continued-fraction pass identically to a per-entry scalar inversion -- the core contract of the
+        # batched de Hoog the propagator-matrix builders rely on. Pin it both ways: vs the scalar loop
+        # (bit-exact) and vs the analytic sum-of-exponentials.
+        coeffs = np.array([[1.0, 2.0], [0.5, 1.5], [3.0, 0.25]])  # (3, 2)
+        poles = np.array([[0.5, 1.0], [2.0, 0.3], [1.2, 0.8]])
+        t = np.array([0.4, 1.1, 2.7])
+        batched = dehoog_inverse(f_hat=lambda s: coeffs / (s[:, None, None] + poles), t=t, n_terms=32, scaling=6.0)
+        scalar = np.empty((t.size, 3, 2))
+        for a in range(3):
+            for b in range(2):
+                scalar[:, a, b] = dehoog_inverse(
+                    f_hat=lambda s, a=a, b=b: coeffs[a, b] / (s + poles[a, b]), t=t, n_terms=32, scaling=6.0
+                )
+        np.testing.assert_allclose(batched, scalar, rtol=0, atol=0)  # bit-exact vs the per-entry loop
+        analytic = coeffs[None] * np.exp(-poles[None] * t[:, None, None])
+        np.testing.assert_allclose(batched, analytic, atol=1e-5)
+
+    def test_nonpositive_t_returns_zero(self):
+        # de Hoog is defined only for t > 0; the t<=0 guard returns exactly 0 there (keeping the internal
+        # scaling finite) while still inverting the positive entries. Unreachable from the reuse engine
+        # (every phase has tau > 0), but the primitive must stay safe.
+        t = np.array([-1.0, 0.0, 2.0])
+        got = dehoog_inverse(f_hat=lambda s: 1.0 / (s + 1.0), t=t, n_terms=32, scaling=4.0)
+        np.testing.assert_array_equal(got[:2], 0.0)
+        np.testing.assert_allclose(got[2], np.exp(-2.0), atol=1e-5)
 
 
 # --- Airy kernel + KB Sec. 6 moments ------------------------------------------------------------
@@ -335,6 +366,32 @@ class TestGammaWrapper:
         recovered = np.sum(cout[flow < 0] * (-flow[flow < 0]))
         np.testing.assert_allclose(recovered, np.sum(cin[flow > 0] * flow[flow > 0]), rtol=1e-2)
 
+    @pytest.mark.slow
+    def test_gamma_multi_cycle_round_trip(self):
+        # Both gamma (screen-velocity ensemble) wrappers on a MULTI-CYCLE schedule, so they route through the
+        # reuse engine: the forward as a weighted streamtube ensemble, the reverse as the dense ensemble
+        # round-trip. (Single-cycle gamma uses the echo operator; only multi-cycle exercises the reuse path.)
+        flow = np.array([100.0] * 4 + [-100.0] * 6 + [100.0] * 4 + [-100.0] * 8)
+        tedges = pd.date_range("2024-01-01", periods=len(flow) + 1, freq="D")
+        cin = np.where(flow > 0, 1.0, 0.0)
+        gargs = {
+            "porosity": 0.3,
+            "well_radius": 0.5,
+            "longitudinal_dispersivity": 0.5,
+            "screen_height": 10.0,
+            "velocity_cv": 0.3,
+            "n_bins": 6,
+            "n_quad": 60,
+        }
+        cout = gamma_infiltration_to_extraction(cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **gargs)
+        recovered = np.sum(cout[flow < 0] * (-flow[flow < 0])) / np.sum(cin[flow > 0] * flow[flow > 0])
+        assert 0.9 < recovered <= 1.0 + 1e-3
+        rec = gamma_extraction_to_infiltration(
+            cout=cout, flow=flow, tedges=tedges, cout_tedges=tedges, regularization_strength=1e-6, **gargs
+        )
+        np.testing.assert_array_equal(np.isnan(rec), flow <= 0.0)
+        np.testing.assert_allclose(rec[flow > 0], cin[flow > 0], atol=5e-3)
+
 
 class TestValidation:
     def test_bad_lengths_raise(self):
@@ -364,7 +421,8 @@ class TestValidation:
 
 
 class TestGeneralEngine:
-    """Multi-cycle and D_m>0 route to the implicit finite-volume solve of the exact PDE (KB Sec. 9)."""
+    """Multi-cycle schedules route to the reused-propagator-matrix engine; an independent finite-volume
+    solve of the exact PDE (KB Sec. 9) is the cross-check oracle."""
 
     def test_fv_matches_analytic_single_cycle(self):
         # Independent engines: finite-volume discretizes the PDE, the analytic path inverts the Laplace kernel.
@@ -423,8 +481,9 @@ class TestGeneralEngine:
 
     @pytest.mark.slow
     def test_dm_positive_forward_conserves(self):
-        # @slow: D_m>0 multi-cycle now runs the per-node Riccati ODE. The conservation assertion is
-        # n_quad-insensitive (verified identical at n_quad 8/16/120), so n_quad=16 suffices.
+        # Single inject->extract cycle (no rest) with D_m>0 routes to the closed-form echo operator; this
+        # checks that path conserves mass under molecular diffusion. The multi-cycle reuse-engine D_m>0 path
+        # is covered by test_dm_positive_multi_cycle_round_trip. n_quad-insensitive (verified 8/16/120).
         tedges, flow, geom = _scenario()
         cin = np.where(flow > 0, 1.0, 0.0)
         cout = infiltration_to_extraction(
@@ -444,3 +503,56 @@ class TestGeneralEngine:
         )
         np.testing.assert_array_equal(np.isnan(rec), flow <= 0.0)
         np.testing.assert_allclose(rec[flow > 0], cin[flow > 0], atol=5e-3)
+
+    @pytest.mark.slow
+    def test_dm_positive_multi_cycle_round_trip(self):
+        # D_m>0 forward AND reverse through the reuse engine's Riccati branch on a multi-cycle schedule. The
+        # public single-cycle D_m>0 path routes to the echo operator, so only a multi-cycle schedule drives
+        # the Riccati propagator matrices (forward) and the dense-column ensemble reverse. @slow: the per-node
+        # Riccati ODE dominates and the reverse rebuilds it per injection column, so the schedule and n_quad
+        # are kept minimal (two single-injection cycles -> a 2-column dense reverse).
+        flow = np.array([100.0] * 1 + [-100.0] * 2 + [100.0] * 1 + [-100.0] * 2)
+        tedges = pd.date_range("2024-01-01", periods=len(flow) + 1, freq="D")
+        cin = np.where(flow > 0, 1.0, 0.0)
+        geom = {"pore_heights": 10.0, "porosity": 0.3, "well_radius": 0.5, "longitudinal_dispersivity": 0.5}
+        cout = infiltration_to_extraction(
+            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, molecular_diffusivity=0.05, n_quad=10
+        )
+        rec = extraction_to_infiltration(
+            cout=cout,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            **geom,
+            molecular_diffusivity=0.05,
+            regularization_strength=1e-6,
+            n_quad=10,
+        )
+        np.testing.assert_array_equal(np.isnan(rec), flow <= 0.0)
+        np.testing.assert_allclose(rec[flow > 0], cin[flow > 0], atol=2e-3)
+
+    @pytest.mark.slow
+    def test_single_cycle_rest_dm_routes_to_reuse_engine(self):
+        # A single inject->rest->extract cycle under D_m>0 must NOT use the rest-blind echo operator: the
+        # dispatch carve-out routes it to the reuse engine (Bessel rest branch). Pin the routing by matching
+        # the public result to a direct single-streamtube engine call -- they agree to machine precision iff
+        # the public dispatch routed there (the echo operator would drop the rest-phase diffusion entirely).
+        flow = np.array([100.0] * 4 + [0.0] * 3 + [-100.0] * 4)
+        tedges = pd.date_range("2024-01-01", periods=len(flow) + 1, freq="D")
+        cin = np.where(flow > 0, 1.0, 0.0)
+        geom = {"pore_heights": 10.0, "porosity": 0.3, "well_radius": 0.5, "longitudinal_dispersivity": 0.5}
+        pub = infiltration_to_extraction(
+            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, molecular_diffusivity=1.0, n_quad=24
+        )
+        eng = cout_deviation(
+            cin_deviation=cin,
+            flow=flow,
+            dt_days=dt_to_days(tedges),
+            c_geo=np.pi * geom["pore_heights"] * geom["porosity"],
+            r_w=geom["well_radius"],
+            alpha_l=geom["longitudinal_dispersivity"],
+            molecular_diffusivity=1.0,
+            n_quad=24,
+        )
+        ext = flow < 0
+        np.testing.assert_allclose(pub[ext], eng[ext], rtol=1e-12, atol=1e-12)

--- a/tests/src/test_radial_asr_gridfree.py
+++ b/tests/src/test_radial_asr_gridfree.py
@@ -7,11 +7,21 @@ so grid-free-vs-finite-volume agreement is ~1% and the finite-volume solve is sh
 the grid-free reference -- the grid-free engine is the reference, not finite-volume.
 """
 
+import contextlib
+
 import mpmath as mp
 import numpy as np
 import pandas as pd
 import pytest
 from _radial_asr_fv_oracle import fv_cout_deviation  # ty: ignore[unresolved-import]  # tests/src on path via conftest
+from _radial_asr_gridfree_oracle import (  # ty: ignore[unresolved-import]  # per-reversal reference, tests/src on path
+    _cout_phase,
+    _fr_profile,
+    _propagate,
+    _propagate_diffusive,
+    _propagate_rest,
+    gridfree_cout_deviation,
+)
 from _radial_asr_whittaker_oracle import (  # ty: ignore[unresolved-import]  # flint oracle, tests/src on path
     resolvent_oracle,
     transfer_function_oracle,
@@ -20,12 +30,20 @@ from _radial_asr_whittaker_oracle import (  # ty: ignore[unresolved-import]  # f
 from flint import acb  # ty: ignore[unresolved-import]  # python-flint is a test-only dependency
 
 from gwtransport._radial_asr_compose import single_cycle_echo_matrix
-from gwtransport._radial_asr_gridfree import gridfree_cout_deviation
 from gwtransport._radial_asr_kernels import (
     _transfer_riccati,
     interior_resolvent,
     resolvent_riccati,
     rest_resolvent,
+)
+from gwtransport._radial_asr_reuse import (
+    _airy_propagator_matrix,
+    _cout_readout_matrix,
+    _field_grid,
+    _fr_source_matrix,
+    _rest_propagator_matrix,
+    _riccati_propagator_matrix,
+    cout_deviation,
 )
 from gwtransport.radial_asr import infiltration_to_extraction
 
@@ -369,7 +387,7 @@ class TestGridfreeEngine:
         )
         manual = np.mean(
             [
-                gridfree_cout_deviation(
+                cout_deviation(
                     cin_deviation=cin,
                     flow=flow,
                     dt_days=np.ones(len(flow)),
@@ -382,7 +400,267 @@ class TestGridfreeEngine:
             ],
             axis=0,
         )
+        # The ensemble is a pure weighted average of the per-disk engine (no new inversion), so it equals
+        # the manual mean of the same production engine (cout_deviation) to machine precision.
         np.testing.assert_allclose(ens[ext], manual, rtol=1e-12)
+
+
+@contextlib.contextmanager
+def _tight_dehoog():
+    """Force the per-reversal field-propagation de Hoog (oracle namespace) to (64, 1e-13).
+
+    Patches only the public ``dehoog_inverse`` the per-reversal ``_propagate*`` use, forcing tight terms
+    regardless of the passed ``n_terms``/``tol``, so the per-reversal engine matches a matrix builder /
+    ``cout_deviation`` run at ``n_terms=64, tol=1e-13`` -- the two then agree to the genuine de Hoog floor
+    (no Pade-nonlinearity gap), the matched-settings machine-precision contract.
+    """
+    import _radial_asr_gridfree_oracle as _ga  # ty: ignore[unresolved-import]  # noqa: PLC0415 -- tests/src on path
+
+    import gwtransport._radial_asr_dehoog as _dh  # noqa: PLC0415
+
+    orig_inv = _ga.dehoog_inverse
+
+    def tight_inv(*, f_hat, t, n_terms=64, scaling=None, alpha=0.0, tol=1e-13):  # noqa: ARG001 -- force tight terms
+        return _dh.dehoog_inverse(f_hat=f_hat, t=t, n_terms=64, scaling=scaling, alpha=alpha, tol=1e-13)
+
+    _ga.dehoog_inverse = tight_inv
+    try:
+        yield
+    finally:
+        _ga.dehoog_inverse = orig_inv
+
+
+def _gridfree_tight(**kw):
+    """``gridfree_cout_deviation`` with its field-propagation de Hoog forced to (64, 1e-13)."""
+    with _tight_dehoog():
+        return gridfree_cout_deviation(**kw)
+
+
+class TestReuseEngine:
+    """The reused-propagator-matrix engine (``cout_deviation``) reproduces the per-reversal grid-free engine
+    (``gridfree_cout_deviation``) by caching each phase's field-propagator as a matrix and reusing it. The
+    load-bearing identity is that each matrix COLUMN is exactly the per-reversal ``_propagate`` of a unit
+    source -- the same single de Hoog inversion of the same kernel -- so the matrix *is* the per-reversal
+    operator (bit-exact, independent of Peclet). End-to-end, ``P @ field`` then equals the per-reversal
+    ``_propagate(field)`` to the de Hoog floor (the only gap is the Pade acceleration's mild nonlinearity,
+    ``invert-then-sum`` vs ``sum-then-invert``, which tightens with ``n_terms``/``tol`` and is never an
+    accuracy regression)."""
+
+    def test_single_cycle_is_exact(self):
+        # K=1 never invokes the propagator (inject builds the field, extract reads it -- no inter-phase
+        # hand-off), so the reuse engine equals the per-reversal engine to machine precision: the readout is
+        # the same FR step response applied as M_cout @ field (a matrix-multiply) rather than a loop sum, so
+        # it agrees up to the BLAS-vs-loop summation order (~1e-15), not via a fresh de Hoog inversion.
+        flow, dt, cin = _scenario(8, 24)
+        gf = gridfree_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_quad=120, **GEOM)
+        re = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_quad=120, **GEOM)
+        np.testing.assert_allclose(re, gf, rtol=1e-13, atol=1e-14, equal_nan=True)
+
+    def test_readout_matrices_match_loops(self):
+        # The injection-source M_fr (cin->field) and cout-readout M_cout (field->cout) operators reproduce the
+        # per-phase _fr_profile / _cout_phase loops they replace, to machine precision -- the same FR step
+        # response applied as a matrix-multiply rather than a loop sum. This pins the readout-matrix reuse
+        # directly, independent of how a schedule composes phases.
+        flow, dt = np.array([100.0] * 4 + [-100.0] * 4), np.ones(8)
+        r_nodes, v_nodes, dr = _field_grid(flow, dt, CG, 0.5, 0.5, 0.0, 60)
+        dv = 2.0 * CG * r_nodes * dr
+        ro = {
+            "c_geo": CG,
+            "r_w": 0.5,
+            "alpha_l": 0.5,
+            "retardation_factor": 1.0,
+            "flow_scale": 100.0,
+            "molecular_diffusivity": 0.0,
+        }
+        edges = np.array([0.0, 100.0, 200.0, 300.0, 400.0])  # 4 within-phase volume bins
+        cin = np.array([1.0, -0.5, 0.3, 0.8])
+        field = np.random.default_rng(0).standard_normal(60)
+        m_fr = _fr_source_matrix(v_nodes, edges, **ro)
+        np.testing.assert_allclose(m_fr @ cin, _fr_profile(v_nodes, cin, edges, **ro), atol=1e-14, rtol=1e-12)
+        m_cout = _cout_readout_matrix(v_nodes, dv, edges, **ro)
+        np.testing.assert_allclose(m_cout @ field, _cout_phase(field, v_nodes, dv, edges, **ro), atol=1e-13, rtol=1e-11)
+
+    @pytest.mark.parametrize("direction", ["injection", "extraction"])
+    def test_airy_matrix_is_per_reversal_operator(self, direction):
+        # THE correctness identity (D_m=0): each cached-matrix column equals the per-reversal _propagate of a
+        # unit source at that node -- the same single de Hoog inversion of the same Airy kernel. Bit-exact,
+        # Peclet-independent (the matrix IS the operator; end-to-end gaps are only the de Hoog nonlinearity).
+        flow, dt = np.array([100.0] * 4 + [-100.0] * 4), np.ones(8)
+        r_nodes, _, dr = _field_grid(flow, dt, CG, 0.5, 0.5, 0.0, 60)
+        tau, flow_scale = 400.0, 100.0  # flushed-volume tau = phase_volume
+        gauge = -1.0 if direction == "injection" else 1.0
+        sl = (2.0 * CG * r_nodes / 0.5) * np.exp(gauge * r_nodes / 0.5) * dr
+        pmat = _airy_propagator_matrix(
+            direction, tau, r_nodes, dr, r_w=0.5, alpha_l=0.5, c_geo=CG, flow_scale=flow_scale, n_terms=44, tol=1e-9
+        )
+        for j in (5, 30, 55):
+            e = np.zeros(60)
+            e[j] = 1.0
+            col = _propagate(e, r_nodes, sl, direction, tau, r_w=0.5, alpha_l=0.5, flow_scale=flow_scale, c_geo=CG)
+            # Bit-identical: the matrix column and _propagate of a unit source feed the SAME Ghat*sl input
+            # (the one-hot contraction adds only zeros, exact in IEEE) through the SAME de Hoog code.
+            np.testing.assert_array_equal(pmat[:, j], col)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(("direction", "r_fac"), [("injection", 1.0), ("extraction", 1.0), ("extraction", 2.0)])
+    def test_riccati_matrix_is_per_reversal_operator(self, direction, r_fac):
+        # D_m>0 correctness identity: each Riccati matrix column equals the per-reversal _propagate_diffusive
+        # of a unit source. This per-column anchor is REQUIRED -- the end-to-end differential is sign-blind
+        # (injection/extraction propagations pair per cycle, so an overall sign flip cancels). The outer-product
+        # vs resolvent_riccati cumsum reorder differs at ~1e-15, amplified by the de Hoog condition (~1e8) to
+        # ~1e-7 at matched-tight settings, so a sign or structural error (col_err ~ |col|) is caught with a
+        # ~1e5 margin below.
+        flow, dt = np.array([100.0] * 4 + [-100.0] * 4), np.ones(8)
+        r_nodes, _, dr = _field_grid(flow, dt, CG, 0.5, 0.5, 1.0, 24)
+        tau, flow_scale = 4.0, 100.0  # wall-clock tau = phase_time
+        pmat = _riccati_propagator_matrix(
+            direction,
+            tau,
+            r_nodes,
+            dr,
+            r_w=0.5,
+            alpha_l=0.5,
+            c_geo=CG,
+            flow_scale=flow_scale,
+            molecular_diffusivity=1.0,
+            retardation_factor=r_fac,
+            n_terms=64,
+            tol=1e-13,
+        )
+        for j in (3, 12, 21):
+            e = np.zeros(24)
+            e[j] = 1.0
+            with _tight_dehoog():  # match _propagate_diffusive's de Hoog to the matrix's (64, 1e-13)
+                col = _propagate_diffusive(
+                    e,
+                    r_nodes,
+                    dr,
+                    direction,
+                    tau,
+                    r_w=0.5,
+                    alpha_l=0.5,
+                    flow_scale=flow_scale,
+                    c_geo=CG,
+                    molecular_diffusivity=1.0,
+                    retardation_factor=r_fac,
+                )
+            np.testing.assert_allclose(pmat[:, j], col, atol=1e-6, rtol=1e-5)
+
+    @pytest.mark.parametrize(
+        ("alpha_l", "r_fac"),
+        [(0.25, 1.0), (0.5, 1.0), (1.0, 1.0), (0.5, 2.0)],  # front-Peclet ~45 / 22 / 11; last adds D_m=0 R>1
+    )
+    def test_matches_per_reversal(self, alpha_l, r_fac):
+        # D_m=0 multi-cycle end-to-end correctness anchor. At MATCHED-TIGHT de Hoog the reuse engine equals the
+        # per-reversal engine to the shared-code floor; the only residual is the Pade nonlinearity of the
+        # intermediate field hand-offs (invert-then-sum P@field vs sum-then-invert _propagate), which closes as
+        # n_terms tightens and is Peclet-dependent (~1e-11 at Pe~45 down to ~5e-8 at Pe~11). R>1 exercises the
+        # Airy tau=V/R clock rescale and the M_cout xR readout. (The column-identity test pins each matrix
+        # bit-exactly; this gate adds caching + composition. The shipped-settings gap is the same Pade residual,
+        # below the de Hoog floor itself, so comparing at matched-tight is both stricter and non-fragile.)
+        flow = np.array(([100.0] * 4 + [-100.0] * 4) * 3)
+        dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
+        ext = flow < 0
+        geom = {**GEOM, "alpha_l": alpha_l}
+        gf = _gridfree_tight(cin_deviation=cin, flow=flow, dt_days=dt, retardation_factor=r_fac, n_quad=120, **geom)
+        re = cout_deviation(
+            cin_deviation=cin,
+            flow=flow,
+            dt_days=dt,
+            retardation_factor=r_fac,
+            n_quad=120,
+            n_terms=64,
+            tol=1e-13,
+            **geom,
+        )
+        assert np.max(np.abs(re[ext] - gf[ext])) < 1e-6
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("r_fac", [1.0, 2.0])
+    def test_dm_positive_matches_per_reversal(self, r_fac):
+        # D_m>0 (Riccati branch) multi-cycle end-to-end: the reused matrix reproduces the per-reversal
+        # _propagate_diffusive hand-off to the matched-tight de Hoog floor (the column-identity test above
+        # pins the matrix bit-exactly; this gate adds caching + composition). R=1 and R>1 via the wall-clock
+        # rescale. n_quad small -- the cost is the per-de-Hoog-node Riccati ODE.
+        flow = np.array(([100.0] * 4 + [-100.0] * 4) * 2)
+        dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
+        ext = flow < 0
+        gf = _gridfree_tight(
+            cin_deviation=cin,
+            flow=flow,
+            dt_days=dt,
+            molecular_diffusivity=1.0,
+            retardation_factor=r_fac,
+            n_quad=8,
+            **GEOM,
+        )
+        re = cout_deviation(
+            cin_deviation=cin,
+            flow=flow,
+            dt_days=dt,
+            molecular_diffusivity=1.0,
+            retardation_factor=r_fac,
+            n_quad=8,
+            n_terms=64,
+            tol=1e-13,
+            **GEOM,
+        )
+        assert np.max(np.abs(re[ext] - gf[ext])) < 1e-5  # diffusive (high-ratio D_m) de Hoog floor
+
+    @pytest.mark.slow
+    def test_seasonal_matches_per_reversal(self):
+        # D_m>0 with Q=0 rest phases (seasonal storage / ATES, inject -> rest -> extract): the Riccati and
+        # Bessel-rest matrices are both reused across cycles and reproduce the per-reversal engine end-to-end
+        # to the matched-tight de Hoog floor (the per-branch matrices are pinned bit-exactly above).
+        flow = np.array(([100.0] * 4 + [0.0] * 3 + [-100.0] * 4) * 2)
+        dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
+        ext = flow < 0
+        gf = _gridfree_tight(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=1.0, n_quad=8, **GEOM)
+        re = cout_deviation(
+            cin_deviation=cin,
+            flow=flow,
+            dt_days=dt,
+            molecular_diffusivity=1.0,
+            n_quad=8,
+            n_terms=64,
+            tol=1e-13,
+            **GEOM,
+        )
+        assert np.max(np.abs(re[ext] - gf[ext])) < 1e-5  # diffusive + rest de Hoog floor
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize("d_m_eff", [1.0, 2.0])  # d_m_eff != 1 exercises the 1/d_m_eff source measure
+    def test_rest_matrix_is_per_reversal_operator(self, d_m_eff):
+        # Rest (Q=0) Bessel branch: each matrix column equals _propagate_rest of a unit source (seasonal
+        # storage / ATES wall-clock molecular diffusion). Shares rest_resolvent with _propagate_rest, so the
+        # column is bit-exact (the SL measure r'/d_m_eff is identity at d_m_eff=1, so d_m_eff=2 pins it).
+        flow, dt = np.array([100.0] * 4 + [0.0] * 3 + [-100.0] * 4), np.ones(11)
+        r_nodes, _, dr = _field_grid(flow, dt, CG, 0.5, 0.5, 1.0, 40)
+        tau = 3.0  # wall-clock rest duration
+        pmat = _rest_propagator_matrix(tau, r_nodes, dr, r_w=0.5, d_m_eff=d_m_eff, n_terms=44, tol=1e-9)
+        for j in (5, 20, 35):
+            e = np.zeros(40)
+            e[j] = 1.0
+            col = _propagate_rest(e, r_nodes, dr, tau, r_w=0.5, d_m_eff=d_m_eff)
+            np.testing.assert_allclose(pmat[:, j], col, atol=1e-9, rtol=1e-8)
+
+    def test_multi_cycle_converges_to_finite_volume(self):
+        # Fully independent end-to-end anchor for the accelerated path: a finite-volume solve of the SAME PDE
+        # (shares NO Laplace-kernel / de Hoog / FR-step-response code) CONVERGES first-order to the reuse engine
+        # on a multi-cycle schedule that actually exercises the propagator-matrix reuse. Every other reuse test
+        # compares against the kernel-sharing per-reversal engine; this closes the validation chain through the
+        # accelerated path itself. The reuse engine is the reference; FV is first-order O(1/n_cells), so refining
+        # the grid drives the error toward zero (a wrong engine would leave a non-vanishing offset, ratio -> 1).
+        flow = np.array(([100.0] * 4 + [-100.0] * 4) * 2)
+        dt, cin = np.ones(len(flow)), np.where(flow > 0, 1.0, 0.0)
+        ext = flow < 0
+        re = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_quad=120, **GEOM)
+
+        def err(n_cells, n_sub):
+            fv = fv_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, n_cells=n_cells, n_sub=n_sub, **GEOM)
+            return np.max(np.abs(fv[ext] - re[ext]))
+
+        assert err(800, 16) < 0.6 * err(200, 8)  # refining 4x reduces the FV error toward the reuse engine
 
 
 class TestMolecularDiffusion:


### PR DESCRIPTION
## Summary

Accelerates the multi-cycle / general signed-flow composition in `radial_asr`. Each per-reversal field propagator is built once per distinct `(direction, phase volume)` as a Bromwich-contour matrix and reused as a bounded matrix-multiply; the `cin -> field` and `field -> cout` readouts are matrixized the same way. The special-function + de Hoog cost drops from `O(reversals)` to `O(distinct phase volumes)` (~6-30x faster for periodic ASR / SWIW), and the result is bit-equivalent -- to the de Hoog floor -- to the per-reversal grid-free composition.

- **`_radial_asr_reuse.py`** (new): Airy (`D_m=0`) / Riccati (`D_m>0`) / Bessel-rest propagator-matrix builders, the readout matrices, and the cached `cout_deviation` state machine, assembled on the well-conditioned Bromwich contour (`Re s > 0`).
- **`_radial_asr_dehoog.py`**: `dehoog_inverse` generalized to a trailing batch axis -- one QD/continued-fraction pass inverts every entry of a propagator matrix.
- **`radial_asr.py`**: dispatch the multi-cycle (and single-cycle-with-rest under `D_m>0`) path to the reuse engine; a single inject->extract cycle keeps the closed-form echo operator.
- **Per-reversal reference -> test oracle**: the per-reversal grid-free composition moves to `tests/src/_radial_asr_gridfree_oracle.py` (alongside the finite-volume and Whittaker oracles); `src/` now holds only the production path.
- Public-API coverage added for the `D_m>0` reverse, both gamma wrappers, and the rest+`D_m` dispatch carve-out; the accelerated path is cross-checked against the finite-volume oracle.

## Test plan

- `pytest tests/src -n auto` -> 1715 passed, 2 skipped.
- Per-reversal equivalence: column-identity tests pin each branch matrix bit-exactly (Airy/rest exact; Riccati matched-tight); `cout_deviation` matches the grid-free oracle to the de Hoog floor (the only gap is the de Hoog Pade nonlinearity, which closes as `n_terms`/`tol` tighten).
- Independent anchor: `test_multi_cycle_converges_to_finite_volume` (the finite-volume oracle shares no Laplace / de Hoog code) converges first-order to the reuse engine.
- `ruff format` + `ruff check` clean; `ty check` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
