### PR TITLE
docs: auto-derive interactive notebook list from examples/

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -196,18 +196,15 @@ _jupyterlite_install = (
     "import numpy, scipy, pandas, matplotlib, mpmath  # noqa: F401\n"
 )
 
-# Example notebooks that run client-side. 01/02/03 use the inline KNMI soil-temperature data
-# embedded in gwtransport.examples, so they no longer need network access. Only 08 is excluded
-# (timflow -> numba, which has no WebAssembly build).
-jupyterlite_interactive_notebooks = [
-    "01_Aquifer_Characterization_Temperature",
-    "02_Residence_Time_Analysis",
-    "03_Pathogen_Removal_Bank_Filtration",
-    "04_Deposition_Analysis_Bank_Filtration",
-    "10_Advection_with_non_linear_sorption",
-    "11_Percolation_Unsaturated_Zone",
-    "12_Bank_Filtration_Rainwater_Fraction",
-]
+# Example notebooks that run client-side. Every notebook in ../examples is exposed as an
+# interactive (JupyterLite/Pyodide) copy and picked up automatically -- adding a new example
+# notebook requires no change here. Only the timflow notebook is excluded: it pulls in numba
+# (transitively via timflow), which has no WebAssembly build.
+_examples_dir = Path(__file__).parent.parent.parent / "examples"
+_jupyterlite_excluded_notebooks = {"08_bank_filtration_timflow"}
+jupyterlite_interactive_notebooks = sorted(
+    nb.stem for nb in _examples_dir.glob("*.ipynb") if nb.stem not in _jupyterlite_excluded_notebooks
+)
 
 # nbsphinx already renders every .ipynb page; keep it that way (do not let
 # jupyterlite-sphinx claim the .ipynb source suffix).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,10 @@ docs = [
   "jupyterlite-core>=0.6",
   "jupyterlite-pyodide-kernel>=0.6",
   "jupyterlite-sphinx>=0.22",
+  # conf.py imports nbformat directly (reads/writes the Pyodide notebook copies). It is
+  # otherwise present only transitively via nbsphinx; declare it so the direct import does
+  # not rest on a transitive dependency.
+  "nbformat>=5.0.2",
   "nbsphinx",
   "nbsphinx-link",
   "sphinx>=9.0,<10.0",


### PR DESCRIPTION
## Summary

Auto-derive the interactive (JupyterLite/Pyodide) example-notebook list in `docs/source/conf.py` instead of hardcoding it.

- `jupyterlite_interactive_notebooks` is now a glob over `../examples/*.ipynb` with a single explicit exclusion: the timflow notebook (`08_bank_filtration_timflow`), which pulls in numba transitively and has no WebAssembly build. Adding a new example notebook no longer requires editing `conf.py`.
- This also closes a silent gap: `13_Aquifer_Storage_Recovery` exists in `examples/` but was missing from the hardcoded list, so it was never offered as an interactive copy. It is now included (7 → 8 interactive notebooks).
- Declare `nbformat>=5.0.2` in the `docs` optional-dependencies. `conf.py` imports `nbformat` directly, but it was previously present only transitively via `nbsphinx`; this makes the direct import rest on a declared dependency.

## Test plan

- Verified the glob resolves to the expected 8 stems (timflow excluded, `13_Aquifer_Storage_Recovery` included) against the real `examples/` directory.
- `ruff format` / `ruff check` on `conf.py`: clean, no changes.
- `pyproject.toml` parses (`tomllib`) and passes `validate-pyproject`.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
