### PR TITLE
fix: resolve 2026-07-05 full-library review findings (correctness, perf, validation)

### DIFF
--- a/src/gwtransport/_diffusion_shared.py
+++ b/src/gwtransport/_diffusion_shared.py
@@ -18,6 +18,12 @@ import pandas as pd
 from scipy.special import erf
 
 from gwtransport._time import dt_to_days
+from gwtransport._validation import (
+    _validate_no_nan,
+    _validate_non_negative_array,
+    _validate_positive_array,
+    _validate_retardation_factor,
+)
 from gwtransport.utils import solve_inverse_transport_banded
 
 # Minimum coefficient sum to consider an output bin valid.
@@ -173,10 +179,10 @@ def _validate_inputs(
     ------
     ValueError
         If array lengths are inconsistent, molecular_diffusivity or
-        longitudinal_dispersivity are negative, cin or cout or flow contain NaN values,
-        aquifer_pore_volumes contains non-positive values, streamline_length is
-        non-positive, or retardation_factor is below 1 (anti-retardation is not physical for
-        the supported sorption isotherms).
+        longitudinal_dispersivity are negative or non-finite, cin or cout or flow contain NaN
+        values, aquifer_pore_volumes contains non-positive or non-finite values,
+        streamline_length is non-positive or non-finite, or retardation_factor is NaN or below 1
+        (anti-retardation is not physical for the supported sorption isotherms).
     """
     if is_forward:
         if len(tedges) != len(cin_or_cout) + 1:
@@ -197,30 +203,17 @@ def _validate_inputs(
         if np.size(arr) not in {1, n_pore_volumes}:
             msg = f"{name} must be a scalar or have length len(aquifer_pore_volumes) = {n_pore_volumes}"
             raise ValueError(msg)
-    if np.any(np.asarray(molecular_diffusivity) < 0):
-        msg = "molecular_diffusivity must be non-negative"
-        raise ValueError(msg)
-    if np.any(np.asarray(longitudinal_dispersivity) < 0):
-        msg = "longitudinal_dispersivity must be non-negative"
-        raise ValueError(msg)
-    if np.any(np.isnan(cin_or_cout)):
-        msg = f"{'cin' if is_forward else 'cout'} contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(np.isnan(flow)):
-        msg = "flow contains NaN values, which are not allowed"
-        raise ValueError(msg)
-    if np.any(flow < 0):
-        msg = "flow must be non-negative (negative flow not supported)"
-        raise ValueError(msg)
-    if np.any(aquifer_pore_volumes <= 0):
-        msg = "aquifer_pore_volumes must be positive"
-        raise ValueError(msg)
-    if np.any(np.asarray(streamline_length) <= 0):
-        msg = "streamline_length must be positive"
-        raise ValueError(msg)
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
+    # Delegate the finite+sign invariants to the shared _validation atoms so the NaN/+inf guards
+    # (which the bare ``< 0`` / ``<= 0`` / ``< 1.0`` comparisons here would let slip through) are
+    # enforced in exactly one place. Order and messages match the historical inline checks.
+    _validate_non_negative_array(molecular_diffusivity, name="molecular_diffusivity")
+    _validate_non_negative_array(longitudinal_dispersivity, name="longitudinal_dispersivity")
+    _validate_no_nan(cin_or_cout, name="cin" if is_forward else "cout")
+    _validate_no_nan(flow, name="flow")
+    _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
+    _validate_positive_array(aquifer_pore_volumes, name="aquifer_pore_volumes")
+    _validate_positive_array(streamline_length, name="streamline_length")
+    _validate_retardation_factor(retardation_factor)
     if flow_out is None:
         # The output-grid extraction flow is only unambiguous when the cout grid matches
         # the flow grid; otherwise it must be supplied (it defines the cout-bin volumes and

--- a/src/gwtransport/_radial_asr_compose.py
+++ b/src/gwtransport/_radial_asr_compose.py
@@ -155,13 +155,15 @@ def single_cycle_echo_matrix(
     t_edges = np.asarray(ext_volume_edges, dtype=float) - ext_volume_edges[0]  # 0 .. T_end
     dt = np.diff(t_edges)
 
-    # V' quadrature window: the resident profile f(V') = G1(S_inj; V') decays to ~0 once the FR front
-    # mean (R c_geo r'^2 ~ R V') exceeds the injected volume by several breakthrough widths; taking
-    # mu_FR(r_max) ~ 4 S_inj covers the support (integrand ~0 beyond -- verified by mass conservation
-    # int f dV' = S_inj to the de Hoog + quadrature floor).
-    r_max = np.sqrt((4.0 * s_inj / (retardation_factor * c_geo)) + r_w**2)
-    # D_m dispatch is inside transfer_function: the vectorized Airy branch for D_m = 0, the Riccati
-    # log-derivative branch for D_m > 0 (exact at any A_0/D_m, no precision cap).
+    # V' quadrature window: the resident profile f(V') = G1(S_inj; V') has its front at the retarded solute
+    # radius r_front (where the FR arrival mean equals S_inj) and a dispersive tail of breakthrough width
+    # ~sqrt(alpha_L r_front). A flat 4 S_inj/R margin is Peclet-blind and truncates that tail at low Peclet
+    # (r_front/alpha_L << 1), losing mass (int f dV' < S_inj/R). Mirror the reuse engine's 12-sigma advective
+    # reach plus a 6-sigma molecular reach over the cycle duration -- the same grid that conserves the mass
+    # to ~1e-5. D_m dispatch is inside transfer_function (Airy for D_m = 0, Riccati log-derivative for D_m > 0).
+    r_front = np.sqrt(r_w**2 + s_inj / (retardation_factor * c_geo))
+    total_time = s_inj / inj_flow_scale + t_edges[-1] / ext_flow_scale
+    r_max = r_front + 12.0 * np.sqrt(alpha_l * r_front + alpha_l**2) + 6.0 * np.sqrt(molecular_diffusivity * total_time)
     v_max = c_geo * (r_max**2 - r_w**2)
     nodes, weights = np.polynomial.legendre.leggauss(n_quad)
     v_nodes = 0.5 * v_max * (nodes + 1.0)

--- a/src/gwtransport/_radial_asr_dehoog.py
+++ b/src/gwtransport/_radial_asr_dehoog.py
@@ -133,31 +133,25 @@ def dehoog_inverse(
         raise ValueError(msg)
     batch = a.shape[1:]
     nb = len(batch)
-    if t_max <= 0.0:
-        # No positive evaluation times: the one-sided inverse is identically zero there.
-        out = np.zeros((n_t, *batch))
-        if scalar_input:
-            return out[0]
-        return out.reshape(t_arr.shape + batch)
     a = a.copy()
-    # Batch entries whose transform is identically zero (e.g. a decoupled azimuthal mode with no source)
-    # invert to zero; the quotient-difference recurrence would otherwise form 0/0 and poison them with NaN.
-    # Park such columns at a unit sentinel through the QD pass and overwrite their output with 0 below.
-    zero_cols = ~np.any(a != 0.0, axis=0)
-    if np.any(zero_cols):
-        a[:, zero_cols] = 1.0
+    # A column is *underflow-degenerate* when its transform stays FINITE but decays to the double-precision
+    # floor -- identically zero (a decoupled azimuthal mode with no source) or underflowing toward zero at
+    # the high-frequency nodes (a heavily damped far-field propagator entry: rest / Airy / Riccati). Both
+    # drive the quotient-difference recurrence into 0/0 or x/0 and poison the column with NaN, yet the
+    # physical inverse is ~0. Such columns are detected here (finite transform) and their non-finite output
+    # is zeroed below. A column whose transform OVERFLOWED (inf/nan already in ``a`` -- an ill-scaled kernel)
+    # is a genuine breakdown and is deliberately NOT masked: it must still surface as NaN so a real failure
+    # can never masquerade as a physical zero.
+    finite_transform = np.all(np.isfinite(a), axis=0)
     a[0] *= 0.5
 
     # Quotient-difference algorithm -> continued-fraction coefficients d[0 .. 2M] (per batch entry; the
-    # rhombus rules slice the leading node axis and broadcast over the trailing batch). A batch entry whose
-    # transform underflows toward zero at the high-frequency nodes (a heavily damped azimuthal mode at the
-    # outer field nodes) yields degenerate quotients here; the resulting non-finite intermediates do not
-    # reach a meaningful (non-negligible) output, so the rhombus divisions (and the final-convergent
-    # division below) are evaluated under errstate. The mask targets exactly these known-benign columns:
-    # a genuinely broken transform still surfaces as NaN in the output, just without a warning.
+    # rhombus rules slice the leading node axis and broadcast over the trailing batch). The degenerate
+    # columns above form 0/0 / x/0 here and in the continued fraction, so every division is evaluated under
+    # errstate; their non-finite output is masked to zero after the assembly.
     d = np.empty((n_nodes, *batch), dtype=complex)
     d[0] = a[0]
-    with np.errstate(divide="ignore", invalid="ignore"):
+    with np.errstate(all="ignore"):  # degenerate columns form 0/0, x/0 and over/underflow; masked below
         q = a[1:] / a[:-1]  # q_1^{(i)}, length 2M
         d[1] = -q[0]
         e = q[1:] - q[:-1]  # e_1^{(i)} = e_0^{(i+1)} + q_1^{(i+1)} - q_1^{(i)}, length 2M-1
@@ -177,22 +171,23 @@ def dehoog_inverse(
     z = np.exp(1j * np.pi * t_flat / big_t).reshape(time_shape)  # (n_t, 1..1)
     a_pp = np.zeros((n_t, *batch), dtype=complex)  # A_{-1}
     b_pp = np.ones((n_t, *batch), dtype=complex)  # B_{-1}
-    a_p = np.broadcast_to(d[0], (n_t, *batch)).astype(complex).copy()  # A_0
+    a_p = np.broadcast_to(d[0], (n_t, *batch))  # A_0 (read-only view; only ever read below, never mutated)
     b_p = np.ones((n_t, *batch), dtype=complex)  # B_0
-    for n in range(1, n_nodes - 1):
-        dz = d[n] * z  # d[n] (batch) broadcasts against z (time, 1..1) -> (n_t, *batch)
-        a_pp, a_p = a_p, a_p + dz * a_pp
-        b_pp, b_p = b_p, b_p + dz * b_pp
-    # a_p, b_p hold the (2M-1) convergent; a_pp, b_pp the (2M-2) convergent.
-    with np.errstate(divide="ignore", invalid="ignore"):
+    with np.errstate(all="ignore"):  # degenerate columns propagate Inf/NaN through the CF; masked below
+        for n in range(1, n_nodes - 1):
+            dz = d[n] * z  # d[n] (batch) broadcasts against z (time, 1..1) -> (n_t, *batch)
+            a_pp, a_p = a_p, a_p + dz * a_pp
+            b_pp, b_p = b_p, b_p + dz * b_pp
+        # a_p, b_p hold the (2M-1) convergent; a_pp, b_pp the (2M-2) convergent.
         rem = 0.5 * (1.0 + z * (d[n_nodes - 2] - d[n_nodes - 1]))
         rem = -rem * (1.0 - np.sqrt(1.0 + z * d[n_nodes - 1] / (rem * rem)))
         a_final = a_p + rem * a_pp
         b_final = b_p + rem * b_pp
         result = (np.exp(gamma * t_flat).reshape(time_shape) / big_t) * np.real(a_final / b_final)
     result = np.where(t_flat.reshape(time_shape) > 0.0, result, 0.0)
-    if np.any(zero_cols):
-        result[..., zero_cols] = 0.0  # identically-zero transforms invert to zero (parked above)
+    # Zero the underflow-degenerate columns (finite transform, non-finite QD output). Overflowed columns
+    # (non-finite transform) are left as NaN so a genuine breakdown surfaces rather than reads as zero.
+    result = np.where(~np.isfinite(result) & finite_transform, 0.0, result)
     if scalar_input:
         return result[0]
     return result.reshape(t_arr.shape + batch)

--- a/src/gwtransport/_radial_asr_kernels.py
+++ b/src/gwtransport/_radial_asr_kernels.py
@@ -279,6 +279,7 @@ def assemble_airy_resolvent(
     r_sum: npt.NDArray[np.floating],
     alpha_l: float,
     gauge_sign: float,
+    source_log_weight: npt.NDArray[np.floating] | float = 0.0,
 ) -> npt.NDArray[np.complexfloating]:
     r"""Assemble ``Ghat(r, r'; s) = -(pref_a e^{ea} - pref_b e^{eb})`` from precomputed scaled-Airy pieces.
 
@@ -290,6 +291,16 @@ def assemble_airy_resolvent(
     of radii once and assemble every output node from prefix selection -- the ``O(n^2) -> O(n)``
     saving the field propagator relies on.
 
+    The gauge term ``g * r_sum = gauge_sign (r + r')/(2 alpha_L)`` grows with the radii, so for the
+    field propagator its ``e^{g r_sum}`` factor is divergent (``+r/alpha_L`` injection) or its Airy
+    counterpart is (``-r/alpha_L`` extraction); on its own it overflows/underflows double precision at
+    Peclet ``r/alpha_L`` beyond ~700. It is tamed by the caller's Sturm-Liouville source weight
+    ``e^{-gauge_sign r'/alpha_L}``, whose LOG (``source_log_weight = -gauge_sign r'/alpha_L``, per
+    source node) must therefore be folded into the exponents *before* ``np.exp`` so the divergent parts
+    cancel to ``gauge_sign (r - r')/(2 alpha_L)`` (bounded by ``r_max/(2 alpha_L)``, and dominated by the
+    Airy decay) -- rather than overflowing to ``Inf`` and then meeting the taming factor as ``Inf * 0``.
+    The default ``0.0`` reproduces the bare interior resolvent (no source weight).
+
     Parameters
     ----------
     piece_a, piece_b, piece_w : dict of ndarray
@@ -300,11 +311,16 @@ def assemble_airy_resolvent(
         Longitudinal dispersivity (m).
     gauge_sign : float
         ``+1`` divergent (injection, Robin well BC) / ``-1`` convergent (extraction, Neumann well BC).
+    source_log_weight : ndarray or float, optional
+        Log of the caller's Sturm-Liouville source weight per source node ``r'``
+        (``-gauge_sign r'/alpha_L``), broadcast over the source axis and folded into both exponents so
+        the divergent gauge cancels before ``np.exp``. Default ``0.0`` (bare resolvent, no weight).
 
     Returns
     -------
     ndarray of complex
-        ``Ghat(r, r'; s)``, same broadcast shape as the input pieces.
+        ``Ghat(r, r'; s)`` (times the source weight when ``source_log_weight`` is given), same broadcast
+        shape as the input pieces.
     """
     g = gauge_sign / (2.0 * alpha_l)
     if gauge_sign < 0:  # extraction: Danckwerts -> zero dispersive flux -> Neumann u_0'(r_w) = 0
@@ -316,8 +332,8 @@ def assemble_airy_resolvent(
     denom0 = piece_w["s_regp"] * piece_w["s_inf"] - piece_w["s_infp"] * piece_w["s_reg"]
     pref_a = bc_reg * piece_a["s_inf"] * piece_b["s_inf"] / (bc_inf * denom0)
     pref_b = piece_a["s_reg"] * piece_b["s_inf"] / denom0
-    exp_a = g * r_sum - (piece_a["xi"] + piece_b["xi"] - 2.0 * piece_w["xi"])
-    exp_b = g * r_sum + (piece_a["xiR"] - piece_w["xiR"]) - (piece_b["xi"] - piece_w["xi"])
+    exp_a = g * r_sum + source_log_weight - (piece_a["xi"] + piece_b["xi"] - 2.0 * piece_w["xi"])
+    exp_b = g * r_sum + source_log_weight + (piece_a["xiR"] - piece_w["xiR"]) - (piece_b["xi"] - piece_w["xi"])
     return -(pref_a * np.exp(exp_a) - pref_b * np.exp(exp_b))
 
 
@@ -373,13 +389,12 @@ def rest_resolvent(
     z_lt, z_gt, z_w = kappa * r_lt, kappa * r_gt, kappa * r_w
     # Ghat = [I_0(z_<) + (I_1(z_w)/K_1(z_w)) K_0(z_<)] K_0(z_>); split so the scaled-Bessel scaling
     # exponents (ive scales by e^{-|Re z|}, kve by e^{+z}) difference to bounded values -- no overflow.
+    # Both terms carry the scaling exponents in a SINGLE np.exp of the combined (bounded) sum: the outer
+    # term's ``|Re z_w| + z_w`` alone overflows at Re(z_w) > ~354, but ``|Re z_w| + z_w - z_lt - z_gt``
+    # <= 0 (since r_w <= r_< <= r_>) so exponentiating the sum is overflow-safe.
     term_inner = ive(0, z_lt) * kve(0, z_gt) * np.exp(np.abs(z_lt.real) - z_gt)
     term_outer = (
-        (ive(1, z_w) / kve(1, z_w))
-        * np.exp(np.abs(z_w.real) + z_w)
-        * kve(0, z_lt)
-        * kve(0, z_gt)
-        * np.exp(-z_lt - z_gt)
+        (ive(1, z_w) / kve(1, z_w)) * kve(0, z_lt) * kve(0, z_gt) * np.exp(np.abs(z_w.real) + z_w - z_lt - z_gt)
     )
     return term_inner + term_outer
 

--- a/src/gwtransport/_radial_asr_reuse.py
+++ b/src/gwtransport/_radial_asr_reuse.py
@@ -29,6 +29,7 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 
 import numpy as np
 import numpy.typing as npt
+from scipy.special import ive, kve
 
 from gwtransport._radial_asr_compose import _DEHOOG_TERMS, _SCALE_MARGIN, _fr_step_response
 from gwtransport._radial_asr_dehoog import dehoog_inverse
@@ -36,7 +37,6 @@ from gwtransport._radial_asr_kernels import (
     _integrate_logderiv,
     _resolvent_airy_pieces,
     assemble_airy_resolvent,
-    rest_resolvent,
 )
 
 _INJECTION = "injection"
@@ -132,7 +132,13 @@ def _airy_propagator_matrix(
     a0 = flow_scale / (2.0 * c_geo)
     gauge_sign = 1.0 if direction == _INJECTION else -1.0
     n = r_nodes.size
-    sl_weight = (2.0 * c_geo * r_nodes / alpha_l) * np.exp(-gauge_sign * r_nodes / alpha_l) * dr_weights
+    # Split the Sturm-Liouville source weight (2 c_geo r'/alpha_L) e^{-gauge_sign r'/alpha_L} dr' into its
+    # non-exponential prefactor and its LOG exponent: the exponent is folded into assemble_airy_resolvent
+    # so the divergent gauge cancels before np.exp (overflow-safe at any Peclet). Applying the exponential
+    # weight afterwards would overflow -- the injection assemble exponent and the extraction weight each blow
+    # up past r/alpha_L ~ 700 and meet as Inf * 0 = NaN.
+    sl_prefactor = (2.0 * c_geo * r_nodes / alpha_l) * dr_weights
+    sl_log = (-gauge_sign * r_nodes / alpha_l)[None, :]
     mu = c_geo * ((float(r_nodes.max()) + alpha_l) ** 2 + alpha_l**2 - r_w**2)
     scaling = _SCALE_MARGIN * max(mu, tau)
     below = r_nodes[None, :] < r_nodes[:, None]  # below[i, j] = r_j < r_i
@@ -148,8 +154,10 @@ def _airy_propagator_matrix(
             piece_a = {f: np.where(mask, grid_p[f], grid_p[f][:, i : i + 1]) for f in grid_p}
             piece_b = {f: np.where(mask, grid_p[f][:, i : i + 1], grid_p[f]) for f in grid_p}
             r_sum = (r_nodes[i] + r_nodes)[None, :]
-            ghat[:, i, :] = assemble_airy_resolvent(piece_a, piece_b, piece_w, r_sum, alpha_l, gauge_sign)
-        ghat *= sl_weight[None, None, :]  # apply the Sturm-Liouville source weight in place (stays complex)
+            ghat[:, i, :] = assemble_airy_resolvent(
+                piece_a, piece_b, piece_w, r_sum, alpha_l, gauge_sign, source_log_weight=sl_log
+            )
+        ghat *= sl_prefactor[None, None, :]  # non-exponential SL prefactor (the gauge is already folded in)
         return ghat
 
     return dehoog_inverse(f_hat=f_hat, t=tau, n_terms=n_terms, scaling=scaling, tol=tol)
@@ -236,22 +244,48 @@ def _rest_propagator_matrix(
     interior resolvent (:func:`gwtransport._radial_asr_kernels.rest_resolvent`) with the Sturm-Liouville rest
     measure ``w(r') dr' = (r'/D_m) dr'``, on the wall-clock clock. Retardation enters as ``d_m_eff = D_m/R``.
 
+    **Resolution limit.** Molecular diffusion over the rest spreads mass by the diffusion length
+    ``sqrt(D_m tau)``. Once that length drops below half the coarsest node gap the Gauss-Legendre grid can no
+    longer resolve the near-delta diffusive Green's function: the quadratured resolvent stops conserving mass
+    (``dv^T P`` amplifies above ``1`` -- a maximum-principle violation, ``cout > cin``). In that under-resolved
+    regime the physical propagator *is* the identity to grid accuracy (diffusion has not crossed a cell), so
+    the identity is returned -- mass-exact and equal to the ``D_m = 0`` echo, the correct small-``D_m`` limit.
+
     Returns
     -------
     ndarray
         Propagator matrix ``P``, shape ``(n_quad, n_quad)``.
     """
-    n = r_nodes.size
+    if np.sqrt(d_m_eff * tau) < 0.5 * float(np.diff(r_nodes).max()):
+        return np.eye(r_nodes.size)
     scaling = _SCALE_MARGIN * tau
     weight = (r_nodes / d_m_eff * dr_weights)[None, None, :]
+    # r_nodes ascend, so r_< = r_nodes[min(i, j)], r_> = r_nodes[max(i, j)]: the order-0 scaled Bessels are
+    # evaluated once on the grid per s-node and gathered by these index maps instead of O(n_quad) times.
+    idx = np.arange(r_nodes.size)
+    lt = np.minimum(idx[:, None], idx[None, :])
+    gt = np.maximum(idx[:, None], idx[None, :])
 
     def f_hat(s: npt.NDArray[np.complexfloating]) -> npt.NDArray[np.complexfloating]:
-        ghat = np.empty((s.size, n, n), dtype=complex)
-        for i in range(n):
-            ghat[:, i, :] = rest_resolvent(s=s, r=float(r_nodes[i]), r_prime=r_nodes, r_w=r_w, d_m=d_m_eff)
+        kappa = np.sqrt(np.asarray(s, dtype=complex).reshape(-1, 1) / d_m_eff)  # (n_s, 1), Re(kappa) > 0
+        zr = kappa * r_nodes[None, :]  # (n_s, n): kappa r' on the grid, Bessels evaluated once here
+        iv0, kv0 = ive(0, zr), kve(0, zr)
+        z_w = kappa * r_w
+        ratio_w = ive(1, z_w) / kve(1, z_w)  # (n_s, 1)
+        z_lt, z_gt = zr[:, lt], zr[:, gt]  # (n_s, n, n)
+        # Ghat = [I_0(z_<) + (I_1(z_w)/K_1(z_w)) K_0(z_<)] K_0(z_>) with scaled Bessels (see rest_resolvent):
+        # the scaling exponents difference to <= 0 so the growing I_0 never overflows at high kappa r.
+        ghat = iv0[:, lt] * kv0[:, gt] * np.exp(np.abs(z_lt.real) - z_gt)
+        outer = ratio_w[:, :, None] * kv0[:, lt]
+        outer *= kv0[:, gt]
+        outer *= np.exp((np.abs(z_w.real) + z_w)[:, :, None] - z_lt - z_gt)
+        ghat += outer
         ghat *= weight
         return ghat
 
+    # The de Hoog underflow guard zeros far-field cells whose transform decayed to the double-precision floor
+    # (physical ~0); a cell whose transform genuinely OVERFLOWED stays NaN so a real breakdown cannot read as
+    # a physical zero. No extra masking here (that would zero overflowed cells too, reversing that contract).
     return dehoog_inverse(f_hat=f_hat, t=tau, n_terms=n_terms, scaling=scaling, tol=tol)
 
 
@@ -331,8 +365,10 @@ def cout_deviation(
 
     Parameters
     ----------
-    cin_deviation : ndarray, shape (n,)
-        Injected concentration deviation per bin (used on injection bins, ``flow > 0``).
+    cin_deviation : ndarray, shape (n,) or (n, k)
+        Injected concentration deviation per bin (used on injection bins, ``flow > 0``). A trailing column
+        axis is transported through one engine pass (the per-phase matrices are cin-independent), used by
+        the reverse operator build to apply all unit-pulse columns at once.
     flow : ndarray, shape (n,)
         Signed flow per bin [m^3/day]: ``> 0`` injection, ``< 0`` extraction, ``0`` rest.
     dt_days : ndarray, shape (n,)
@@ -358,10 +394,12 @@ def cout_deviation(
 
     Returns
     -------
-    ndarray, shape (n,)
-        Extracted-flux deviation per bin; ``NaN`` on injection / rest bins.
+    ndarray, shape (n,) or (n, k)
+        Extracted-flux deviation per bin (matching ``cin_deviation``); ``NaN`` on injection / rest bins.
     """
     flow = np.asarray(flow, dtype=float)
+    cin_deviation = np.asarray(cin_deviation, dtype=float)
+    batch = cin_deviation.shape[1:]  # () for a single series, (k,) for a column batch (reverse operator build)
     flushed = np.abs(flow) * dt_days
     # D_m = 0 keeps the advective grid; D_m > 0 widens it to the molecular reach (the diffusive pumping and
     # rest kernels both spread beyond the advective front), matching gridfree_cout_deviation.
@@ -407,8 +445,8 @@ def cout_deviation(
             )
         return matrices[key] @ field
 
-    field = np.zeros(n_quad)
-    cout = np.full(len(flow), np.nan)
+    field = np.zeros((n_quad, *batch))
+    cout = np.full((len(flow), *batch), np.nan)
     for idx, (sign, sl) in enumerate(phases):
         phase_volume = float(flushed[sl].sum())
         if phase_volume == 0.0:  # rest: pure molecular diffusion on the wall-clock clock (D_m = 0 -> identity)

--- a/src/gwtransport/_validation.py
+++ b/src/gwtransport/_validation.py
@@ -89,9 +89,11 @@ def _validate_non_negative_array(
     name: str,
     message: str | None = None,
 ) -> None:
-    """Validate that ``arr`` has no strictly negative elements.
+    """Validate that every element of ``arr`` is finite and non-negative (``>= 0``).
 
-    Zeros are allowed. The companion ``_validate_positive_array`` rejects zeros too.
+    Zeros are allowed. The companion ``_validate_positive_array`` rejects zeros too. NaN and
+    ``+inf`` are rejected: both pass every ``< 0`` comparison, so a bare inequality would let
+    them slip through and poison the downstream computation.
 
     Parameters
     ----------
@@ -105,9 +107,10 @@ def _validate_non_negative_array(
     Raises
     ------
     ValueError
-        If any element of ``arr`` is strictly negative.
+        If any element of ``arr`` is negative or non-finite (NaN or infinite).
     """
-    if np.any(np.asarray(arr) < 0):
+    a = np.asarray(arr, dtype=float)
+    if not np.all(np.isfinite(a) & (a >= 0.0)):
         msg = message if message is not None else f"{name} must be non-negative"
         raise ValueError(msg)
 
@@ -118,7 +121,10 @@ def _validate_positive_array(
     name: str,
     message: str | None = None,
 ) -> None:
-    """Validate that every element of ``arr`` is strictly positive (``> 0``).
+    """Validate that every element of ``arr`` is finite and strictly positive (``> 0``).
+
+    NaN and ``+inf`` are rejected: both pass every ``<= 0`` comparison, so a bare inequality
+    would let them slip through and poison the downstream computation.
 
     Parameters
     ----------
@@ -132,9 +138,10 @@ def _validate_positive_array(
     Raises
     ------
     ValueError
-        If any element of ``arr`` is ``<= 0``.
+        If any element of ``arr`` is ``<= 0`` or non-finite (NaN or infinite).
     """
-    if np.any(np.asarray(arr) <= 0):
+    a = np.asarray(arr, dtype=float)
+    if np.any(~np.isfinite(a)) or np.any(a <= 0.0):
         msg = message if message is not None else f"{name} must be positive"
         raise ValueError(msg)
 
@@ -145,7 +152,11 @@ def _validate_positive_scalar(
     name: str,
     message: str | None = None,
 ) -> None:
-    """Validate that ``value`` is strictly positive (``> 0``).
+    """Validate that ``value`` is finite and strictly positive (``> 0``).
+
+    NaN and ``+inf`` are rejected: both pass the bare ``<= 0`` comparison, so an unchecked
+    inequality would let them slip through and poison the downstream computation (e.g. a
+    ``+inf`` thickness silently zeroed the deposition output).
 
     Parameters
     ----------
@@ -159,10 +170,32 @@ def _validate_positive_scalar(
     Raises
     ------
     ValueError
-        If ``value <= 0``.
+        If ``value <= 0`` or is non-finite (NaN or infinite).
     """
-    if value <= 0:
+    if not np.isfinite(value) or value <= 0:
         msg = message if message is not None else f"{name} must be positive, got {value}"
+        raise ValueError(msg)
+
+
+def _validate_retardation_factor(value: float) -> None:
+    """Validate that the retardation factor is ``>= 1`` (anti-retardation is unphysical).
+
+    The check is written as ``not value >= 1.0`` rather than ``value < 1.0`` so that NaN is
+    rejected too: ``NaN >= 1.0`` is False, so the bare ``< 1.0`` form would let NaN pass and
+    silently propagate an all-NaN transport output.
+
+    Parameters
+    ----------
+    value : float
+        Retardation factor to check.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` is NaN or ``value < 1.0``.
+    """
+    if not value >= 1.0:
+        msg = "retardation_factor must be >= 1.0"
         raise ValueError(msg)
 
 

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -19,18 +19,6 @@ Available functions:
   (alpha, beta) or (mean, std). Discretizes gamma distribution into equal-probability bins.
   Use case: Heterogeneous aquifer with calibrated gamma parameters.
 
-Note on dispersion: The spreading from the pore volume distribution (APVD) represents
-macrodispersion—aquifer-scale velocity heterogeneity that depends on both aquifer
-properties and hydrological boundary conditions. To add microdispersion and molecular
-diffusion separately (when APVD comes from streamline analysis), use :mod:`gwtransport.diffusion`.
-See :ref:`concept-dispersion-scales` for details.
-
-Note on cross-compound calibration: When APVD is calibrated from measurements of one
-compound (e.g., temperature with D_m ~ 0.1 m²/day) and used to predict another (e.g., a
-solute with D_m ~ 1e-4 m²/day), the molecular diffusion contribution is baked into the
-calibrated std. The cleanest fix is to calibrate with :mod:`gwtransport.diffusion_fast`
-instead, which keeps the three contributions separate.
-
 - :func:`extraction_to_infiltration` - Arbitrary pore volume distribution, deconvolution.
   Inverts forward transport for arbitrary pore volume distributions. Symmetric inverse of
   infiltration_to_extraction. Flow-weighted averaging in reverse direction. Use case:
@@ -49,6 +37,18 @@ instead, which keeps the three contributions separate.
   concentration fronts with exact mass balance required, across a distribution of aquifer
   pore volumes (macrodispersion). Forward modeling only; nonlinear sorption has no inverse.
 
+Note on dispersion: The spreading from the pore volume distribution (APVD) represents
+macrodispersion—aquifer-scale velocity heterogeneity that depends on both aquifer
+properties and hydrological boundary conditions. To add microdispersion and molecular
+diffusion separately (when APVD comes from streamline analysis), use :mod:`gwtransport.diffusion`.
+See :ref:`concept-dispersion-scales` for details.
+
+Note on cross-compound calibration: When APVD is calibrated from measurements of one
+compound (e.g., temperature with D_m ~ 0.1 m²/day) and used to predict another (e.g., a
+solute with D_m ~ 1e-4 m²/day), the molecular diffusion contribution is baked into the
+calibrated std. The cleanest fix is to calibrate with :mod:`gwtransport.diffusion_fast`
+instead, which keeps the three contributions separate.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """
@@ -64,6 +64,7 @@ from gwtransport._time import tedges_to_days
 from gwtransport._validation import (
     _validate_no_nan,
     _validate_non_negative_array,
+    _validate_retardation_factor,
     _validate_tedges_parity,
 )
 from gwtransport.advection_utils import (
@@ -79,7 +80,7 @@ from gwtransport.fronttracking.math import (
     SorptionModel,
 )
 from gwtransport.fronttracking.output import compute_bin_averaged_concentration_exact
-from gwtransport.fronttracking.solver import FrontTracker
+from gwtransport.fronttracking.solver import FrontTracker, find_unresolved_interaction
 from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
 from gwtransport.utils import solve_inverse_transport_banded
 
@@ -89,6 +90,7 @@ def _validate_advection_inputs(
     tedges: pd.DatetimeIndex,
     flow: np.ndarray,
     retardation_factor: float,
+    aquifer_pore_volumes: npt.ArrayLike | None = None,
     cin_values: np.ndarray | None = None,
     cout_values: np.ndarray | None = None,
     cout_tedges: pd.DatetimeIndex | None = None,
@@ -102,9 +104,11 @@ def _validate_advection_inputs(
       flow; ``cout_tedges`` parities cout.
 
     All shared checks fire on both paths. ``flow >= 0`` is enforced in both
-    directions (the previous reverse prologue omitted this; see issue #187). Every
-    other error-message string is preserved verbatim from the prior duplicated
-    prologue so that ``match=`` regex tests do not break.
+    directions (the previous reverse prologue omitted this; see issue #187), and
+    ``aquifer_pore_volumes`` (when passed) must be finite and strictly positive --
+    a negative or zero volume would source a cout bin from future infiltration.
+    Every other error-message string is preserved verbatim from the prior
+    duplicated prologue so that ``match=`` regex tests do not break.
 
     Raises
     ------
@@ -124,9 +128,15 @@ def _validate_advection_inputs(
         raise ValueError(msg)
     _validate_no_nan(flow, name="flow")
     _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
+    _validate_retardation_factor(retardation_factor)
+    if aquifer_pore_volumes is not None:
+        apv = np.asarray(aquifer_pore_volumes, dtype=float)
+        # A negative or zero pore volume back-projects a cout bin to *future*
+        # infiltration (anti-causal); a non-finite one poisons the whole solve.
+        # The nonlinear and diffusion paths already reject these.
+        if np.any(~np.isfinite(apv)) or np.any(apv <= 0.0):
+            msg = "aquifer_pore_volumes must be positive"
+            raise ValueError(msg)
 
 
 def gamma_infiltration_to_extraction(
@@ -196,7 +206,7 @@ def gamma_infiltration_to_extraction(
     Returns
     -------
     numpy.ndarray
-        Concentration of the compound in the extracted water [ng/m³] or temperature.
+        Concentration of the compound in the extracted water, or temperature. Same units as cin.
 
     See Also
     --------
@@ -372,7 +382,7 @@ def gamma_extraction_to_infiltration(
     Returns
     -------
     numpy.ndarray
-        Concentration of the compound in the infiltrating water [ng/m³] or temperature.
+        Concentration of the compound in the infiltrating water, or temperature. Same units as cout.
 
     See Also
     --------
@@ -552,12 +562,12 @@ def infiltration_to_extraction(
         Flow-weighted concentration in the extracted water. Same units
         as cin. Length equals ``len(cout_tedges) - 1``. NaN values mark
         cout bins where the chosen ``spinup`` policy is not satisfied:
-        the default ``"constant"`` only leaves NaN when cout extends
-        past the right edge of cin by more than the longest residence
-        time (the largest ``retardation_factor * aquifer_pore_volume /
-        flow``); ``spinup=None`` additionally NaNs left-edge spin-up bins;
-        a float threshold relaxes either case in exchange for
-        non-mass-conserving count-mean output.
+        the default ``"constant"`` leaves NaN for any cout bin extending
+        past the end of the flow record (a cout edge beyond
+        ``tedges[-1]``, whose back-projected source window leaves the cin
+        range) and for zero-throughflow bins; ``spinup=None`` additionally
+        NaNs left-edge spin-up bins; a float threshold relaxes either case
+        in exchange for non-mass-conserving count-mean output.
 
     Raises
     ------
@@ -665,6 +675,7 @@ def infiltration_to_extraction(
         tedges=tedges,
         flow=flow,
         retardation_factor=retardation_factor,
+        aquifer_pore_volumes=aquifer_pore_volumes,
         cin_values=cin,
     )
 
@@ -778,11 +789,11 @@ def extraction_to_infiltration(
         ``tedges[0]`` backward by ``retardation_factor *
         max(aquifer_pore_volumes) / flow[0]`` so the inverse problem has
         no spin-up zero-rows for cout bins inside the original tedges
-        range. The output cin is returned aligned with the *padded*
-        tedges (length ``len(tedges)``); the first cin bin therefore
-        corresponds to the warm-start interval. Passing ``None`` keeps
-        the strict-validity behavior (zero-rows in W from incomplete
-        breakthrough).
+        range. The warm-start prefix is solved for internally but dropped
+        before returning, so the output cin stays aligned with the
+        user-provided ``tedges`` (length ``len(tedges) - 1``), not the
+        padded grid. Passing ``None`` keeps the strict-validity behavior
+        (zero-rows in W from incomplete breakthrough).
 
     Returns
     -------
@@ -897,6 +908,7 @@ def extraction_to_infiltration(
         tedges=tedges,
         flow=flow,
         retardation_factor=retardation_factor,
+        aquifer_pore_volumes=aquifer_pore_volumes,
         cout_values=cout,
         cout_tedges=cout_tedges,
     )
@@ -1026,10 +1038,7 @@ def _validate_front_tracking_inputs(
 
     # Create sorption object
     if retardation_factor is not None:
-        if retardation_factor < 1.0:
-            msg = "retardation_factor must be >= 1.0"
-            raise ValueError(msg)
-
+        _validate_retardation_factor(retardation_factor)
         sorption: SorptionModel = ConstantRetardation(retardation_factor=retardation_factor)
     elif has_freundlich:
         if freundlich_k is None or freundlich_n is None or bulk_density is None or porosity is None:
@@ -1123,22 +1132,36 @@ def _flow_weighted_front_tracking_output(
     ]
     fine_edges = np.unique(np.concatenate([cout_tedges_days, inner_flow_edges]))
 
-    # np.interp clips on both sides — extrapolate past flow_tedges_days[-1] at
-    # last-bin flow (matches FrontTrackerState.theta_at_t extrapolation rule);
-    # without this, fine_edges past the flow window collapse to duplicate θ
-    # and compute_bin_averaged_concentration_exact rejects the zero-width bin.
+    # np.interp clips on both sides; extrapolate the θ map past either flow edge at
+    # the adjacent-bin flow (matches the FrontTrackerState.theta_at_t rule). Without
+    # this, out-of-window fine_edges collapse to a duplicate θ. A θ edge ≤ 0
+    # downstream reads back as m = 0 → 0.0 (the documented out-of-range contract).
     fine_theta_edges = np.interp(fine_edges, flow_tedges_days, theta_edges)
+    underflow = fine_edges < flow_tedges_days[0]
+    if underflow.any():
+        fine_theta_edges[underflow] = theta_edges[0] - (flow_tedges_days[0] - fine_edges[underflow]) * float(flow[0])
     overflow = fine_edges > flow_tedges_days[-1]
     if overflow.any():
         fine_theta_edges[overflow] = theta_edges[-1] + (fine_edges[overflow] - flow_tedges_days[-1]) * float(flow[-1])
-    c_fine = compute_bin_averaged_concentration_exact(
-        theta_bin_edges=fine_theta_edges,
-        v_outlet=v_outlet,
-        waves=waves,
-        sorption=sorption,
-        cin=cin,
-        theta_edges_inlet=theta_edges,
-    )
+
+    # A zero-flow input span leaves θ stationary, so its sub-bins have zero width in
+    # θ and zero q·dt weight. Drop them before the exact averaging (which rejects
+    # non-positive-width bins); their concentration cannot affect the flow-weighted
+    # mean, so they read back as 0 and carry no weight. Consecutive kept bins stay
+    # contiguous because the dropped bins share their neighbours' θ value.
+    theta_lo, theta_hi = fine_theta_edges[:-1], fine_theta_edges[1:]
+    nondegenerate = theta_hi > theta_lo
+    c_fine = np.zeros(theta_lo.shape)
+    if nondegenerate.any():
+        kept_edges = np.concatenate([theta_lo[nondegenerate], theta_hi[nondegenerate][-1:]])
+        c_fine[nondegenerate] = compute_bin_averaged_concentration_exact(
+            theta_bin_edges=kept_edges,
+            v_outlet=v_outlet,
+            waves=waves,
+            sorption=sorption,
+            cin=cin,
+            theta_edges_inlet=theta_edges,
+        )
 
     # Map each fine sub-bin to its flow value. side="right" enforces the
     # half-open [t_k, t_{k+1}) bin convention if a midpoint ever lands
@@ -1160,9 +1183,12 @@ def _flow_weighted_front_tracking_output(
     n_cout = len(cout_tedges_days) - 1
     qdt_product = q_fine * dt_fine
     cqdt_product = c_fine * qdt_product
-    denominator = np.bincount(cout_bin_idx, weights=qdt_product, minlength=n_cout).astype(np.float64)
-    numerator = np.bincount(cout_bin_idx, weights=cqdt_product, minlength=n_cout).astype(np.float64)
-    c_out = np.zeros(n_cout)
+    denominator = np.bincount(cout_bin_idx, weights=qdt_product, minlength=n_cout)
+    numerator = np.bincount(cout_bin_idx, weights=cqdt_product, minlength=n_cout)
+    # A zero-throughflow output bin (all overlapping input bins have zero flow) has
+    # an undefined flow-weighted average: emit NaN, matching the linear sibling.
+    # Pre-record bins keep positive throughflow, so their 0-mass windows read as 0.0.
+    c_out = np.full(n_cout, np.nan)
     valid = denominator > 0
     c_out[valid] = numerator[valid] / denominator[valid]
     return c_out
@@ -1204,7 +1230,7 @@ def infiltration_to_extraction_nonlinear_sorption(
         Length = len(tedges) - 1. The model assumes this value is constant over each
         interval ``[tedges[i], tedges[i+1])``.
     flow : array-like
-        Flow rate [m³/day]. Must be positive.
+        Flow rate [m³/day]. Must be non-negative.
         Length = len(tedges) - 1. The model assumes this value is constant over each
         interval ``[tedges[i], tedges[i+1])``.
     tedges : pandas.DatetimeIndex
@@ -1243,6 +1269,9 @@ def infiltration_to_extraction_nonlinear_sorption(
         before first breakthrough, or extending past the flow record) are
         returned as ``0.0``, not NaN; the front-tracking solver clamps such
         out-of-range windows to the last known state rather than masking them.
+        An output bin with zero throughflow (every overlapping input bin has
+        zero flow) has an undefined flow-weighted average and is returned as
+        NaN, matching :func:`infiltration_to_extraction`.
 
     structures : list of dict
         List of detailed simulation structures, one for each pore volume, with keys:
@@ -1331,6 +1360,25 @@ def infiltration_to_extraction_nonlinear_sorption(
         )
 
         tracker.run(max_iterations=max_iterations)
+
+        # The front tracker resolves shock↔shock / shock↔rarefaction collisions but not a
+        # later front overtaking an existing decaying-shock fan (or two fans composing). Such
+        # an unresolved interaction makes the public cout a spurious linear superposition of a
+        # nonlinear operator — non-conservative and silently wrong — so refuse it. The detector
+        # combines a geometric fan-overlap scan with a cumulative-outlet-mass monotonicity check
+        # (the latter catches the multi-pulse shock-overtakes-fan class whose fans never share an
+        # in-domain point); see find_unresolved_interaction.
+        interaction = find_unresolved_interaction(tracker.state)
+        if interaction is not None:
+            msg = (
+                "infiltration_to_extraction_nonlinear_sorption: input produces interacting fronts "
+                f"(a shock overtakes another shock / rarefaction / decaying-shock fan within the "
+                f"transport domain: {interaction}); exact multi-front interaction is not yet "
+                "implemented. Use non-interacting inputs — a single front, or well-separated pulses "
+                "whose fronts break through before they overtake one another — or track "
+                "https://github.com/gwtransport/gwtransport/issues/294 for exact multi-front interaction support."
+            )
+            raise NotImplementedError(msg)
 
         cout_sum += _flow_weighted_front_tracking_output(
             cout_tedges_days=cout_tedges_days,

--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -244,12 +244,12 @@ def _resolve_spinup_mask(
     invalid_mask : numpy.ndarray of bool
         True for cout bins where the policy is not satisfied.
 
-    Raises
-    ------
-    ValueError
-        If ``spinup`` is not ``None`` or a float in ``[0, 1]``. The string
-        ``"constant"`` is resolved into a threshold by
-        :func:`_resolve_spinup_inputs` before reaching this function.
+    Notes
+    -----
+    ``spinup`` is assumed already validated: :func:`_resolve_spinup_inputs`
+    resolves the string ``"constant"`` and rejects out-of-range values before
+    this function is reached, so ``spinup`` is always ``None`` or a float in
+    ``[0, 1]`` here.
     """
     if n_pv == 0:
         # No streamtubes means no transport: every cout bin is invalid.
@@ -257,18 +257,18 @@ def _resolve_spinup_mask(
 
     if spinup is None:
         # Strict validity: every streamtube must have contributed, so
-        # contributing_bins == n_pv on valid rows and the shared divisor below
+        # contributing_bins == n_pv on valid rows and the divisor below
         # (contributing_bins) coincides with n_pv there.
         valid = (contributing_bins == n_pv) & ~zero_flow_cout
-    elif isinstance(spinup, (int, float)) and not isinstance(spinup, bool) and 0.0 <= spinup <= 1.0:
-        valid = (contributing_bins >= spinup * n_pv) & ~zero_flow_cout & (contributing_bins > 0)
     else:
-        msg = f"spinup must be None, 'constant', or float in [0, 1]; got {spinup!r}"
-        raise ValueError(msg)
+        # ``_resolve_spinup_inputs`` has already narrowed a non-None threshold to a
+        # float in [0, 1], so no further type/range check is reachable here.
+        valid = (contributing_bins >= spinup * n_pv) & ~zero_flow_cout & (contributing_bins > 0)
 
+    # Every valid row has contributing_bins > 0 (== n_pv > 0 for strict validity,
+    # > 0 for the float threshold), so the divisor is guaranteed positive.
     weights = np.zeros_like(band_vals)
-    safe_div = np.where(valid, contributing_bins, 1)
-    weights[valid, :] = band_vals[valid, :] / safe_div[valid, None]
+    weights[valid, :] = band_vals[valid, :] / contributing_bins[valid, None]
     return weights, col_start, ~valid
 
 

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -59,11 +59,13 @@ from gwtransport._validation import (
     _validate_no_nan,
     _validate_non_negative_array,
     _validate_positive_scalar,
+    _validate_retardation_factor,
     _validate_tedges_parity,
 )
 from gwtransport.advection_utils import _densify_weights, _resolve_spinup_inputs
 from gwtransport.deposition_utils import _clipped_linear_integral
 from gwtransport.utils import (
+    _make_strictly_monotone,
     cumulative_flow_volume,
     linear_interpolate,
     solve_inverse_transport_banded,
@@ -79,6 +81,7 @@ def _validate_deposition_inputs(
     porosity: float,
     thickness: float,
     retardation_factor: float = 1.0,
+    spinup: str | float | None = "constant",
     cout_tedges: pd.DatetimeIndex | None = None,
     cout_values: np.ndarray | None = None,
     dep_values: np.ndarray | None = None,
@@ -108,7 +111,17 @@ def _validate_deposition_inputs(
     ValueError
         If any of the activated checks fails. The specific message names which
         invariant was violated (see body for the verbatim strings).
+    NotImplementedError
+        If ``spinup`` is a float. The fraction-threshold mode is not
+        implemented for deposition (matching the diffusion family); only
+        ``None`` and ``"constant"`` are supported.
     """
+    if isinstance(spinup, float):
+        msg = (
+            "deposition's spinup parameter only supports None or 'constant'; "
+            f"float thresholds are not yet implemented (got {spinup!r})"
+        )
+        raise NotImplementedError(msg)
     if dep_values is not None:
         _validate_tedges_parity(tedges, dep_values, tedges_name="tedges", values_name="dep")
     _validate_tedges_parity(tedges, flow_values, tedges_name="tedges", values_name="flow")
@@ -135,9 +148,7 @@ def _validate_deposition_inputs(
         name="aquifer_pore_volume",
         message=f"Aquifer pore volume must be positive, got {aquifer_pore_volume}",
     )
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
+    _validate_retardation_factor(retardation_factor)
 
 
 def compute_deposition_weights(
@@ -168,7 +179,8 @@ def compute_deposition_weights(
     cumulative flow volume ``flow_cum``; the per-cell math reuses
     ``gwtransport.deposition_utils._clipped_linear_integral`` restricted to
     the band columns, so each row sums to
-    ``r_k = residence_time_k / (porosity * thickness)``. Reconstruct the dense
+    ``r_k = residence_time_k / (retardation_factor * porosity * thickness)``.
+    Reconstruct the dense
     ``(n_cout, n_cin)`` matrix with
     ``gwtransport.advection_utils._densify_weights`` when a dense operator
     is required (the nullspace inverse).
@@ -195,8 +207,8 @@ def compute_deposition_weights(
     band_vals : numpy.ndarray
         Banded weights of shape ``(n_cout, full_band)``. Slot ``band_vals[k, b]``
         is the weight on cin bin ``col_start[k] + b``. Row ``k`` sums to
-        ``r_k = residence_time_k / (porosity * thickness)``; invalid rows (NaN
-        residence time, zero-flow cout bins) are zero.
+        ``r_k = residence_time_k / (retardation_factor * porosity * thickness)``;
+        invalid rows (NaN residence time, zero-flow cout bins) are zero.
     col_start : numpy.ndarray of int
         First cin bin index of each cout row's band, shape ``(n_cout,)``.
     row_valid : numpy.ndarray of bool
@@ -262,7 +274,7 @@ def compute_deposition_weights(
     y_at_edge = flow_cum[band_edge_clipped]  # (n_cout, full_band + 1)
     y_top = y_at_edge - sv_top[:, None]
     y_bot = y_at_edge - sv_bot[:, None]
-    widths = dt[np.clip(col_start[:, None] + np.arange(full_band)[None, :], 0, n_cin - 1)]
+    widths = dt[np.clip(band_edge[:, :-1], 0, n_cin - 1)]
     # Zero the width of right-pad slots (band slot index >= width) so they add nothing.
     slot = np.arange(full_band)[None, :]
     widths = np.where(slot < width[:, None], widths, 0.0)
@@ -272,11 +284,14 @@ def compute_deposition_weights(
     # (porosity*thickness) converts that overlap to plan-area * time, the areal
     # footprint (and duration) over which the areal deposition flux is mixed down
     # through the aquifer thickness. The bin width is already folded into the
-    # integral, so do NOT multiply by widths again.
+    # integral, so do NOT multiply by widths again. The R-scaled window (r_apv)
+    # stretches this measure by R, but the steady-state areal mass balance
+    # Q*cout = dep*A_plan is R-independent (retardation delays breakthrough, it
+    # does not raise the outlet concentration), so divide out that same R here.
     top_integral = _clipped_linear_integral(y_top[:, :-1], y_top[:, 1:], widths, 0.0, r_apv)
     bottom_integral = _clipped_linear_integral(y_bot[:, :-1], y_bot[:, 1:], widths, 0.0, r_apv)
     contact_volume_time = np.maximum(top_integral - bottom_integral, 0.0)
-    numerator = contact_volume_time / (porosity * thickness)
+    numerator = contact_volume_time / (porosity * thickness * retardation_factor)
 
     band_vals = np.zeros((n_cout, full_band))
     # row_valid implies extracted_volume > 0, so the masked divide never sees a zero.
@@ -294,7 +309,7 @@ def deposition_to_extraction(
     porosity: float,
     thickness: float,
     retardation_factor: float = 1.0,
-    spinup: str | float | None = "constant",
+    spinup: str | None = "constant",
 ) -> npt.NDArray[np.floating]:
     """Compute concentrations from deposition rates (convolution).
 
@@ -317,20 +332,28 @@ def deposition_to_extraction(
         Aquifer thickness [m].
     retardation_factor : float, optional
         Compound retardation factor, by default 1.0.
-    spinup : {"constant"} | float in [0, 1] | None, optional
+    spinup : {"constant"} | None, optional
         Spin-up policy applied before computing deposition weights.
         Default ``"constant"`` shifts ``tedges[0]`` backward by
         ``retardation_factor * aquifer_pore_volume / flow[0]`` and treats
         ``dep`` and ``flow`` as constant at their first observed values
         over the prepended interval. ``None`` keeps the existing
         strict-validity behavior (NaN cout rows during spin-up). A float
-        value is accepted but silently ignored; behavior is identical to
-        ``None``.
+        raises ``NotImplementedError`` -- the fraction-threshold mode is
+        not implemented for deposition (matching the diffusion family).
 
     Returns
     -------
     numpy.ndarray
         Concentration changes [g/m³] with length len(cout_tedges) - 1.
+
+        Zero-extraction-flow cout bins (no water leaves the aquifer over the
+        bin) return ``0.0``, not NaN. This deliberately differs from advection,
+        which returns NaN for its undefined zero-flow output: the deposition
+        source term is defined even with no water (an areal flux still supplies
+        mass), and a bin that extracts zero volume carries zero mass, so ``0.0``
+        is the physically correct value rather than an undefined result. NaN is
+        reserved for spin-up bins whose residence time is not yet resolved.
 
     Raises
     ------
@@ -339,6 +362,9 @@ def deposition_to_extraction(
         arrays contain NaN values, or if physical parameters are out of
         valid range (porosity not in (0, 1), non-positive thickness or
         aquifer pore volume).
+    NotImplementedError
+        If ``spinup`` is a float (the fraction-threshold mode is not
+        implemented for deposition).
 
     See Also
     --------
@@ -385,6 +411,7 @@ def deposition_to_extraction(
         porosity=porosity,
         thickness=thickness,
         retardation_factor=retardation_factor,
+        spinup=spinup,
         dep_values=dep_values,
     )
 
@@ -430,7 +457,7 @@ def extraction_to_deposition(
     thickness: float,
     retardation_factor: float = 1.0,
     regularization_strength: float = 1e-10,
-    spinup: str | float | None = "constant",
+    spinup: str | None = "constant",
 ) -> npt.NDArray[np.floating]:
     """Compute deposition rates from concentration changes (deconvolution).
 
@@ -478,15 +505,16 @@ def extraction_to_deposition(
 
         Larger values trust the target more (smoother, more biased); smaller
         values trust the data more (noisier, less biased). Default is 1e-10.
-    spinup : {"constant"} | float in [0, 1] | None, optional
+    spinup : {"constant"} | None, optional
         Spin-up policy applied before building the forward weight matrix.
         Default ``"constant"`` shifts ``tedges[0]`` backward by
         ``retardation_factor * aquifer_pore_volume / flow[0]`` and treats
         flow as constant at its first value over the prepended interval;
         the recovered deposition vector is sliced back to the original
         ``tedges`` length so the public output shape is unchanged.
-        ``None`` keeps strict-validity behavior. A float value is accepted
-        but silently ignored; behavior is identical to ``None``.
+        ``None`` keeps strict-validity behavior. A float raises
+        ``NotImplementedError`` -- the fraction-threshold mode is not
+        implemented for deposition (matching the diffusion family).
 
     Returns
     -------
@@ -498,6 +526,9 @@ def extraction_to_deposition(
     ------
     ValueError
         If input dimensions are incompatible or if flow contains NaN values.
+    NotImplementedError
+        If ``spinup`` is a float (the fraction-threshold mode is not
+        implemented for deposition).
 
     See Also
     --------
@@ -520,7 +551,8 @@ def extraction_to_deposition(
     the cin bins inside its residence-time window -- and is built and solved in
     a compact banded layout (peak memory ``O(n_cin * band)``, never the dense
     ``O(n_cout * n_cin)``). Unlike advection (where rows sum to ~1), deposition
-    rows sum to ``r_i = residence_time_i / (porosity * thickness)``. Rows are
+    rows sum to ``r_i = residence_time_i / (retardation_factor * porosity *
+    thickness)``. Rows are
     rescaled by ``r_i`` before solving: for systems where ``cout`` lies in
     the column space of ``W`` this preserves the exact ``dep``, while for
     overdetermined systems with noise it is equivalent to weighted least
@@ -573,6 +605,7 @@ def extraction_to_deposition(
         porosity=porosity,
         thickness=thickness,
         retardation_factor=retardation_factor,
+        spinup=spinup,
         cout_tedges=cout_tedges,
         cout_values=cout_values,
     )
@@ -637,7 +670,7 @@ def extraction_to_deposition_full(
     nullspace_objective: str | Callable = "squared_differences",
     optimization_method: str = "BFGS",
     rcond: float | None = None,
-    spinup: str | float | None = "constant",
+    spinup: str | None = "constant",
 ) -> npt.NDArray[np.floating]:
     """Compute deposition rates from concentration changes using nullspace solver.
 
@@ -683,13 +716,14 @@ def extraction_to_deposition_full(
     rcond : float or None, optional
         Cutoff for small singular values in the least-squares step.
         Default is None (uses numpy default).
-    spinup : {"constant"} | float in [0, 1] | None, optional
+    spinup : {"constant"} | None, optional
         Spin-up policy applied before building the forward weight matrix.
         Default ``"constant"`` shifts ``tedges[0]`` backward by
         ``retardation_factor * aquifer_pore_volume / flow[0]``; the
         recovered deposition is sliced back to the original ``tedges``
-        length. ``None`` keeps strict-validity behavior. A float value is
-        accepted but silently ignored; behavior is identical to ``None``.
+        length. ``None`` keeps strict-validity behavior. A float raises
+        ``NotImplementedError`` -- the fraction-threshold mode is not
+        implemented for deposition (matching the diffusion family).
         See :func:`extraction_to_deposition` for full semantics.
 
     Returns
@@ -705,6 +739,9 @@ def extraction_to_deposition_full(
         does not have one more element than flow, if flow contains NaN
         values, or if physical parameters are out of valid range (porosity
         not in (0, 1), non-positive thickness or aquifer pore volume).
+    NotImplementedError
+        If ``spinup`` is a float (the fraction-threshold mode is not
+        implemented for deposition).
 
     See Also
     --------
@@ -728,6 +765,7 @@ def extraction_to_deposition_full(
         porosity=porosity,
         thickness=thickness,
         retardation_factor=retardation_factor,
+        spinup=spinup,
         cout_tedges=cout_tedges,
         cout_values=cout_values,
     )
@@ -773,7 +811,7 @@ def spinup_duration(
     flow: npt.ArrayLike,
     tedges: pd.DatetimeIndex,
     aquifer_pore_volume: float,
-    retardation_factor: float,
+    retardation_factor: float = 1.0,
 ) -> float:
     """
     Compute the spinup duration for deposition modeling.
@@ -794,8 +832,9 @@ def spinup_duration(
         Time edges for the flow data.
     aquifer_pore_volume : float
         Pore volume of the aquifer [m³].
-    retardation_factor : float
-        Retardation factor of the compound in the aquifer [dimensionless].
+    retardation_factor : float, optional
+        Retardation factor of the compound in the aquifer [dimensionless], by
+        default 1.0.
 
     Returns
     -------
@@ -845,5 +884,7 @@ def spinup_duration(
         raise ValueError(msg)
     # Plateaus in flow_cum from Q = 0 bins make V → t inversion multi-valued; bump duplicates
     # by the smallest representable amount so np.interp resolves consistently at plateau levels.
-    flow_cum = cumulative_flow_volume(flow_arr, dt_days, strictly_monotone=True)
+    # Reuse the raw cumsum (bit-identical to cumulative_flow_volume(..., strictly_monotone=True),
+    # which applies the same _make_strictly_monotone to the same array).
+    flow_cum = _make_strictly_monotone(flow_cum_raw)
     return float(linear_interpolate(x_ref=flow_cum, y_ref=tedges_days, x_query=target_cum))

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -28,7 +28,9 @@ When to choose this module vs :mod:`gwtransport.diffusion_fast`
 ---------------------------------------------------------------
 
 This is the reference implementation: it evaluates the bin-averaged Kreft-Zuber flux
-concentration by 16-point Gauss-Legendre quadrature (splitting at flow-bin boundaries).
+concentration by resolution-aware composite Gauss-Legendre quadrature (splitting at
+flow-bin boundaries, with extra front-centred panels wherever a sharp breakthrough front
+is otherwise under-resolved).
 Prefer it only when the output grid is coarser than the flow detail -- it integrates the
 full within-bin flow, which the closed-form :mod:`gwtransport.diffusion_fast` approximates as
 constant per output bin. Otherwise that module computes the same physics to machine
@@ -75,17 +77,23 @@ where:
   travelled [m]
 
 The K-Z flux-correction term is what makes the column-sum invariant
-``integral Q c_out dt = integral Q c_in dt`` hold to machine precision under
-arbitrary variable Q. Without it, the leading-order C_R loses O(1/Pe) per
-column under variable Q + pure D_m (issue #180).
+``integral Q c_out dt = integral Q c_in dt`` hold under arbitrary variable Q.
+Without it, the leading-order C_R loses O(1/Pe) per column under variable Q +
+pure D_m (issue #180).
 
-Implementation: the bin-averaged C_F is computed by 16-point Gauss-Legendre
-quadrature in volume space, split at flow-bin boundaries so each sub-interval
-sees a linear t(V) and a smooth integrand. The variance is evaluated at each
-quadrature node from the parcel's own tau and xi histories — never capped at
-the residence time. The K-Z identity requires Bear's formula to satisfy the
-variable-coefficient ADE exactly, which holds only when D_t is allowed to
-keep growing past breakthrough.
+Implementation: the bin-averaged C_F is computed by resolution-aware composite
+Gauss-Legendre quadrature in volume space, split at flow-bin boundaries so each
+sub-interval sees a linear t(V). Within a sub-interval the erf-like front has
+width ``sqrt(4*D_t)`` (in volume units); for near-zero dispersivity this can be
+orders of magnitude below the flow-bin width, so a single fixed-order rule
+cannot resolve it. Sub-intervals whose front is under-resolved are therefore
+tiled with front-centred panels (fine near the front, flat tails outside),
+which restores the column-mass invariant to ~1e-11 for every dispersion regime;
+smooth/already-resolved sub-intervals keep the plain single 16-point rule. The
+variance is evaluated at each quadrature node from the parcel's own tau and xi
+histories — never capped at the residence time. The K-Z identity requires
+Bear's formula to satisfy the variable-coefficient ADE exactly, which holds only
+when D_t is allowed to keep growing past breakthrough.
 
 Macrodispersion vs microdispersion
 ----------------------------------
@@ -131,6 +139,7 @@ from gwtransport._validation import (
     _validate_no_nan,
     _validate_non_negative_array,
     _validate_positive_array,
+    _validate_retardation_factor,
     _validate_scalar_or_matching_length,
     _validate_tedges_parity,
 )
@@ -142,6 +151,20 @@ EPSILON_COEFF_SUM = 1e-10
 
 # Gauss-Legendre quadrature nodes and weights for volume-space integration
 _GL_NODES, _GL_WEIGHTS = np.polynomial.legendre.leggauss(16)
+
+# Resolution-aware composite-quadrature template for the erf-like breakthrough front.
+# When the front width sqrt(4*D_t) (in volume units) is much smaller than a
+# (cell, flow-bin) sub-interval, plain 16-point GL cannot resolve it. Cells flagged
+# as under-resolved get panels placed at ``V_front + front_width * _FRONT_OFFSETS``
+# (clipped to the sub-interval); the two outer panels then cover the flat erf tails,
+# where 16-point GL is already exact. Panels near the front are ~1 front-width wide,
+# spanning +-6 front-widths (erf and the flux-correction Gaussian are flat to ~1e-16
+# beyond that). A cell is refined only when its front lies inside the sub-interval and
+# the sub-interval is wider than _REFINE_RATIO front-widths, so adaptivity triggers
+# only near sharp fronts (smooth regimes keep the plain single-panel cost and answer).
+_FRONT_REACH = 6.0
+_FRONT_OFFSETS = np.arange(-_FRONT_REACH, _FRONT_REACH + 0.5, 1.0)
+_REFINE_RATIO = 4.0
 
 
 def _cfrac_mean_volume(
@@ -196,12 +219,16 @@ def _cfrac_mean_volume(
     misses the dispersive boundary flux at the outlet and column-sum mass
     conservation fails by O(1/Pe) under variable Q.
 
-    Implementation: 16-point Gauss-Legendre quadrature in volume space, split
-    at flow-bin boundaries so that within each sub-interval :math:`t(V)` is
-    linear and the integrand is smooth. No "fully capped" branch: the moving-
-    frame variance keeps growing past breakthrough, and the K-Z identity
-    requires Bear's formula to satisfy the variable-coefficient ADE exactly
-    (which it does only without capping).
+    Implementation: resolution-aware composite Gauss-Legendre quadrature in
+    volume space, split at flow-bin boundaries so that within each sub-interval
+    :math:`t(V)` is linear. The erf-like front has width :math:`\sqrt{4 D_t}`
+    (in volume units); a sub-interval whose front is under-resolved by a single
+    16-point rule (front width far below the sub-interval width) is tiled with
+    front-centred panels (see ``_FRONT_OFFSETS``), while smooth/already-resolved
+    sub-intervals keep the plain single 16-point rule (bit-identical to it). No
+    "fully capped" branch: the moving-frame variance keeps growing past
+    breakthrough, and the K-Z identity requires Bear's formula to satisfy the
+    variable-coefficient ADE exactly (which it does only without capping).
 
     Parameters
     ----------
@@ -276,11 +303,14 @@ def _cfrac_mean_volume(
             0.0,
         )
 
-    # --- Gauss-Legendre quadrature over each cell, split by flow bins ---
+    # --- Resolution-aware composite Gauss-Legendre quadrature, split by flow bins ---
     # The integration window per (cell, flow-bin) is the intersection of
     # [V_lo, V_hi] (cell), [ve_lo, ve_hi] (flow bin), and [V_j, infty) (parcel
-    # entered). Within each sub-interval, t(V) is linear and the integrand is
-    # smooth, so 16-point GL gives machine precision.
+    # entered). Within each sub-interval, t(V) is linear. Where the sub-interval is
+    # much wider than the front width sqrt(4*D_t), the erf-like front is under-resolved
+    # by a single 16-point GL rule; such sub-intervals are tiled with front-centred
+    # panels (see _FRONT_OFFSETS). Smooth sub-intervals keep the single panel and are
+    # bit-identical to the plain 16-point rule.
     idx_i, idx_j = np.nonzero(is_valid)
     if len(idx_i) == 0:
         return frac
@@ -292,6 +322,9 @@ def _cfrac_mean_volume(
     total_dv = v_hi_cells - v_lo_cells
     valid_cells = total_dv > 0
 
+    # Post-injection lower bound is loop-invariant: max(V_lo, V_cin) (D2 hoist).
+    v_lo_or_cin = np.maximum(v_lo_cells, v_cin_cells)
+
     integral_cf = np.zeros(len(idx_i))
 
     vol_edges = cumulative_volume_at_cin_tedges
@@ -300,31 +333,64 @@ def _cfrac_mean_volume(
         if v_per_bin[k] <= 0.0:
             continue
         dl_over_v_k = dl_over_v_per_bin[k]
+        dt_sub_bin = tedges_days[k + 1] - tedges_days[k]
+        dv_sub_edge = ve_hi - ve_lo
 
         # Intersection of cell, flow-bin, and post-injection range
-        sub_lo = np.maximum(np.maximum(v_lo_cells, ve_lo), v_cin_cells)
+        sub_lo = np.maximum(v_lo_or_cin, ve_lo)
         sub_hi = np.minimum(v_hi_cells, ve_hi)
         overlap = (sub_hi > sub_lo) & valid_cells
         if not np.any(overlap):
             continue
 
-        dv_sub = sub_hi[overlap] - sub_lo[overlap]
-        v_mid_sub = (sub_hi[overlap] + sub_lo[overlap]) / 2.0
-        v_half_sub = dv_sub / 2.0
+        lo = sub_lo[overlap]
+        hi = sub_hi[overlap]
+        vcin = v_cin_cells[overlap]
+        tj = t_j_cells[overlap]
 
-        v_nodes = v_mid_sub[:, np.newaxis] + v_half_sub[:, np.newaxis] * _GL_NODES[np.newaxis, :]
+        # Front centre (x = 0 => xi = L => V = V_cin + r_vpv) and its width in volume.
+        # front_width = sqrt(4*D_t_front) * r_vpv / L, with D_t_front = D_m*tau_front +
+        # alpha_L*L (xi = L at the front). t(V) is linear within flow bin k.
+        v_front = vcin + r_vpv
+        t_front = tedges_days[k] + (v_front - ve_lo) * (dt_sub_bin / dv_sub_edge)
+        tau_front = np.maximum(t_front - tj, 0.0)
+        dt_front = molecular_diffusivity * tau_front + longitudinal_dispersivity * streamline_len
+        front_width = np.sqrt(4.0 * dt_front) * r_vpv / streamline_len
+
+        # Refine only where a sharp front region intersects this sub-interval and is
+        # under-resolved by a single 16-point rule; elsewhere the integrand is flat
+        # or already resolved, so one panel is exact. The front-region test (not just
+        # "centre in this bin") also catches a front whose tail spills across a
+        # flow-bin boundary. A spuriously large extrapolated front_width far from the
+        # front fails ``underresolved`` and so cannot trigger refinement.
+        front_hits = (v_front + _FRONT_REACH * front_width > lo) & (v_front - _FRONT_REACH * front_width < hi)
+        underresolved = (hi - lo) > _REFINE_RATIO * front_width
+        if np.any(front_hits & underresolved):
+            inner = np.clip(
+                v_front[:, np.newaxis] + front_width[:, np.newaxis] * _FRONT_OFFSETS[np.newaxis, :],
+                lo[:, np.newaxis],
+                hi[:, np.newaxis],
+            )
+            edges = np.concatenate([lo[:, np.newaxis], inner, hi[:, np.newaxis]], axis=1)
+        else:
+            edges = np.stack([lo, hi], axis=1)
+
+        p_lo = edges[:, :-1]
+        p_hi = edges[:, 1:]
+        p_mid = 0.5 * (p_lo + p_hi)
+        p_half = 0.5 * (p_hi - p_lo)
+
+        # GL nodes over every panel: shape (n_cell, n_panel, n_gl)
+        v_nodes = p_mid[:, :, np.newaxis] + p_half[:, :, np.newaxis] * _GL_NODES[np.newaxis, np.newaxis, :]
 
         # Geometry: x = xi - L = (V - V_j - r_vpv) * L / r_vpv (parcel position
         # relative to outlet); xi = parcel travel distance.
-        x_nodes = (v_nodes - v_cin_cells[overlap, np.newaxis] - r_vpv) * streamline_len / r_vpv
+        x_nodes = (v_nodes - vcin[:, np.newaxis, np.newaxis] - r_vpv) * streamline_len / r_vpv
         xi_nodes = x_nodes + streamline_len
 
-        # t(V) linear within flow bin k
-        dt_sub_bin = tedges_days[k + 1] - tedges_days[k]
-        dv_sub_edge = ve_hi - ve_lo
         t_nodes = tedges_days[k] + (v_nodes - ve_lo) * (dt_sub_bin / dv_sub_edge)
-        # tau >= 0 by construction (sub_lo >= v_cin_cells); clip for safety.
-        tau_nodes = np.maximum(t_nodes - t_j_cells[overlap, np.newaxis], 0.0)
+        # tau >= 0 by construction (lo >= v_cin); clip for safety.
+        tau_nodes = np.maximum(t_nodes - tj[:, np.newaxis, np.newaxis], 0.0)
 
         # Bear's variance accumulator (sigma^2/2) — NO capping at RT/L
         dt_nodes = molecular_diffusivity * tau_nodes + longitudinal_dispersivity * xi_nodes
@@ -344,7 +410,11 @@ def _cfrac_mean_volume(
             )
         cf_vals = cr_vals + dl_over_v_k * gauss_vals
 
-        integral_cf[overlap] += v_half_sub * (cf_vals @ _GL_WEIGHTS)
+        # Integrate: GL-weight over nodes, then sum panel contributions per cell.
+        # The weight contraction is done in 2D so a single-panel (non-refined)
+        # sub-interval is bit-identical to a plain 16-point rule.
+        cf_weighted = (cf_vals.reshape(-1, cf_vals.shape[-1]) @ _GL_WEIGHTS).reshape(cf_vals.shape[:-1])
+        integral_cf[overlap] += (p_half * cf_weighted).sum(axis=1)
 
     with np.errstate(divide="ignore", invalid="ignore"):
         frac_cells = np.where(valid_cells, integral_cf / total_dv, np.nan)
@@ -452,9 +522,7 @@ def _validate_diffusion_inputs(
     _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
     _validate_positive_array(aquifer_pore_volumes, name="aquifer_pore_volumes")
     _validate_positive_array(streamline_length, name="streamline_length")
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
+    _validate_retardation_factor(retardation_factor)
 
 
 def _prepare_diffusion_arrays(
@@ -763,11 +831,14 @@ def infiltration_to_extraction(
          from the outlet at each (cout-edge, cin-edge)
 
     2. For each cell, compute the bin-averaged Kreft-Zuber flux concentration
-       ``frac[i, j] = (1/dV_i) * integral C_F(L, V; t_j) dV`` by 16-point
-       Gauss-Legendre quadrature in volume space, split at flow-bin
-       boundaries so that ``t(V)`` is linear within each sub-interval. The
-       moving-frame variance ``D_t = D_m*tau + alpha_L*xi`` is evaluated at
-       each quadrature node (never capped at the residence time).
+       ``frac[i, j] = (1/dV_i) * integral C_F(L, V; t_j) dV`` by resolution-aware
+       composite Gauss-Legendre quadrature in volume space, split at flow-bin
+       boundaries so that ``t(V)`` is linear within each sub-interval. Where the
+       erf-like front (width ``sqrt(4*D_t)`` in volume units) is under-resolved by
+       a single 16-point rule -- as for near-zero dispersivity -- the sub-interval
+       is tiled with front-centred panels; smooth sub-intervals keep the single
+       rule. The moving-frame variance ``D_t = D_m*tau + alpha_L*xi`` is evaluated
+       at each quadrature node (never capped at the residence time).
 
     3. Coefficient for bin: ``coeff[i,j] = frac[i, j] - frac[i, j+1]``. This
        is the contribution of cin[j] to cout[i] in the W matrix.

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -223,13 +223,20 @@ def _pv_band_values(
     r"""Bin-averaged ``C_F`` stripe for one streamtube on the shared band (values pass).
 
     ``C_F`` over a cout bin is ``(I(x_hi) - I(x_lo)) / dx`` with the closed-form antiderivative
-    ``I`` evaluated at both cout edges over the band cin edges. Because ``D_t = D_m*tau + alpha_L*xi``
+    ``I`` evaluated at the two cout edges bounding the bin. Because ``D_t = D_m*tau + alpha_L*xi``
     with ``tau = R*V/(L*Q)``, the antiderivative's slope ``dD_t/dx = R*D_m/v_fluid + alpha_L =
     D_s/v_s`` is exactly the Kreft-Zuber flux coefficient at the solute-front velocity
     ``v_s = Q*L/(R*V_pore)``, so the flux concentration emerges natively -- no correction term is
     added. The stripe is the band itself: each row spans cin edges
     ``col_start[k] .. col_start[k] + full_band`` (``full_band + 1`` edges), so the coefficient for
-    band offset ``b`` (cin bin ``col_start[k] + b``) is ``frac[b] - frac[b + 1]``. The
+    band offset ``b`` (cin bin ``col_start[k] + b``) is ``frac[b] - frac[b + 1]``.
+
+    ``I`` is evaluated once per cout EDGE, not once per (row, edge) pair: an interior edge bounds two
+    adjacent rows (it is a row's upper edge and the next row's lower edge), so the two evaluations of
+    ``I`` there are the identical function of the identical breakthrough coordinate. The build
+    therefore evaluates ``I`` on the ``n_cout_bins + 1`` cout edges over a single per-edge cin-edge
+    window (anchored so both adjacent rows can read it), then gathers each row's lower/upper edge
+    values from it -- roughly halving the ``erf`` work relative to evaluating both edges per row. The
     zero-dispersion limit is exact here too: ``D_t`` floors to ``_DT_FLOOR``, so ``C_F`` is a step
     smoothed by ~1e-15.
 
@@ -241,17 +248,33 @@ def _pv_band_values(
     """
     v_cin = cumulative_volume_at_cin
     n_cin_edges = v_cin.size
-    v_cout_lo, v_cout_hi = cumulative_volume_at_cout[:-1], cumulative_volume_at_cout[1:]
-    t_cout_lo, t_cout_hi = cout_tedges_days[:-1], cout_tedges_days[1:]
+    n_cout_bins = cumulative_volume_at_cout.size - 1
+    width = full_band + 1
 
-    # Bin-averaged C_F over the band: I evaluated at both cout edges on the full_band + 1 cin edges
-    # of each row's band. Edges are clipped to the real data edges, which the warm-start extension
-    # makes saturated, so out-of-range edges carry frac 0/1 and telescope away in the difference.
-    cols = col_start[:, None] + np.arange(full_band + 1)[None, :]
-    cc = np.clip(cols, 0, n_cin_edges - 1)
-    v_c, t_c = v_cin[cc], tedges_days[cc]
-    sw_lo = (v_cout_lo[:, None] - v_c - r_vpv) * length / r_vpv
-    sw_hi = (v_cout_hi[:, None] - v_c - r_vpv) * length / r_vpv
+    # Per-edge cin-edge window. Cout edge e bounds row e (as its lower edge, needing cin band anchor
+    # col_start[e]) and row e-1 (as its upper edge, needing col_start[e-1]); anchoring at the smaller
+    # of the two lets one evaluation serve both. col_start is non-decreasing here, but the min keeps
+    # both read offsets non-negative regardless. The sentinel (>= any column) drops the absent
+    # consumer at the two end edges. The window is widened past full_band + 1 only by the col_start
+    # jump between adjacent rows (typically 0-1), so it collapses to the row width when aligned.
+    big = n_cin_edges
+    estart = np.minimum(np.append(col_start, big), np.append(big, col_start))
+    lo_off = col_start - estart[:-1]
+    hi_off = col_start - estart[1:]
+    edge_width = width + int(max(lo_off.max(), hi_off.max()))
+    edge_cols = np.clip(estart[:, None] + np.arange(edge_width)[None, :], 0, n_cin_edges - 1)
+    v_c, t_c = v_cin[edge_cols], tedges_days[edge_cols]
+    sw_edge = (cumulative_volume_at_cout[:, None] - v_c - r_vpv) * length / r_vpv
+
+    # Gather each row's lower (cout edge k) and upper (cout edge k + 1) breakthrough coordinates from
+    # the per-edge stripe. Clipped cin edges fall in the warm-start-saturated tail, carrying frac 0/1
+    # that telescopes away in the coefficient difference.
+    rows = np.arange(n_cout_bins)[:, None]
+    band = np.arange(width)[None, :]
+    lo_idx = lo_off[:, None] + band
+    hi_idx = hi_off[:, None] + band
+    sw_lo = sw_edge[rows, lo_idx]
+    sw_hi = sw_edge[rows + 1, hi_idx]
 
     # No dispersion: C_R is the step H(x); its exact bin-average is the fraction of the cout bin with
     # x > 0, and at a zero-width (dv_cout = 0) cout bin it is the point value 0.5*(1 + sign(x_lo)).
@@ -264,18 +287,14 @@ def _pv_band_values(
         frac = np.where(dx > 0.0, frac, 0.5 + 0.5 * np.sign(sw_lo))
         return frac[:, :-1] - frac[:, 1:]
 
-    dt_lo = np.maximum(
-        molecular_diffusivity * np.maximum(t_cout_lo[:, None] - t_c, 0.0)
-        + longitudinal_dispersivity * np.maximum(sw_lo + length, 0.0),
+    dt_edge = np.maximum(
+        molecular_diffusivity * np.maximum(cout_tedges_days[:, None] - t_c, 0.0)
+        + longitudinal_dispersivity * np.maximum(sw_edge + length, 0.0),
         _DT_FLOOR,
     )
-    dt_hi = np.maximum(
-        molecular_diffusivity * np.maximum(t_cout_hi[:, None] - t_c, 0.0)
-        + longitudinal_dispersivity * np.maximum(sw_hi + length, 0.0),
-        _DT_FLOOR,
-    )
-    i_lo = _breakthrough_antideriv(sw_lo, dt_lo)
-    i_hi = _breakthrough_antideriv(sw_hi, dt_hi)
+    i_edge = _breakthrough_antideriv(sw_edge, dt_edge)
+    i_lo = i_edge[rows, lo_idx]
+    i_hi = i_edge[rows + 1, hi_idx]
     dx = sw_hi - sw_lo
     with np.errstate(divide="ignore", invalid="ignore"):
         frac = np.where(dx > 0.0, (i_hi - i_lo) / dx, 0.0)

--- a/src/gwtransport/diffusion_fast_fast.py
+++ b/src/gwtransport/diffusion_fast_fast.py
@@ -41,13 +41,17 @@ Accuracy (vs :mod:`gwtransport.diffusion_fast`, flow-independent unless noted)
 ------------------------------------------------------------------------------
 
 - **~3e-4 whenever microdispersion is present** (``alpha_L > 0`` -- the typical groundwater
-  regime, Peclet number >> 1), constant *and* variable flow. Here molecular diffusion is
-  sub-dominant, so approximating it barely matters.
+  regime, Peclet number >> 1), constant *and* variable flow, for realistic solute diffusivities
+  (``D_m`` ~ 1e-4) or ``R = 1``. Here molecular diffusion is sub-dominant, so approximating it
+  barely matters. This survives retardation for a typical APVD (measured <~1e-3 up to ``R = 3``).
 - In the **molecular-diffusion-dominated** corner (``alpha_L`` ~ 0): ~1e-4 for smooth inputs, but
   degrading to ~1e-2 for sharp inputs (and ~5e-2 for sharp inputs with a very wide / bimodal APVD or
   a large single pore volume), because the symmetric time-Gaussian cannot reproduce the skewed
-  molecular breakthrough. **Use** :mod:`gwtransport.diffusion_fast` **for exact results in this
-  regime.**
+  molecular breakthrough. **Retardation enlarges this corner:** the Gaussian's variance scales as
+  ``sigma_t^2 ~ D_m * R^3``, so ``R > 1`` reaches the ~1e-2 looseness at a smaller ``D_m`` -- a
+  sharp input at ``D_m = 0.01`` degrades from ~8e-4 at ``R = 1`` to ~1.7e-2 at ``R = 2`` and ~3.5e-2
+  at ``R = 3``. **Use** :mod:`gwtransport.diffusion_fast` **for exact results in this regime** --
+  in particular for heat transport (``R > 1`` with a large ``D_m``).
 
 The inverse (:func:`extraction_to_infiltration`) deconvolves the *same* approximate operator the
 forward applies. It assembles ``W = G . M`` directly in banded form (one ``Ibar`` gather plus a
@@ -202,8 +206,12 @@ def _eval_antideriv(
     g0 = grid[0]
     dstep = grid[1] - grid[0]
     f = (dv - g0) / dstep
-    i0 = np.clip(np.floor(f).astype(np.intp), 0, grid.size - 2)
-    out = ibar[i0] + (f - i0) * (ibar[i0 + 1] - ibar[i0])
+    # astype truncates toward zero; equals floor on f >= 0 (the only regime that survives the
+    # dv < g0 override below and the lower clip), so the floor call is redundant. Precompute the
+    # segment slopes once so the O(N*band) gather reads a single array instead of differencing two.
+    slopes = np.diff(ibar)
+    i0 = np.clip(f.astype(np.intp), 0, grid.size - 2)
+    out = ibar[i0] + (f - i0) * slopes[i0]
     out = np.where(dv < g0, 0.0, out)
     return np.where(dv > grid[-1], dv - mean_r_vpv, out)
 
@@ -471,8 +479,11 @@ def infiltration_to_extraction(
     The advection + macrodispersion + microdispersion (``alpha_L``) part is the exact skewed
     ``D_m=0`` Kreft-Zuber breakthrough applied on the native cumulative-volume grid; molecular
     diffusion (``D_m``) is a symmetric time-domain Gaussian. The result is flow-independent and
-    accurate to ~3e-4 whenever ``alpha_L > 0`` (the typical regime), degrading to ~1e-2 (sharp
-    inputs) in the molecular-diffusion-dominated corner (``alpha_L`` ~ 0). For machine precision, use
+    accurate to ~3e-4 whenever ``alpha_L > 0`` (the typical regime) for realistic solute ``D_m``
+    (~1e-4) or ``R = 1``. It loosens to ~1e-2 (sharp inputs) in the molecular-diffusion-dominated
+    corner (``alpha_L`` ~ 0), and retardation enlarges that corner because the Gaussian variance
+    grows as ``D_m * R^3`` (a sharp input at ``D_m = 0.01`` reaches ~1.7e-2 at ``R = 2`` and ~3.5e-2
+    at ``R = 3``). For machine precision -- or heat transport with ``R > 1`` and large ``D_m`` -- use
     :mod:`gwtransport.diffusion_fast`.
 
     Parameters
@@ -572,11 +583,21 @@ def infiltration_to_extraction(
     coeff, cin_bin, sigma_bins, valid = operator
 
     # Apply the advection+macro+micro band M to the (warm-start-extended) cin, then the molecular
-    # time-Gaussian G. The Gaussian runs before masking so it operates on NaN-free values.
+    # time-Gaussian G. Output bins with no through-flow carry a hard 0 in cout_micro; a plain
+    # Gaussian would smear those zeros into the valid neighbours. Convolve mask-aware instead --
+    # G(cout_micro*support)/G(support) -- so gap bins act as missing (not zero) data. This equals a
+    # plain G where support is all-True (constants stay constant, incl. exactly across a gap).
     cin_ext = np.concatenate([[cin[0]], cin, [cin[-1]]]) if extend else cin
     cout_micro = np.einsum("kb,kb->k", coeff, cin_ext[cin_bin])
-    cout = cout_micro if sigma_bins == 0.0 else gaussian_filter1d(cout_micro, sigma_bins, mode="nearest", truncate=6.0)
-    return np.where((coeff.sum(axis=1) >= _EPSILON_COEFF_SUM) & valid, cout, np.nan)
+    support = coeff.sum(axis=1) >= _EPSILON_COEFF_SUM
+    if sigma_bins == 0.0:
+        cout = cout_micro
+    else:
+        num = gaussian_filter1d(cout_micro * support, sigma_bins, mode="nearest", truncate=6.0)
+        den = gaussian_filter1d(support.astype(float), sigma_bins, mode="nearest", truncate=6.0)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            cout = num / den  # den > 0 wherever support is True; 0/0 gap bins are masked out below
+    return np.where(support & valid, cout, np.nan)
 
 
 def extraction_to_infiltration(

--- a/src/gwtransport/examples.py
+++ b/src/gwtransport/examples.py
@@ -189,7 +189,9 @@ def generate_example_data(
     rng = np.random.default_rng(rng)
 
     dates = pd.date_range(start=date_start, end=date_end, freq=date_freq).tz_localize("UTC")
-    days = (dates - dates[0]).days.values
+    # Fractional elapsed days so the seasonal sinusoid resolves sub-daily sampling (integer .days
+    # would stair-step, holding the seasonal constant within each calendar day).
+    days = ((dates - dates[0]) / pd.Timedelta(days=1)).to_numpy()
 
     # Generate flow data with seasonal pattern (higher in winter)
     seasonal_flow = flow_mean + flow_amplitude * np.sin(2 * np.pi * days / 365 + np.pi)
@@ -647,8 +649,10 @@ def generate_example_deposition_timeseries(
     n_dates = len(dates)
     tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=n_dates)
 
-    # Base deposition rate with seasonal and event patterns
-    seasonal_pattern = seasonal_amplitude * np.sin(2 * np.pi * np.arange(n_dates) / 365.25)
+    # Base deposition rate with seasonal and event patterns. Use elapsed days (not the sample
+    # index) so the period stays one year for any ``freq``, not one year of samples.
+    days = ((dates - dates[0]) / pd.Timedelta(days=1)).to_numpy()
+    seasonal_pattern = seasonal_amplitude * np.sin(2 * np.pi * days / 365.25)
     noise = noise_scale * rng.normal(0, 1, n_dates)
 
     # Default event dates if not provided

--- a/src/gwtransport/fronttracking/events.py
+++ b/src/gwtransport/fronttracking/events.py
@@ -23,6 +23,39 @@ from gwtransport.fronttracking.waves import CharacteristicWave, DecayingShockWav
 
 # Numerical tolerance constants
 EPSILON_SPEED = 1e-15  # Tolerance for checking if two speeds are equal (machine precision)
+# A boundary state at/below the c_min retardation floor whose floored retardation
+# exceeds this value is "pinned": for the n>1 dry-soil singularity R(c_min) is
+# inflated to ~1e6, so the state advects orders of magnitude slower than any
+# physical wave and its outlet crossing lands at a non-physical θ (~1e8) that only
+# pollutes the diagnostic event record. n<1 clean water (R(c_min) ≈ 1, fast) stays
+# well below this threshold and is NOT pinned, so its outlet crossing is kept.
+OUTLET_PIN_RETARDATION = 1e4
+
+
+def is_outlet_crossing_pinned(concentration: float, sorption) -> bool:
+    """Whether a boundary state is pinned by the ``c_min`` retardation floor.
+
+    A crossing scheduled for such a state is a non-physical artifact (its speed is
+    a floor artifact, not physics); the caller drops it so it does not pollute the
+    solver's event record / ``theta_current``.
+
+    Parameters
+    ----------
+    concentration : float
+        Boundary-state concentration [mass/volume].
+    sorption : SorptionModel
+        Sorption model (supplies ``c_min`` and ``retardation``).
+
+    Returns
+    -------
+    bool
+        ``True`` only when ``concentration`` is at/below ``c_min`` AND the floored
+        retardation ``R(c_min)`` is inflated past :data:`OUTLET_PIN_RETARDATION`.
+    """
+    c_min = getattr(sorption, "c_min", 0.0)
+    if concentration > c_min:
+        return False
+    return float(sorption.retardation(c_min)) > OUTLET_PIN_RETARDATION
 
 
 class EventType(Enum):
@@ -288,7 +321,10 @@ def find_outlet_crossing(wave, v_outlet: float, theta_current: float) -> float |
 
         speed = characteristic_speed(wave.concentration, wave.sorption)
 
-        if speed <= 0:
+        # A c_min-floored (pinned) characteristic — R(c_min) inflated for n>1,
+        # c→0 — advects too slowly to cross at any physical θ; suppress the
+        # artifact crossing rather than scheduling it at θ~1e8.
+        if speed <= 0 or is_outlet_crossing_pinned(wave.concentration, wave.sorption):
             return None
 
         dtheta = (v_outlet - v_current) / speed

--- a/src/gwtransport/fronttracking/handlers.py
+++ b/src/gwtransport/fronttracking/handlers.py
@@ -296,6 +296,7 @@ def handle_shock_rarefaction_collision(
         theta_origin=raref.theta_start,
         sorption=sorption,
     )
+
     shock.deactivate(theta_event)
     raref.deactivate(theta_event)
     return [decaying]
@@ -374,11 +375,11 @@ def create_inlet_waves_at_theta(
     c_new: float,
     theta: float,
     sorption: SorptionModel,
-    v_inlet: float = 0.0,
 ) -> list:
     """Emit the wave produced by a step change in inlet concentration.
 
-    Wave type is determined by characteristic speed comparison in (V, θ):
+    All inlet waves originate at the inlet face ``V = 0``. Wave type is
+    determined by characteristic speed comparison in (V, θ):
 
     - ``s_new > s_prev``: compression → shock.
     - ``s_new < s_prev``: expansion → rarefaction.
@@ -400,7 +401,7 @@ def create_inlet_waves_at_theta(
         return [
             CharacteristicWave(
                 theta_start=theta,
-                v_start=v_inlet,
+                v_start=0.0,
                 concentration=c_new,
                 sorption=sorption,
             )
@@ -412,7 +413,7 @@ def create_inlet_waves_at_theta(
     if s_new > s_prev + 1e-15:
         shock = ShockWave(
             theta_start=theta,
-            v_start=v_inlet,
+            v_start=0.0,
             c_left=c_new,
             c_right=c_prev,
             sorption=sorption,
@@ -425,7 +426,7 @@ def create_inlet_waves_at_theta(
         return [
             RarefactionWave(
                 theta_start=theta,
-                v_start=v_inlet,
+                v_start=0.0,
                 c_head=c_prev,
                 c_tail=c_new,
                 sorption=sorption,
@@ -435,7 +436,7 @@ def create_inlet_waves_at_theta(
     return [
         CharacteristicWave(
             theta_start=theta,
-            v_start=v_inlet,
+            v_start=0.0,
             concentration=c_new,
             sorption=sorption,
         )

--- a/src/gwtransport/fronttracking/math.py
+++ b/src/gwtransport/fronttracking/math.py
@@ -280,37 +280,21 @@ class FreundlichSorption(NonlinearSorption):
         -----
         - For n > 1: R decreases with increasing C (higher C travels faster)
         - For n < 1: R increases with increasing C (higher C travels slower)
-        - n<1 with c_min=0: R(0)=1 (no sorption at zero, physically correct).
+        - n<1 with c_min=0: R(0)=1 (no sorption at zero, physically correct)
+          because clamping to ``c_min=0`` leaves ``C^((1/n)-1) = 0^positive = 0``.
         - Otherwise: ``c`` is clamped to ``c_min`` before evaluation. This pairs with
           :meth:`total_concentration`, which also clamps to ``c_min``.
+
+        Clamping with ``np.maximum`` before the power keeps a single general path
+        for every ``(n, c_min)`` combination and avoids raising the base to a
+        fractional power on negative ``c``.
         """
         is_array = isinstance(c, np.ndarray)
-        c_arr = np.asarray(c)
-
-        if self.c_min == 0 and self.n < 1.0:
-            result = np.where(c_arr <= 0, 1.0, self._compute_retardation(c_arr))
-        else:
-            c_eff = np.maximum(c_arr, self.c_min)
-            result = self._compute_retardation(c_eff)
-
-        return result if is_array else float(result)
-
-    def _compute_retardation(self, c: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
-        """Compute retardation for positive concentrations.
-
-        Parameters
-        ----------
-        c : numpy.ndarray
-            Dissolved concentration [mass/volume]. Must be positive.
-
-        Returns
-        -------
-        numpy.ndarray
-            Retardation factor [-]. Always >= 1.0.
-        """
+        c_eff = np.maximum(np.asarray(c), self.c_min)
         exponent = (1.0 / self.n) - 1.0
         coefficient = (self.bulk_density * self.k_f) / (self.porosity * self.n)
-        return 1.0 + coefficient * (c**exponent)
+        result = 1.0 + coefficient * (c_eff**exponent)
+        return result if is_array else float(result)
 
     def total_concentration(self, c: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """
@@ -753,7 +737,7 @@ class BrooksCoreyConductivity(NonlinearSorption):
     .. math::
         K(\\theta) = K_s \\cdot \\Theta^a, \\qquad
         \\Theta = (\\theta - \\theta_r)/(\\theta_s - \\theta_r), \\qquad
-        a = 3 + 2/\\lambda \\;(\\text{Mualem})
+        a = 3 + 2/\\lambda \\;(\\text{Burdine})
 
     is recast in the framework's ``(C, C_T)`` variables by identifying
     ``C ≡ K`` (the flux variable) and ``C_T ≡ θ - θ_r`` (the conserved
@@ -773,9 +757,10 @@ class BrooksCoreyConductivity(NonlinearSorption):
         Saturated hydraulic conductivity [length/time]. Positive.
     brooks_corey_lambda : float
         Pore-size distribution index ``λ`` [-]. Positive. The exponent
-        ``a = 3 + 2/λ`` (Mualem variant; Burdine's ``a = 2 + 3/λ`` is not
-        implemented in v1, but a user wanting it can re-derive ``λ`` so the
-        Mualem ``a`` matches the desired Burdine exponent).
+        ``a = 3 + 2/λ`` is the Burdine pore-connectivity result. The Mualem
+        variant (``L = 0.5``) gives ``a = 2.5 + 2/λ`` and is not implemented;
+        a user wanting it can re-derive ``λ`` so the Burdine ``a`` matches the
+        desired Mualem exponent.
 
     See Also
     --------
@@ -819,7 +804,7 @@ class BrooksCoreyConductivity(NonlinearSorption):
     brooks_corey_lambda: float
     """Pore-size distribution index λ [-]."""
     a: float = field(init=False)
-    """Exponent ``a = 3 + 2/λ`` (Mualem); set in ``__post_init__``."""
+    """Exponent ``a = 3 + 2/λ`` (Burdine); set in ``__post_init__``."""
     delta_theta: float = field(init=False)
     """``θ_s − θ_r``; set in ``__post_init__``."""
 

--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -46,6 +46,11 @@ EPSILON_VELOCITY = 1e-15  # Tolerance for checking if velocity is effectively ze
 EPSILON_TIME = 1e-15  # Tolerance for negligible time segments
 EPSILON_VOLUME = 1e-15  # Tolerance for negligible spatial-segment widths Δv [m³]
 EPSILON_POSITION = 1e-15  # Tolerance for shock-face proximity in position v [m³]
+# Multiplier on the eps·max(|m_in|,|m_dom|)/Δθ cancellation scale below which a conservation-form
+# residual is numerical zero. The m_dom fan-integral sum accumulates ~few·10² ULP over a
+# multi-pulse record (measured max ratio ~460); 65536 clears that with wide margin while staying
+# ~7 orders below any real breakthrough concentration (O(cin)).
+FP_CANCELLATION_CLAMP = 65536.0
 
 
 def concentration_at_point(
@@ -85,10 +90,10 @@ def concentration_at_point(
     point, returns 0.0 (initial condition).
     """
     # Multi-DSW dispatch: when several active DSW fans contain v, the newest
-    # (largest ``theta_start``) wins — same rule as ``compute_domain_mass`` at
-    # line ~1057. Iterating chronologically and short-circuiting picks the
-    # older DSW's fan value, which is wrong for overlap regions. The fan
-    # predicate mirrors the in-fan check used downstream.
+    # (largest ``theta_start``) wins — same rule as ``compute_domain_mass``.
+    # Iterating chronologically and short-circuiting picks the older DSW's fan
+    # value, which is wrong for overlap regions. The fan predicate mirrors the
+    # in-fan check used downstream.
     dsw_in_fan: list[DecayingShockWave] = []
     for wave in waves:
         if isinstance(wave, DecayingShockWave) and wave.was_active_at(theta):
@@ -812,9 +817,10 @@ def compute_bin_averaged_concentration_exact(
     compute_cumulative_outlet_mass : Cumulative outlet mass via conservation
     """
     theta_edges_out = np.asarray(theta_bin_edges, dtype=float)
+    dtheta_out = np.diff(theta_edges_out)
 
-    if np.any(np.diff(theta_edges_out) <= 0):
-        bad = int(np.argmin(np.diff(theta_edges_out)))
+    if np.any(dtheta_out <= 0):
+        bad = int(np.argmin(dtheta_out))
         msg = (
             f"Invalid θ-bin: theta_bin_edges[{bad}]={theta_edges_out[bad]} >= "
             f"theta_bin_edges[{bad + 1}]={theta_edges_out[bad + 1]}"
@@ -823,15 +829,20 @@ def compute_bin_averaged_concentration_exact(
 
     if cin is not None and theta_edges_inlet is not None:
         # Conservation form: c_avg = Δm_out/Δθ where m_out = m_in − m_dom.
-        # m_in is the piecewise-constant inlet integral up to each output edge —
-        # vectorized over all edges at once (one broadcast clip-and-sum rather
-        # than a per-edge ``compute_cumulative_inlet_mass`` call). m_dom is a
-        # per-θ spatial geometry query, so it stays a loop.
+        # m_in(θ) = ∫₀^θ cin dτ is the piecewise-LINEAR (in θ) integral of the piecewise-constant
+        # cin, so evaluate it at every output edge in O(N+M) from the inlet-bin cumulative sums
+        # plus the partial bin containing θ — instead of the dense N_out×M_in clip-and-matmul
+        # (≈245× slower, a 128 MB temporary at N=M=4000). Edges below te_in[0] contribute 0
+        # (nothing is injected before the record starts, even if it starts mid-window); edges at
+        # or past te_in[-1] saturate at the total. This mirrors ``compute_cumulative_inlet_mass``'s
+        # clip exactly. m_dom stays a per-θ spatial geometry loop.
         te_in = np.asarray(theta_edges_inlet, dtype=float)
         cin_arr = np.asarray(cin, dtype=float)
-        widths_full = np.diff(te_in)
-        widths = np.clip(theta_edges_out[:, None] - te_in[None, :-1], 0.0, widths_full[None, :])
-        m_in_at_edges = widths @ cin_arr
+        cum_in = np.concatenate([[0.0], np.cumsum(cin_arr * np.diff(te_in))])
+        idx = np.clip(np.searchsorted(te_in, theta_edges_out, side="right") - 1, 0, len(cin_arr) - 1)
+        m_in_at_edges = cum_in[idx] + cin_arr[idx] * (theta_edges_out - te_in[idx])
+        m_in_at_edges = np.where(theta_edges_out < te_in[0], 0.0, m_in_at_edges)
+        m_in_at_edges = np.where(theta_edges_out >= te_in[-1], cum_in[-1], m_in_at_edges)
         m_dom_at_edges = np.array([
             compute_domain_mass(theta=float(theta_e), v_outlet=v_outlet, waves=waves, sorption=sorption)
             for theta_e in theta_edges_out
@@ -839,32 +850,55 @@ def compute_bin_averaged_concentration_exact(
         # ``compute_cumulative_outlet_mass`` short-circuits to 0 for θ ≤ 0;
         # replicate that clamp so non-positive output edges contribute no mass.
         m_out_at_edges = np.where(theta_edges_out <= 0.0, 0.0, m_in_at_edges - m_dom_at_edges)
-        result = np.diff(m_out_at_edges) / np.diff(theta_edges_out)
-        # FP-noise clamp: m_in − m_dom subtracts nearly-equal large numbers,
-        # leaving ~1 ULP residuals on either sign. Clamp those to 0.
-        max_c = float(np.max(np.abs(result))) if result.size else 0.0
-        eps_clamp = 1e-12 * max(max_c, 1.0)
-        result = np.where(np.abs(result) < eps_clamp, 0.0, result)
-        # Large-negative diagnostic: residuals beyond the FP-noise band signal
-        # a real conservation-form violation, most commonly the post-inlet
-        # artifact — output edges exceed ``theta_edges_inlet[-1]``, m_in
-        # caps at the last injected mass while the simulator's wave list
-        # continues to evolve, producing FP-cancellation residuals from
-        # inconsistent θ ranges. Surface as a UserWarning; clamp to 0 to
-        # preserve the ``cout >= 0`` API contract.
-        if result.size:
-            min_val = float(np.min(result))
-            if min_val < -eps_clamp:
-                msg = (
-                    f"compute_bin_averaged_concentration_exact produced concentrations "
-                    f"as negative as {min_val:.3e} (clamp threshold -{eps_clamp:.3e}); "
-                    f"likely caused by output θ-bin edges exceeding "
-                    f"theta_edges_inlet[-1]={float(np.asarray(theta_edges_inlet)[-1]):.3f}, "
-                    "putting the inlet integral and the wave list on inconsistent θ ranges. "
-                    "Extend cin with trailing zeros to cover the output range, "
-                    "or restrict output bins to within the inlet window."
+        result = np.diff(m_out_at_edges) / dtheta_out
+        # FP-noise clamp scaled to the m_in − m_dom CANCELLATION magnitude: each cumulative-mass
+        # edge carries ~eps·max(|m_in|,|m_dom|) rounding (the m_dom fan-integral sum accumulates
+        # several hundred ULP over a multi-pulse record), amplified by 1/Δθ. The former
+        # 1e-12·max(cout) band keyed off the OUTPUT concentration, which collapses to ~0 before
+        # breakthrough — far too tight, so ~1e-11 cancellation dust tripped the diagnostic on
+        # fully in-range inputs. Residuals within this band are numerical zero: clamp and stay
+        # silent.
+        mass_scale = np.maximum(np.abs(m_in_at_edges), np.abs(m_dom_at_edges))
+        eps_band = (
+            FP_CANCELLATION_CLAMP
+            * np.finfo(float).eps
+            * np.maximum(np.maximum(mass_scale[:-1], mass_scale[1:]), 1.0)
+            / dtheta_out
+        )
+        result = np.where(np.abs(result) < eps_band, 0.0, result)
+        # A residual MORE negative than the FP band is a genuine conservation-form violation with two
+        # possible drivers, and BOTH can be present at once. Attribute per offending bin, not off the
+        # single last edge: a bin whose right edge passes ``theta_edges_inlet[-1]`` sees m_in saturate
+        # while the wave list keeps evolving (out-of-window); a fully in-window offending bin is a real
+        # wave-model over-count (e.g. overlapping non-interacting waves from an oscillating inlet, see
+        # ``compute_domain_mass`` Notes). Report every cause that actually produced a negative bin
+        # instead of the previously unconditional — and often factually false — "edges exceed range"
+        # message. Clamp to 0 to preserve the ``cout >= 0`` API contract either way.
+        neg_mask = result < -eps_band
+        if np.any(neg_mask):
+            worst = float(np.min(result))
+            te_in_last = float(te_in[-1])
+            out_of_window = neg_mask & (theta_edges_out[1:] > te_in_last)
+            causes = []
+            if np.any(out_of_window):
+                causes.append(
+                    f"output θ-bin edges exceeding theta_edges_inlet[-1]={te_in_last:.3f} (m_in "
+                    "saturates at the last injected mass while the wave list keeps evolving — extend "
+                    "cin with trailing zeros to cover the output range, or restrict output bins to the "
+                    "inlet window)"
                 )
-                warnings.warn(msg, UserWarning, stacklevel=2)
+            if np.any(neg_mask & ~out_of_window):
+                causes.append(
+                    "the domain-mass integral growing faster than the inlet-mass integral within the "
+                    "inlet window (an m_dom over-count — e.g. overlapping non-interacting waves from a "
+                    "continuous/oscillating inlet — or a wave-list / cin inconsistency)"
+                )
+            warnings.warn(
+                f"compute_bin_averaged_concentration_exact produced a concentration as negative as "
+                f"{worst:.3e}, beyond the FP-cancellation band; likely cause(s): {'; '.join(causes)}.",
+                UserWarning,
+                stacklevel=2,
+            )
         return np.maximum(result, 0.0)
 
     # Legacy outlet-segment integration (compatible with hand-constructed
@@ -1349,35 +1383,31 @@ def compute_cumulative_outlet_mass(
 
 
 def compute_total_outlet_mass(
-    v_outlet: float,
-    sorption: SorptionModel,
+    v_outlet: float,  # noqa: ARG001
+    sorption: SorptionModel,  # noqa: ARG001
     *,
     cin: npt.ArrayLike,
     theta_edges: npt.NDArray[np.floating],
 ) -> float:
-    """Asymptotic total outlet mass via the conservation-law identity.
+    """Total outlet mass over θ → ∞ (finite only for a returning-to-zero pulse).
 
-    Computed as ``m_in_total − m_dom_asymptotic`` where ``m_dom_asymptotic``
-    is the aquifer's steady-state domain mass: ``C_T(c_∞) · v_outlet``, with
-    ``c_∞ = cin[-1]`` (the final/sustained inlet boundary value). This is
-    the asymptotic limit of ``m_in(θ) − m_dom(θ)`` as θ → ∞:
+    The final inlet value ``c_∞ = cin[-1]`` is the sustained boundary state as θ → ∞:
 
-    - For ``c_∞ = 0`` (canonical c_R=0 pulse): m_dom_asymptotic = 0 and
-      ``m_out_total = m_in_total`` — every injected mass unit eventually exits.
-    - For ``c_∞ > 0`` (sustained ambient): m_dom_asymptotic = C_T(c_∞) · V_outlet
-      stays in the domain at steady state; the rest exits.
-
-    Sidesteps the multi-fan dispatch problem entirely — the integration is
-    purely closed-form arithmetic over (cin, theta_edges) plus one
-    ``sorption.total_concentration`` evaluation. The wave list is not
-    needed.
+    - For ``c_∞ = 0`` (canonical c_R=0 pulse): injection ceases, the domain empties, and
+      every injected mass unit eventually exits — ``m_out_total = m_in_total`` (the finite
+      record integral ``Σ cin·Δθ``). The wave list is not needed.
+    - For ``c_∞ > 0`` (sustained ambient): the inlet keeps injecting ``c_∞`` forever, so the
+      cumulative outlet mass grows without bound — return ``+inf``. The previous formula
+      ``m_in_total − C_T(c_∞)·v_outlet`` paired the FINITE record integral with the
+      infinite-time steady-state fill and went **negative** whenever
+      ``m_in_total < C_T(c_∞)·v_outlet``, which is not a physical outlet mass.
 
     Parameters
     ----------
     v_outlet : float
-        Outlet position [m³].
+        Outlet position [m³] (unused for ``c_∞ = 0``; the ``+inf`` branch does not need it).
     sorption : SorptionModel
-        Sorption model — used only for ``C_T(c_∞)``.
+        Sorption model (kept for API symmetry; no ``C_T`` evaluation is required).
     cin : array-like (kw-only)
         Inlet concentration per θ-bin [mass/volume].
     theta_edges : ndarray (kw-only)
@@ -1386,18 +1416,18 @@ def compute_total_outlet_mass(
     Returns
     -------
     float
-        Asymptotic outlet mass [mass]. Equals ``m_in_total`` for ``cin[-1]=0``.
+        ``m_in_total`` for ``cin[-1] = 0``; ``+inf`` for ``cin[-1] > 0``.
 
     See Also
     --------
-    compute_cumulative_outlet_mass : Cumulative outlet mass up to finite θ
+    compute_cumulative_outlet_mass : Cumulative outlet mass up to a finite θ (use this for
+        a sustained ``c_∞ > 0`` boundary, where the θ → ∞ total is unbounded).
     compute_domain_mass : Spatial integral of C_total in the aquifer
     """
     cin_arr = np.asarray(cin, dtype=float)
-    te = np.asarray(theta_edges, dtype=float)
-    m_in_total = float(np.sum(cin_arr * np.diff(te)))
     # An empty cin is a malformed (no-bin) input by the cin/theta_edges contract;
     # let cin_arr[-1] raise IndexError rather than masking it as c_inf=0.
-    c_inf = float(cin_arr[-1])
-    m_dom_asymptotic = float(sorption.total_concentration(c_inf)) * v_outlet
-    return m_in_total - m_dom_asymptotic
+    if float(cin_arr[-1]) > 0.0:
+        return float("inf")
+    te = np.asarray(theta_edges, dtype=float)
+    return float(np.sum(cin_arr * np.diff(te)))

--- a/src/gwtransport/fronttracking/plot.py
+++ b/src/gwtransport/fronttracking/plot.py
@@ -87,7 +87,7 @@ def _wave_trajectory_in_t(
     t_arr = [state.t_at_theta(float(theta)) for theta in thetas[mask]]
     # Callers test truthiness of the returned lists (``if v_head:``), so keep
     # Python lists rather than arrays.
-    return t_arr, [float(v) for v in vs[mask]]
+    return t_arr, vs[mask].tolist()
 
 
 def plot_vt_diagram(
@@ -263,7 +263,7 @@ def plot_vt_diagram(
 
     # Plot wave interaction events as markers. Event records carry ``"theta"``;
     # translate to user-facing t for display via ``state.t_at_theta``.
-    if show_events and hasattr(state, "events") and state.events:
+    if show_events and state.events:
         for event in state.events:
             if "theta" in event and "location" in event:
                 t_event = state.t_at_theta(event["theta"])
@@ -411,6 +411,7 @@ def plot_breakthrough_curve(
             t_raref = np.linspace(t_seg_start, t_seg_end, n_rarefaction_points)
             theta_raref = state.theta_at_t_array(t_raref)
             c_raref = np.zeros_like(t_raref)
+            c_fallback = segment.get("c_start", raref.c_tail)
 
             # concentration_at_point is inherently scalar (returns None outside
             # the fan); only the t→θ map is vectorizable and is hoisted above.
@@ -419,7 +420,7 @@ def plot_breakthrough_curve(
                 if c_at_point is not None:
                     c_raref[j] = c_at_point
                 else:
-                    c_raref[j] = segment.get("c_start", raref.c_tail)
+                    c_raref[j] = c_fallback
 
             ax.plot(t_raref, c_raref, "b-", linewidth=2, label="Outlet concentration" if i == 0 else "")
 
@@ -720,7 +721,7 @@ def plot_front_tracking_summary(
     ----------
     structure : dict
         Structure returned from infiltration_to_extraction_nonlinear_sorption.
-        Must contain keys: 'tracker_state', 't_first_arrival'.
+        Must contain keys: 'tracker_state', 'theta_first_arrival'.
     tedges : pandas.DatetimeIndex
         Time bin edges for inlet concentration.
         Length = len(cin) + 1.
@@ -777,7 +778,7 @@ def plot_front_tracking_summary(
     tracker_state: FrontTrackerState = structure["tracker_state"]
 
     if t_max is None:
-        t_max = float((tedges.to_numpy()[-1] - tedges.to_numpy()[0]) / pd.Timedelta(days=1))
+        t_max = float((tedges[-1] - tedges[0]) / pd.Timedelta(days=1))
 
     # Top left: V-t diagram
     ax_vt = fig.add_subplot(gs[0, 0])
@@ -819,7 +820,9 @@ def plot_front_tracking_summary(
         )
 
     if show_bin_averaged:
-        t_edges_days = tedges_to_days(cout_tedges)
+        # Share the exact curve's origin (tracker_state.tedges[0]); referencing the output
+        # grid to its own first edge shifts the overlay by (cout_tedges[0] - tedges[0]) days.
+        t_edges_days = tedges_to_days(cout_tedges, ref=tracker_state.tedges[0])
         xstep_cout, ystep_cout = step_plot_coords(t_edges_days, cout)
         ax_outlet.plot(
             xstep_cout,
@@ -927,9 +930,9 @@ def plot_sorption_comparison(
     )
 
     if t_max_pulse is None:
-        t_max_pulse = (pulse_tedges.to_numpy()[-1] - pulse_tedges.to_numpy()[0]) / pd.Timedelta(days=1)
+        t_max_pulse = float((pulse_tedges[-1] - pulse_tedges[0]) / pd.Timedelta(days=1))
     if t_max_dip is None:
-        t_max_dip = (dip_tedges.to_numpy()[-1] - dip_tedges.to_numpy()[0]) / pd.Timedelta(days=1)
+        t_max_dip = float((dip_tedges[-1] - dip_tedges[0]) / pd.Timedelta(days=1))
 
     # === ROW 1: Pulse inlet ===
     t_days_pulse = tedges_to_days(pulse_tedges)

--- a/src/gwtransport/fronttracking/solver.py
+++ b/src/gwtransport/fronttracking/solver.py
@@ -20,6 +20,7 @@ All calculations are exact analytical with machine precision.
 
 import logging
 from dataclasses import dataclass
+from itertools import pairwise
 from operator import itemgetter
 
 import numpy as np
@@ -35,6 +36,7 @@ from gwtransport.fronttracking.events import (
     find_rarefaction_boundary_intersections,
     find_shock_characteristic_intersection,
     find_shock_shock_intersection,
+    is_outlet_crossing_pinned,
 )
 from gwtransport.fronttracking.handlers import (
     EPSILON_CONCENTRATION,
@@ -49,6 +51,10 @@ from gwtransport.fronttracking.handlers import (
 from gwtransport.fronttracking.math import (
     SorptionModel,
     compute_first_front_arrival_theta,
+)
+from gwtransport.fronttracking.output import (
+    FP_CANCELLATION_CLAMP,
+    compute_cumulative_outlet_mass,
 )
 from gwtransport.fronttracking.waves import (
     CharacteristicWave,
@@ -276,7 +282,6 @@ class FrontTracker:
                     c_new=c_new,
                     theta=float(theta_edges[i]),
                     sorption=self.state.sorption,
-                    v_inlet=0.0,
                 )
                 self.state.waves.extend(new_waves)
 
@@ -376,15 +381,18 @@ class FrontTracker:
         for wave in active_waves:
             if isinstance(wave, RarefactionWave):
                 theta_eval = max(theta_current, wave.theta_start)
-                for pos_fn, speed_fn in (
-                    (wave.head_position_at_theta, wave.head_speed),
-                    (wave.tail_position_at_theta, wave.tail_speed),
+                for c_boundary, pos_fn, speed_fn in (
+                    (wave.c_head, wave.head_position_at_theta, wave.head_speed),
+                    (wave.c_tail, wave.tail_position_at_theta, wave.tail_speed),
                 ):
                     v_pos = pos_fn(theta_eval)
                     if v_pos is None or v_pos >= v_outlet - outlet_tol:
                         continue
                     s = speed_fn()
-                    if s <= 0:
+                    # Skip a c_min-floored (pinned) boundary — R(c_min) inflated
+                    # for n>1, c→0: its crossing lands at a non-physical θ~1e8 and
+                    # only pollutes the event record.
+                    if s <= 0 or is_outlet_crossing_pinned(c_boundary, wave.sorption):
                         continue
                     theta_cross = theta_eval + (v_outlet - v_pos) / s
                     if theta_cross > theta_current:
@@ -590,3 +598,113 @@ class FrontTracker:
                     f"speed={wave.speed:.6g}"
                 )
                 raise RuntimeError(msg)
+
+
+def find_unresolved_interaction(state: FrontTrackerState) -> str | None:
+    """Locate an unresolved wave–wave interaction inside the transport domain.
+
+    The event-driven solver resolves shock↔shock, shock↔characteristic and
+    shock↔rarefaction collisions (the last into a :class:`DecayingShockWave`), but it
+    never collides anything *with* a decaying shock, nor composes two fans that come to
+    occupy the same region. Such an unresolved interaction leaves the non-interacting wave
+    objects overlapping, so the exact nonlinear multi-front field is not represented — the
+    public ``cout`` degrades to a spurious linear superposition of a nonlinear operator
+    (mass-fabricating once the reader clamps the resulting negative bins to zero). This
+    detects the first offending interaction so the public API can refuse the input rather
+    than return a wrong, non-conservative answer. Two complementary detectors run over the
+    input θ-window ``(0, theta_edges[-1]]``:
+
+    1. **Geometric fan overlap.** When two or more fan-bearing waves (rarefactions /
+       decaying shocks) cover a common point inside ``[0, v_outlet]``, their composite
+       field is wrong even when total mass happens to be conserved (a positive-but-wrong
+       ``cout`` with no negative bin — e.g. two decaying shocks with a zero fan tail, or a
+       later pulse's fan sweeping an earlier one). A symptom-only proxy cannot see this
+       class, so the geometric scan is a necessary complement.
+
+    2. **Conservation symptom.** The cumulative outlet mass ``m_out(θ) = m_in(θ) − m_dom(θ)``
+       must be non-decreasing in θ (mass exits the column, it never re-enters). A decrease
+       beyond the FP-cancellation band means the reader's domain-mass field transiently
+       over-counts stored mass — the fingerprint of a shock overtaking another shock /
+       rarefaction / decaying-shock fan. The two fans need NOT share an in-domain point
+       (they may only cross beyond ``v_outlet``), so the geometric scan misses this dominant
+       multi-pulse class; the monotonicity check catches it.
+
+    Parameters
+    ----------
+    state : FrontTrackerState
+        Completed simulation state (after :meth:`FrontTracker.run`).
+
+    Returns
+    -------
+    str or None
+        A short description (position/θ and mechanism) of the first offending interaction,
+        or ``None`` when the solution is a clean single-front / well-separated superposition
+        that the reader represents exactly.
+
+    Notes
+    -----
+    Both scans stay strictly inside the inlet θ-window, so the benign out-of-window
+    saturation clamp (a single-front run whose output bins extend past the last injected
+    mass) does not trip the symptom check. Well-separated pulses that clear a short column
+    before overtaking one another (their fans never share an in-domain point and their
+    cumulative outflow stays monotone) are correctly accepted.
+    """
+    waves = state.waves
+    v_outlet = state.v_outlet
+    theta_hi = float(state.theta_edges[-1])
+    v_tol = 1e-9 * max(v_outlet, 1.0)
+    thetas = np.linspace(theta_hi / 400.0, theta_hi, 400)
+
+    # (1) Geometric fan overlap.
+    def fan_covers(wave: Wave, v: float, theta: float) -> bool:
+        """Whether ``wave``'s self-similar fan geometrically spans ``v`` at ``theta``."""
+        if isinstance(wave, DecayingShockWave):
+            v_s = wave.position_at_theta(theta)
+            if v_s is None or v == wave.v_origin:
+                return False
+            return (wave.decay_side == "left" and v < v_s) or (wave.decay_side == "right" and v > v_s)
+        return isinstance(wave, RarefactionWave) and wave.contains_point(v, theta)
+
+    for theta in thetas:
+        fans = [w for w in waves if isinstance(w, (DecayingShockWave, RarefactionWave)) and w.was_active_at(theta)]
+        if len(fans) <= 1:  # a single fan (or none) cannot overlap another
+            continue
+        boundaries = {0.0, v_outlet}
+        for wave in waves:
+            if not wave.was_active_at(theta):
+                continue
+            if isinstance(wave, RarefactionWave):
+                candidates = (wave.head_position_at_theta(theta), wave.tail_position_at_theta(theta))
+            else:
+                candidates = (wave.position_at_theta(theta),)
+            boundaries.update(p for p in candidates if p is not None and 0.0 < p < v_outlet)
+        for v_lo, v_hi in pairwise(sorted(boundaries)):
+            if v_hi - v_lo < v_tol:
+                continue
+            v_mid = 0.5 * (v_lo + v_hi)
+            if len([w for w in fans if fan_covers(w, v_mid, theta)]) > 1:  # ≥ 2 fans share this point
+                return f"two fans overlap at V={v_mid:.4g} m³ (θ={theta:.4g} m³)"
+
+    # (2) Conservation symptom: cumulative outlet mass must be monotone non-decreasing.
+    # The band mirrors ``compute_bin_averaged_concentration_exact``'s FP-cancellation clamp
+    # (same constant, same ``max(scale, 1.0)`` floor) scaled to the total injected mass, so
+    # pre-breakthrough cancellation dust stays silent while a genuine over-count (orders of
+    # magnitude above the band) refuses the input.
+    grid = np.concatenate(([0.0], thetas))
+    m_out = np.array([
+        compute_cumulative_outlet_mass(
+            float(theta), v_outlet, waves, state.sorption, cin=state.cin, theta_edges=state.theta_edges
+        )
+        for theta in grid
+    ])
+    m_in_total = float(np.sum(state.cin * np.diff(state.theta_edges)))
+    band = FP_CANCELLATION_CLAMP * np.finfo(float).eps * max(m_in_total, 1.0)
+    steps = np.diff(m_out)
+    worst = int(np.argmin(steps))
+    if steps[worst] < -band:
+        return (
+            f"cumulative outlet mass drops by {-steps[worst]:.4g} near θ={grid[worst + 1]:.4g} m³ "
+            "(a shock overtakes another shock / rarefaction / decaying-shock fan; the reader "
+            "over-counts stored mass there)"
+        )
+    return None

--- a/src/gwtransport/fronttracking/validation.py
+++ b/src/gwtransport/fronttracking/validation.py
@@ -210,8 +210,11 @@ def verify_physics(
     # Check 5: No NaN values after spin-up
     tracker_state = structure.get("tracker_state")
     if tracker_state is not None and np.isfinite(theta_first):
-        t_days = tedges_to_days(cout_tedges)[:-1]
-        theta_at_edge = np.asarray([tracker_state.theta_at_t(float(t)) for t in t_days])
+        # theta_at_t measures days from the input origin tracker_state.tedges[0]; the output
+        # grid must be referenced to that same origin (not its own first edge) or the mask
+        # shifts and NaNs after spin-up slip through.
+        t_days = tedges_to_days(cout_tedges, ref=tracker_state.tedges[0])[:-1]
+        theta_at_edge = tracker_state.theta_at_t_array(t_days)
         mask_after_spinup = theta_at_edge >= theta_first
     elif not np.isfinite(theta_first):
         # No spin-up bound — every output row counts as "after spin-up".

--- a/src/gwtransport/fronttracking/waves.py
+++ b/src/gwtransport/fronttracking/waves.py
@@ -15,12 +15,11 @@ This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """
 
-import warnings
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
 import numpy as np
-from scipy.integrate import IntegrationWarning, quad
+from scipy.interpolate import CubicSpline
 from scipy.optimize import brentq
 
 from gwtransport.fronttracking.math import (
@@ -39,6 +38,12 @@ DECAYING_SHOCK_U_FLOOR = 1e-300  # Lower bracket bound for brentq on Freundlich 
 DECAYING_SHOCK_BRENTQ_XTOL = (
     1e-14  # brentq absolute tolerance for monotone θ inversions (exhaustion, outlet, numerical)
 )
+# Cached numerical decay profile (see ``_build_decay_profile``): c-grid resolution, the
+# Gauss-Legendre panel order for the cumulative invariant integral, and the fraction of the
+# c-gap the grid stops short of a secant-speed pole (where ``θ_local → ∞``).
+DECAY_PROFILE_NODES = 6000
+DECAY_PROFILE_GAUSS_ORDER = 10
+DECAY_PROFILE_POLE_FLOOR = 1e-6
 
 
 @dataclass
@@ -197,10 +202,16 @@ class CharacteristicWave(Wave):
     """Constant concentration carried [mass/volume]."""
     sorption: SorptionModel
     """Sorption model determining the speed."""
+    _speed: float = field(init=False, repr=False, compare=False)
+    """Cached characteristic speed (immutable inputs; set in ``__post_init__``)."""
+
+    def __post_init__(self) -> None:
+        """Cache the (immutable) characteristic speed once."""
+        self._speed = characteristic_speed(self.concentration, self.sorption)
 
     def speed(self) -> float:
         """Characteristic speed dV/dθ = 1/R(C) (``+∞`` at a saturated state, R = 0)."""
-        return characteristic_speed(self.concentration, self.sorption)
+        return self._speed
 
     def position_at_theta(self, theta: float) -> float | None:
         """Position at cumulative flow θ.
@@ -386,26 +397,30 @@ class RarefactionWave(Wave):
     """Concentration at trailing edge (slower) [mass/volume]."""
     sorption: SorptionModel
     """Sorption model (must be concentration-dependent)."""
+    _head_speed: float = field(init=False, repr=False, compare=False)
+    """Cached head celerity (immutable inputs; set in ``__post_init__``)."""
+    _tail_speed: float = field(init=False, repr=False, compare=False)
+    """Cached tail celerity (immutable inputs; set in ``__post_init__``)."""
 
     def __post_init__(self):
-        """Verify this is a rarefaction (head faster than tail)."""
-        s_head = self.head_speed()
-        s_tail = self.tail_speed()
+        """Cache head/tail celerities and verify this is a rarefaction (head faster than tail)."""
+        self._head_speed = characteristic_speed(self.c_head, self.sorption)
+        self._tail_speed = characteristic_speed(self.c_tail, self.sorption)
 
-        if s_head <= s_tail:
+        if self._head_speed <= self._tail_speed:
             msg = (
-                f"Not a rarefaction: head_speed={s_head:.6g} <= tail_speed={s_tail:.6g}. "
+                f"Not a rarefaction: head_speed={self._head_speed:.6g} <= tail_speed={self._tail_speed:.6g}. "
                 f"This would be a compression (shock) instead."
             )
             raise ValueError(msg)
 
     def head_speed(self) -> float:
         """Speed of rarefaction head dV/dθ = 1/R(C_head) (``+∞`` at a saturated state, R = 0)."""
-        return characteristic_speed(self.c_head, self.sorption)
+        return self._head_speed
 
     def tail_speed(self) -> float:
         """Speed of rarefaction tail dV/dθ = 1/R(C_tail) (``+∞`` at a saturated state, R = 0)."""
-        return characteristic_speed(self.c_tail, self.sorption)
+        return self._tail_speed
 
     def head_position_at_theta(self, theta: float) -> float | None:
         """Position of rarefaction head at cumulative flow θ."""
@@ -515,8 +530,8 @@ class DecayingShockWave(Wave):
 
     **Dispatch.** ``_c_decay_at_theta_local`` is the single dispatch site
     (position, fan-exhaustion and outlet-crossing all route through it): a
-    closed form is used where one exists, otherwise the shared numerical solver
-    ``_c_decay_numerical``. No combination raises — any
+    closed form is used where one exists, otherwise the per-wave cached numerical
+    profile (:func:`_build_decay_profile`). No combination raises — any
     :class:`~gwtransport.fronttracking.math.NonlinearSorption` is valid. With
     ``θ_local := θ − theta_origin`` measured from the rarefaction apex,
     ``α := ρ_b · k_f / n_por`` for Freundlich, and ``u_d := c_decay^(1/n)``:
@@ -537,11 +552,12 @@ class DecayingShockWave(Wave):
       invariant ``θ_local ∝ R(c_decay)^{a/(a−1)}`` (``R·S = 1/a`` constant),
       so ``R(c_d) = R(c0)·(θ_local/θ_local_coll)^{(a−1)/a}``.
     - Every other ``(isotherm, c_fixed)`` combination (Freundlich ``c_fixed>0,
-      n≠2``, Langmuir/Brooks-Corey ``c_fixed>0``, any van Genuchten) —
-      numerical solver ``_c_decay_numerical``: the decay-agnostic invariant
-      ``θ_local(c_d) = θ_local_coll · exp(∫ R'/[(1 − R·S)·R] dc)`` with the
-      symmetric secant speed ``S = (c − c_fixed)/(C_T(c) − C_T(c_fixed))`` by
-      ``scipy.integrate.quad``, inverted for ``c_d(θ)`` via ``brentq``.
+      n≠2``, Langmuir/Brooks-Corey ``c_fixed>0``, any van Genuchten) — cached
+      numerical profile (:func:`_build_decay_profile`): the decay-agnostic
+      invariant ``θ_local(c_d) = θ_local_coll · exp(∫ R'/[(1 − R·S)·R] dc)`` with
+      the symmetric secant speed ``S = (c − c_fixed)/(C_T(c) − C_T(c_fixed))``,
+      built once by composite quadrature and inverted for ``c_d(θ)`` by monotone
+      spline interpolation.
 
     Every path shares the fan-continuity identity
     ``V_s = v_origin + θ_local / R(c_decay)``, which ``position_at_theta`` and
@@ -605,6 +621,16 @@ class DecayingShockWave(Wave):
     K: float = field(init=False)
     """Invariant constant set in ``__post_init__`` (closed-form Freundlich ``c_fixed=0``/``n≈2`` and Langmuir
     ``c_fixed=0`` cases; ``nan`` for every numerical case)."""
+    _freundlich_cf: bool = field(init=False, repr=False, compare=False)
+    """Cached Freundlich-closed-form predicate (immutable inputs; set in ``__post_init__``)."""
+    _langmuir_cf: bool = field(init=False, repr=False, compare=False)
+    """Cached Langmuir-closed-form predicate."""
+    _brooks_corey_cf: bool = field(init=False, repr=False, compare=False)
+    """Cached Brooks-Corey ``c_fixed=0`` closed-form predicate."""
+    _numerical: bool = field(init=False, repr=False, compare=False)
+    """Cached predicate: no closed form applies, so the decay routes to the cached numerical profile."""
+    _decay_profile_cache: tuple | None = field(default=None, init=False, repr=False, compare=False)
+    """Lazily-built monotone ``θ_local(c)`` map for the numerical decay path (see ``_decay_profile``)."""
 
     def __post_init__(self) -> None:
         """Validate inputs and compute the closed-form invariant K when applicable."""
@@ -634,47 +660,54 @@ class DecayingShockWave(Wave):
             msg = f"DecayingShockWave requires a NonlinearSorption, got {type(self.sorption).__name__}"
             raise TypeError(msg)
 
-        # Closed where an exact form exists, else the shared numerical solver.
-        # K is the closed-form invariant constant; it is set only for the
-        # closed-form cases (see ``_uses_freundlich_closed_form`` /
-        # ``_uses_langmuir_closed_form``) and left as NaN for every numerical
-        # case. The ``_c_decay_at_theta_local`` dispatch mirrors these.
-        self.K = float("nan")
+        # Classify the decay path once (immutable inputs). Closed forms exist for:
+        # Freundlich c_fixed=0 (general n) or the n≈2 quadratic when the decaying side
+        # starts above the fixed side (the +√ / (u_d−u_R)² branch was derived only for
+        # c_decay_initial > c_fixed — the mirror routes to the numerical profile);
+        # Langmuir c_fixed=0; Brooks-Corey c_fixed=0. Everything else is numerical.
         s = self.sorption
-        if isinstance(s, FreundlichSorption) and self._uses_freundlich_closed_form():
+        self._freundlich_cf = isinstance(s, FreundlichSorption) and (
+            self.c_fixed == 0.0 or bool(np.isclose(s.n, 2.0, rtol=1e-12) and self.c_decay_initial > self.c_fixed)
+        )
+        self._langmuir_cf = isinstance(s, LangmuirSorption) and self.c_fixed == 0.0
+        self._brooks_corey_cf = isinstance(s, BrooksCoreyConductivity) and self.c_fixed == 0.0
+        self._numerical = not (self._freundlich_cf or self._langmuir_cf or self._brooks_corey_cf)
+
+        # K is the closed-form invariant constant; set only for the Freundlich/Langmuir
+        # closed forms and left NaN for every numerical (and Brooks-Corey) case. The
+        # isinstance guards narrow ``s`` for the typed helpers (the cached predicate already
+        # implies the type; the ``np.isclose`` cost is not re-incurred).
+        self.K = float("nan")
+        if self._freundlich_cf and isinstance(s, FreundlichSorption):
             self.K = _compute_k_freundlich(
                 s,
                 self.theta_start - self.theta_origin,
                 self.c_decay_initial,
                 self.c_fixed,
             )
-        elif isinstance(s, LangmuirSorption) and self._uses_langmuir_closed_form():
+        elif self._langmuir_cf and isinstance(s, LangmuirSorption):
             self.K = _compute_k_langmuir(
                 s,
                 self.theta_start - self.theta_origin,
                 self.c_decay_initial,
             )
 
-    def _uses_freundlich_closed_form(self) -> bool:
-        """Whether the Freundlich closed form (constant ``K``) applies.
+    def _decay_profile(self) -> tuple:
+        """Lazily build & cache the monotone ``θ_local(c)`` map for the numerical decay path.
 
-        Closed form holds for ``c_fixed = 0`` (general ``n``), and for the
-        ``n ≈ 2`` quadratic ONLY when the decaying side starts above the fixed
-        side (``c_decay_initial > c_fixed``) — that is the orientation the
-        ``+√`` root branch and the ``(u_d − u_R)²`` invariant were derived for.
-        The ``c_decay_initial < c_fixed`` mirror (e.g. ``decay_side='right'``)
-        has no valid closed form and routes to ``_c_decay_numerical``.
+        Returns ``(c_of_i, i_max, c_limit_node)``: a ``CubicSpline`` mapping the
+        cumulative invariant ``I = ln(θ_local/θ_local_coll)`` to ``c_decay``, the
+        largest resolved ``I`` (endpoint of the reachable c-range), and the c at
+        that endpoint. Built once per wave (see :func:`_build_decay_profile`).
         """
-        s = self.sorption
-        if not isinstance(s, FreundlichSorption):
-            return False
-        if self.c_fixed == 0.0:
-            return True
-        return bool(np.isclose(s.n, 2.0, rtol=1e-12) and self.c_decay_initial > self.c_fixed)
-
-    def _uses_langmuir_closed_form(self) -> bool:
-        """Whether the Langmuir closed form (constant ``K``) applies (``c_fixed = 0``)."""
-        return isinstance(self.sorption, LangmuirSorption) and self.c_fixed == 0.0
+        if self._decay_profile_cache is None:
+            self._decay_profile_cache = _build_decay_profile(
+                self.sorption,
+                self.c_decay_initial,
+                self.c_fixed,
+                self.c_fan_tail,
+            )
+        return self._decay_profile_cache
 
     def c_decay_at_theta(self, theta: float) -> float | None:
         """Concentration on the decaying side at cumulative flow θ.
@@ -728,16 +761,23 @@ class DecayingShockWave(Wave):
 
         theta_local_collision = self.theta_start - self.theta_origin
 
+        if self._numerical:
+            # The numerical forward map saturates AT c_fan_tail (it never crosses it),
+            # so a forward-map bracket cannot see the crossing for either decay
+            # orientation. Evaluate θ_local(c_fan_tail) from the un-clamped invariant
+            # directly: the gate above guarantees c_fan_tail is the reachable limit, so
+            # it is exactly the cached profile's endpoint ``i_max``.
+            _c_of_i, i_max, _c_limit_node = self._decay_profile()
+            return self.theta_origin + theta_local_collision * float(np.exp(i_max))
+
+        # Closed forms cross c_fan_tail smoothly (always a shrinking decay); invert the
+        # monotone forward map by bracketing (orientation-agnostic — no early return).
         def f(theta_local: float) -> float:
             return self._c_decay_at_theta_local(theta_local) - self.c_fan_tail
 
-        # c_decay is monotone in θ_local; find where it crosses c_fan_tail.
-        f_lo = f(theta_local_collision)
-        if f_lo <= 0.0:
-            # Already at/below the tail at collision — exhausted immediately.
-            return self.theta_start
-        # Seed == theta_local_collision, so reuse f_lo to skip one quad/eval.
-        theta_local_exhaust = _invert_monotone_theta_local(f, theta_hi_seed=theta_local_collision, f_seed=f_lo)
+        theta_local_exhaust = _invert_monotone_theta_local(
+            f, theta_hi_seed=theta_local_collision, f_seed=f(theta_local_collision)
+        )
         if theta_local_exhaust is None:
             return None
         return self.theta_origin + theta_local_exhaust
@@ -746,28 +786,35 @@ class DecayingShockWave(Wave):
         """Decaying concentration as a function of ``θ_local`` (apex-relative).
 
         The SOLE isotherm dispatch site: closed where an exact form exists,
-        otherwise the shared numerical solver. The closed forms (Freundlich
-        ``c_fixed=0`` or ``n≈2``; Langmuir ``c_fixed=0``; Brooks-Corey
-        ``c_fixed=0``) are selected by ``isinstance``; every other
-        ``(isotherm, c_fixed)`` combination falls through to
-        ``_c_decay_numerical``. Takes ``θ_local`` directly and skips the
-        activity check. ``c_decay_at_theta``, ``position_at_theta``,
+        otherwise the cached numerical decay profile. The closed forms
+        (Freundlich ``c_fixed=0`` or ``n≈2``; Langmuir ``c_fixed=0``;
+        Brooks-Corey ``c_fixed=0``) are selected by the ``__post_init__``
+        predicates; every other ``(isotherm, c_fixed)`` combination falls through
+        to the per-wave cached invariant profile. Takes ``θ_local`` directly and
+        skips the activity check. ``c_decay_at_theta``, ``position_at_theta``,
         ``theta_at_fan_exhaustion`` and ``outlet_crossing_theta`` all route
         through here rather than repeating the dispatch.
         """
         theta_local_collision = self.theta_start - self.theta_origin
         s = self.sorption
-        if isinstance(s, FreundlichSorption) and self._uses_freundlich_closed_form():
+        if self._freundlich_cf and isinstance(s, FreundlichSorption):
             return _c_decay_freundlich(
                 s, self.K, self.c_decay_initial, self.c_fixed, theta_local_collision, theta_local
             )
-        if isinstance(s, LangmuirSorption) and self._uses_langmuir_closed_form():
+        if self._langmuir_cf and isinstance(s, LangmuirSorption):
             return _c_decay_langmuir(s, self.K, theta_local)
-        if isinstance(s, BrooksCoreyConductivity) and self.c_fixed == 0.0:
+        if self._brooks_corey_cf and isinstance(s, BrooksCoreyConductivity):
             return _c_decay_brooks_corey(s, self.c_decay_initial, theta_local_collision, theta_local)
-        return _c_decay_numerical(
-            s, self.c_decay_initial, self.c_fixed, self.c_fan_tail, theta_local_collision, theta_local
-        )
+
+        # Numerical path: invert the cached monotone θ_local(c) map. c_decay stays at
+        # c_decay_initial up to the collision and clamps at the reachable c-limit past it.
+        if theta_local <= theta_local_collision:
+            return self.c_decay_initial
+        c_of_i, i_max, c_limit_node = self._decay_profile()
+        i_target = np.log(theta_local / theta_local_collision)
+        if i_target >= i_max:
+            return float(c_limit_node)
+        return float(c_of_i(i_target))
 
     def outlet_crossing_theta(self, v_outlet: float) -> float | None:
         """Cumulative flow at which ``V_s = v_outlet``.
@@ -791,7 +838,7 @@ class DecayingShockWave(Wave):
         # via the fan-continuity identity V_s - v_origin = θ_local / R(c_decay)
         # combined with the invariant to eliminate u, then solve for θ.
         s = self.sorption
-        if isinstance(s, FreundlichSorption) and self._uses_freundlich_closed_form():
+        if self._freundlich_cf and isinstance(s, FreundlichSorption):
             return _outlet_crossing_freundlich(
                 s,
                 self.K,
@@ -800,7 +847,7 @@ class DecayingShockWave(Wave):
                 self.theta_origin,
                 v_outlet,
             )
-        if isinstance(s, LangmuirSorption) and self._uses_langmuir_closed_form():
+        if self._langmuir_cf and isinstance(s, LangmuirSorption):
             return _outlet_crossing_langmuir(
                 s,
                 self.K,
@@ -827,66 +874,13 @@ class DecayingShockWave(Wave):
             # Already at/past the outlet at collision; the linear-shock guards
             # in the solver handle the duplicate-crossing suppression.
             return self.theta_start
-        # Reuse f_lo only when the seed coincides with the collision (≥1.0);
-        # otherwise let the helper evaluate f at its own seed.
-        theta_hi_seed = max(theta_local_collision, 1.0)
-        seed_f = f_lo if theta_local_collision >= 1.0 else None
-        theta_local_cross = _invert_monotone_theta_local(f, theta_hi_seed=theta_hi_seed, f_seed=seed_f)
+        # Seed at the collision (f_lo < 0 established above) and let the helper grow the
+        # bracket upward — no dimensional floor, so crossings within θ_local < 1 of the
+        # apex are found (mirrors theta_at_fan_exhaustion's closed-form bracket).
+        theta_local_cross = _invert_monotone_theta_local(f, theta_hi_seed=theta_local_collision, f_seed=f_lo)
         if theta_local_cross is None:
             return None
         return self.theta_origin + theta_local_cross
-
-    def mass_after_outlet_arrival(self, v_outlet: float) -> float:
-        """Mass exiting at ``v_outlet`` from the wave's outlet arrival to ``θ=+∞``.
-
-        Semantics depend on ``decay_side``:
-
-        - ``'left'`` (favorable n>1, Langmuir): after ``V_s`` reaches
-          ``v_outlet``, ``v_outlet`` falls *inside* the fan; c at ``v_outlet``
-          follows the fan's self-similar profile and asymptotes to
-          ``c_fixed``. For ``c_fixed=0`` the +∞ integral converges.
-        - ``'right'`` (n<1 mirror): after ``V_s`` reaches ``v_outlet``,
-          ``v_outlet`` is *upstream* of the shock; c at ``v_outlet`` jumps to
-          ``c_fixed`` and stays there. For ``c_fixed=0`` the +∞ contribution
-          is zero.
-
-        Parameters
-        ----------
-        v_outlet : float
-            Outlet position [m³].
-
-        Returns
-        -------
-        float
-            Total mass exiting at v_outlet from theta_arrival to +∞.
-
-        Raises
-        ------
-        ValueError
-            If ``c_fixed > 0`` (mass integral diverges; use segment-based
-            mass functions over a finite upper bound instead).
-        """
-        if self.c_fixed > 0.0:
-            msg = (
-                f"mass_after_outlet_arrival requires c_fixed=0 for the +∞ integral to converge; "
-                f"got c_fixed={self.c_fixed}"
-            )
-            raise ValueError(msg)
-        if self.decay_side == "right":
-            return 0.0
-        theta_arrival = self.outlet_crossing_theta(v_outlet)
-        if theta_arrival is None:
-            return 0.0
-        from gwtransport.fronttracking.output import integrate_fan_exact  # noqa: PLC0415
-
-        return integrate_fan_exact(
-            theta_origin=self.theta_origin,
-            v_origin=self.v_origin,
-            v_outlet=v_outlet,
-            theta_start=theta_arrival,
-            theta_end=float("inf"),
-            sorption=self.sorption,
-        )
 
     def concentration_left(self) -> float:
         """Concentration on the left (upstream) side at θ=theta_start.
@@ -979,25 +973,24 @@ class DecayingShockWave(Wave):
 def _invert_monotone_theta_local(f, *, theta_hi_seed: float, f_seed: float | None = None) -> float | None:
     """Bracket-then-brentq a monotone ``f(θ_local)`` with a sign change above the seed.
 
-    Shared by ``theta_at_fan_exhaustion`` and ``_outlet_crossing_numerical``:
-    both invert a monotone function of ``θ_local`` whose sign at the collision
-    is already known to differ from its sign at large ``θ_local``. Geometrically
-    grows ``θ_hi`` (``×2``, ≤200 iters) from ``theta_hi_seed`` until ``f`` flips
-    sign, then inverts with ``brentq``. Returns ``None`` if no sign change is
-    bracketed within the iteration budget.
+    Shared by the closed-form branch of ``theta_at_fan_exhaustion`` and by
+    ``_outlet_crossing_numerical``: both invert a monotone function of
+    ``θ_local`` whose sign at the collision is already known to differ from its
+    sign at large ``θ_local``. Geometrically grows ``θ_hi`` (``×2``, ≤200 iters)
+    from ``theta_hi_seed`` until ``f`` flips sign, then inverts with ``brentq``.
+    Returns ``None`` if no sign change is bracketed within the iteration budget.
 
     Parameters
     ----------
     f : callable
         Monotone residual ``f(θ_local)``; ``f(theta_hi_seed)`` and the far-field
         value must straddle zero. Caller-specific early sentinels
-        (already-exhausted / already-past-outlet) are handled by the caller.
+        (already-past-outlet) are handled by the caller.
     theta_hi_seed : float
         ``θ_local`` lower bracket; the search grows ``θ_hi`` from here.
     f_seed : float, optional
-        Pre-evaluated ``f(theta_hi_seed)``; callers that already computed it
-        (the numerical path's ``f`` is a ``scipy.quad`` call) pass it to avoid a
-        redundant evaluation. ``None`` recomputes it here.
+        Pre-evaluated ``f(theta_hi_seed)``; callers that already computed it pass
+        it to avoid a redundant evaluation. ``None`` recomputes it here.
 
     Returns
     -------
@@ -1014,30 +1007,30 @@ def _invert_monotone_theta_local(f, *, theta_hi_seed: float, f_seed: float | Non
     return None
 
 
-def _c_decay_numerical(
+def _build_decay_profile(
     sorption: NonlinearSorption,
     c_decay_initial: float,
     c_fixed: float,
     c_fan_tail: float,
-    theta_local_collision: float,
-    theta_local: float,
-) -> float:
-    r"""Decaying-side concentration for collisions with no closed form.
+) -> tuple:
+    r"""Build the per-wave monotone ``θ_local(c)`` map for collisions with no closed form.
 
     Decay-agnostic: the fan-continuity + Rankine-Hugoniot relations do not
     depend on which side decays. The secant speed
     ``S(c) = (c − c_fixed)/(C_T(c) − C_T(c_fixed))`` is symmetric in
     ``(c_decay, c_fixed)``, so the same invariant
-    ``θ_local(c) = θ_local_coll · exp(∫_{c0}^{c} R'/[(1 − R·S)·R] dc)`` (with
-    ``R'`` by central finite difference and ``scipy.integrate.quad``) holds for
-    Freundlich ``c_fixed>0, n≠2``, Langmuir ``c_fixed>0``, Brooks-Corey
-    ``c_fixed>0`` and any van Genuchten case alike. The invariant is monotone
-    from ``c_decay_initial`` to the reachable boundary, so the root is unique;
-    we bracket strictly inside and invert via brentq. The reachable boundary is
-    the fan tail ``c_fan_tail`` UNLESS ``c_fixed`` lies strictly between
-    ``c_decay_initial`` and ``c_fan_tail`` — then the secant speed has a pole at
-    ``c_fixed`` (the shock asymptotes to the fixed state and cannot cross it),
-    so ``c_fixed`` is the limit.
+    ``θ_local(c) = θ_local_coll · exp(I(c))``, ``I(c) = ∫_{c0}^{c} R'/[(1 − R·S)·R] dc``
+    (``R'`` by central finite difference) holds for Freundlich ``c_fixed>0, n≠2``,
+    Langmuir ``c_fixed>0``, Brooks-Corey ``c_fixed>0`` and any van Genuchten case
+    alike. ``I(c)`` is built ONCE by a single vectorised composite Gauss-Legendre
+    cumulative quadrature over a c-grid from ``c_decay_initial`` to the reachable
+    limit, then inverted by monotone-spline interpolation — replacing the former
+    quad-inside-brentq-inside-brentq scalar solve (~1000× fewer integrand evals
+    across a record). The reachable limit is the fan tail ``c_fan_tail`` UNLESS
+    ``c_fixed`` lies strictly between ``c_decay_initial`` and ``c_fan_tail`` — then
+    the secant speed has a pole at ``c_fixed`` (``R·S → 1``, ``θ_local → ∞``): the
+    shock asymptotes to the fixed state, so the grid stops a hair short of it and
+    ``c_decay`` clamps there.
 
     Parameters
     ----------
@@ -1049,67 +1042,56 @@ def _c_decay_numerical(
         Non-decaying-side concentration [mass/volume].
     c_fan_tail : float
         Concentration at the fan's far boundary [mass/volume]; bounds the decay.
-    theta_local_collision : float
-        ``θ_local`` at the collision (``θ_start − theta_origin``) [m³].
-    theta_local : float
-        ``θ_local`` at which to evaluate the decaying concentration [m³].
 
     Returns
     -------
-    float
-        Decaying-side concentration ``c`` at ``theta_local``.
+    tuple
+        ``(c_of_i, i_max, c_limit_node)``: a ``CubicSpline`` mapping the cumulative
+        invariant ``I = ln(θ_local/θ_local_coll)`` to ``c_decay``, the endpoint
+        ``I`` of the reachable c-range, and the ``c`` at that endpoint. ``I`` is
+        collision-independent (``θ_local_coll`` enters only at query time).
     """
     ct_fixed = float(sorption.total_concentration(c_fixed))
 
-    def r_prime(c: float) -> float:
-        h = max(1e-9, 1e-7 * abs(c))
-        return (float(sorption.retardation(c + h)) - float(sorption.retardation(c - h))) / (2.0 * h)
+    def integrand(c):
+        c = np.asarray(c, dtype=float)
+        h = np.maximum(1e-9, 1e-7 * np.abs(c))
+        r_prime = (np.asarray(sorption.retardation(c + h)) - np.asarray(sorption.retardation(c - h))) / (2.0 * h)
+        r = np.asarray(sorption.retardation(c))
+        ct = np.asarray(sorption.total_concentration(c))
+        secant = (c - c_fixed) / (ct - ct_fixed)
+        return r_prime / ((1.0 - r * secant) * r)
 
-    def integrand(c_eval: float) -> float:
-        r = float(sorption.retardation(c_eval))
-        ct = float(sorption.total_concentration(c_eval))
-        s = (c_eval - c_fixed) / (ct - ct_fixed)
-        return r_prime(c_eval) / ((1.0 - r * s) * r)
+    pole = (c_decay_initial - c_fixed) * (c_fan_tail - c_fixed) < 0.0
+    c_limit = c_fixed if pole else c_fan_tail
 
-    def theta_local_of_c(c: float) -> float:
-        # The integrand can have an integrable endpoint singularity (where
-        # R·S → 1); adaptive quadrature may exhaust its subdivision budget
-        # there while still converging. Suppress that benign warning.
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", IntegrationWarning)
-            val, _ = quad(integrand, c_decay_initial, c, limit=200)
-        return float(theta_local_collision * np.exp(val))
+    # c-grid from c0 to the reachable limit. Toward a pole (θ_local → ∞) the grid is
+    # geometric, stopping a fraction DECAY_PROFILE_POLE_FLOOR of the gap short; the
+    # non-pole grid reaches c_fan_tail exactly (so i_max is the exhaustion integral).
+    frac = np.linspace(0.0, 1.0, DECAY_PROFILE_NODES)
+    gap0 = abs(c_decay_initial - c_limit)
+    gaps = gap0 * DECAY_PROFILE_POLE_FLOOR**frac if pole else gap0 * (1.0 - frac)
+    c_nodes = c_limit + np.sign(c_decay_initial - c_limit) * gaps
 
-    if theta_local <= theta_local_collision:
-        return c_decay_initial
+    # Cumulative composite Gauss-Legendre integral of the invariant integrand.
+    x_gl, w_gl = np.polynomial.legendre.leggauss(DECAY_PROFILE_GAUSS_ORDER)
+    lo = c_nodes[:-1]
+    hi = c_nodes[1:]
+    mid = 0.5 * (lo + hi)
+    half = 0.5 * (hi - lo)
+    points = mid[:, None] + half[:, None] * x_gl[None, :]
+    panel = (integrand(points.ravel()).reshape(points.shape) * w_gl[None, :]).sum(axis=1) * half
+    i_nodes = np.concatenate([[0.0], np.cumsum(panel)])
 
-    # The decaying side relaxes from c_decay_initial toward the first boundary
-    # it reaches. If c_fixed lies strictly between c_decay_initial and
-    # c_fan_tail, the secant speed S has a pole at c_fixed (R·S → 1 there): the
-    # shock asymptotes to the fixed state and CANNOT cross it, so c_fixed — not
-    # the more distant c_fan_tail — is the reachable limit. Otherwise the fan's
-    # far boundary c_fan_tail bounds the decay.
-    c_limit = c_fan_tail
-    if (c_decay_initial - c_fixed) * (c_fan_tail - c_fixed) < 0.0:
-        c_limit = c_fixed
-    lo, hi = sorted((c_decay_initial, c_limit))
-    eps = (hi - lo) * 1e-9
-    # Bracket endpoints: the c_decay_initial side and the asymptotic-limit side,
-    # each held strictly off the boundary (the limit may carry a secant-speed
-    # pole).
-    c_start = c_decay_initial + (eps if c_limit > c_decay_initial else -eps)
-    c_bound = c_limit + (-eps if c_limit > c_decay_initial else eps)
-
-    def f(c: float) -> float:
-        return theta_local_of_c(c) - theta_local
-
-    # f is monotone: f(c_start) = θ_local_coll − θ_local < 0 and f → +∞ at the
-    # asymptotic limit. If even c_bound has not reached the requested θ_local
-    # (asymptote not yet numerically exceeded), the root is past machine
-    # resolution of the boundary — clamp to it rather than letting brentq fail.
-    if f(c_bound) <= 0.0:
-        return float(c_bound)
-    return float(brentq(f, min(c_start, c_bound), max(c_start, c_bound), xtol=DECAYING_SHOCK_BRENTQ_XTOL))
+    # Inverse-interpolation precondition: keep the strictly-increasing prefix (the
+    # near-pole tail can lose monotonicity as the singular integrand outruns the grid).
+    non_increasing = np.nonzero(np.diff(i_nodes) <= 0.0)[0]
+    if non_increasing.size:
+        cut = non_increasing[0] + 1
+        i_nodes = i_nodes[:cut]
+        c_nodes = c_nodes[:cut]
+    c_of_i = CubicSpline(i_nodes, c_nodes)
+    return c_of_i, float(i_nodes[-1]), float(c_nodes[-1])
 
 
 def _c_decay_brooks_corey(

--- a/src/gwtransport/gamma.py
+++ b/src/gwtransport/gamma.py
@@ -264,8 +264,9 @@ def bins(
 
     If ``n_bins`` is provided, the gamma distribution is divided into ``n_bins``
     equal-mass bins. If ``quantile_edges`` is provided, the distribution is divided
-    into bins defined by those quantile edges. The quantile edges must lie in
-    ``[0, 1]`` with size ``n_bins + 1``; the first and last entries must be 0 and 1.
+    into bins defined by those quantile edges. The quantile edges must be a strictly
+    increasing 1-D array of at least 3 entries (>= 2 bins) in ``[0, 1]``, with the
+    first and last entries exactly 0 and 1; ``n_bins`` is then ignored.
 
     Parameters
     ----------
@@ -284,9 +285,9 @@ def bins(
     n_bins : int, optional
         Number of bins to divide the gamma distribution (must be >= 2). Default is 100.
     quantile_edges : array-like, optional
-        Quantile edges for binning. Must be a 1-D, strictly increasing array of size
-        ``n_bins + 1`` with all entries in ``[0, 1]``; the first and last entries must
-        be exactly 0 and 1, respectively. If provided, ``n_bins`` is ignored.
+        Quantile edges for binning. Must be a strictly increasing 1-D array of at least
+        3 entries (>= 2 bins), all in ``[0, 1]``, with the first and last entries exactly
+        0 and 1. If provided, ``n_bins`` is ignored.
 
     Returns
     -------
@@ -345,6 +346,9 @@ def bins(
         if quantile_edges.ndim != 1:
             msg = "quantile_edges must be a 1-D array."
             raise ValueError(msg)
+        if quantile_edges.size == 0:
+            msg = "quantile_edges must not be empty."
+            raise ValueError(msg)
         if not np.all(np.diff(quantile_edges) > 0):
             msg = "quantile_edges must be strictly increasing."
             raise ValueError(msg)
@@ -369,7 +373,7 @@ def bins(
     #     E[X * 1_{a<=X<b}] = alpha * beta * (F_{alpha+1}(b/beta) - F_{alpha+1}(a/beta))
     # where F_{alpha+1} is the CDF of Gamma(alpha+1, beta).
     cdf_alpha_plus_1 = gamma_dist.cdf(unshifted_edges, alpha + 1, scale=beta)
-    diff_alpha_plus_1 = cdf_alpha_plus_1[1:] - cdf_alpha_plus_1[:-1]
+    diff_alpha_plus_1 = np.diff(cdf_alpha_plus_1)
     expected_values = beta * alpha * diff_alpha_plus_1 / probability_mass + loc
 
     return {

--- a/src/gwtransport/logremoval.py
+++ b/src/gwtransport/logremoval.py
@@ -50,13 +50,18 @@ Gamma-distribution parameter notation
 Several functions are parameterized by a gamma distribution. The parameter prefix marks
 *which* physical quantity is gamma-distributed, because two distinct quantities appear here:
 
-- ``rt_alpha`` / ``rt_beta`` / ``rt_loc`` parameterize the gamma distribution of the
-  **residence time** (used by :func:`gamma_pdf`, :func:`gamma_cdf`, :func:`gamma_mean`).
-- ``apv_alpha`` / ``apv_beta`` / ``apv_loc`` parameterize the gamma distribution of the
-  **aquifer pore volume** (used by :func:`gamma_find_flow_for_target_mean`).
+- ``rt_alpha`` / ``rt_beta`` / ``rt_loc`` (or the equivalent ``rt_mean`` / ``rt_std`` /
+  ``rt_loc``) parameterize the gamma distribution of the **residence time** (used by
+  :func:`gamma_pdf`, :func:`gamma_cdf`, :func:`gamma_mean`).
+- ``apv_alpha`` / ``apv_beta`` / ``apv_loc`` (or the equivalent ``apv_mean`` / ``apv_std`` /
+  ``apv_loc``) parameterize the gamma distribution of the **aquifer pore volume** (used by
+  :func:`gamma_find_flow_for_target_mean`).
 
 These prefixes are intentional and load-bearing: residence time and pore volume are different
-quantities, so a bare ``alpha`` / ``beta`` / ``loc`` would be ambiguous in this module.
+quantities, so a bare ``alpha`` / ``beta`` / ``loc`` would be ambiguous in this module. Both the
+shape/scale and the mean/std pairs are validated through :func:`gwtransport.gamma.parse_parameters`,
+so invalid parameters (e.g. a negative shape) raise ``ValueError`` rather than silently returning
+an unphysical result.
 
 Available functions:
 
@@ -102,6 +107,8 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 import numpy as np
 import numpy.typing as npt
 from scipy import optimize, stats
+
+from gwtransport.gamma import parse_parameters
 
 
 def residence_time_to_log_removal(
@@ -349,9 +356,11 @@ def parallel_mean(
 def gamma_pdf(
     *,
     r: npt.ArrayLike,
-    rt_alpha: float,
-    rt_beta: float,
+    rt_alpha: float | None = None,
+    rt_beta: float | None = None,
     rt_loc: float = 0.0,
+    rt_mean: float | None = None,
+    rt_std: float | None = None,
     log10_decay_rate: float,
 ) -> npt.NDArray[np.floating]:
     """
@@ -361,17 +370,27 @@ def gamma_pdf(
     the log removal ``R = mu * T`` follows a shifted gamma distribution with shape
     ``rt_alpha``, scale ``mu * rt_beta``, and location ``mu * rt_loc``.
 
+    The residence-time distribution is specified with either ``(rt_alpha, rt_beta)`` or
+    ``(rt_mean, rt_std)`` (optionally shifted by ``rt_loc``); both are routed through
+    :func:`gwtransport.gamma.parse_parameters`.
+
     Parameters
     ----------
     r : array-like
         Log removal values at which to compute the PDF.
-    rt_alpha : float
+    rt_alpha : float, optional
         Shape parameter of the gamma distribution for residence time. Must be positive.
-    rt_beta : float
+    rt_beta : float, optional
         Scale parameter of the gamma distribution for residence time (days). Must be positive.
     rt_loc : float, optional
         Location (minimum residence time, days) of the residence time distribution.
         Must be non-negative. Default is ``0.0``.
+    rt_mean : float, optional
+        Mean residence time (days). Alternative to ``rt_alpha``; supply with ``rt_std``.
+        Must be strictly greater than ``rt_loc``.
+    rt_std : float, optional
+        Standard deviation of the residence time (days). Alternative to ``rt_beta``;
+        supply with ``rt_mean``. Must be positive.
     log10_decay_rate : float
         Log10 decay rate mu (log10/day). Relates residence time to
         log removal via R = mu * T.
@@ -384,25 +403,27 @@ def gamma_pdf(
     Raises
     ------
     ValueError
-        If ``rt_loc`` is negative.
+        If parameter validation in :func:`gwtransport.gamma.parse_parameters` fails
+        (e.g. ``rt_loc`` negative, non-positive shape/scale, or neither/both
+        parameter pairs supplied).
 
     See Also
     --------
     gamma_cdf : Cumulative distribution function of log removal
     gamma_mean : Mean of the log removal distribution
     """
-    if rt_loc < 0:
-        msg = "rt_loc must be non-negative"
-        raise ValueError(msg)
+    rt_alpha, rt_beta, rt_loc = parse_parameters(mean=rt_mean, std=rt_std, loc=rt_loc, alpha=rt_alpha, beta=rt_beta)
     return stats.gamma.pdf(r, a=rt_alpha, loc=log10_decay_rate * rt_loc, scale=log10_decay_rate * rt_beta)
 
 
 def gamma_cdf(
     *,
     r: npt.ArrayLike,
-    rt_alpha: float,
-    rt_beta: float,
+    rt_alpha: float | None = None,
+    rt_beta: float | None = None,
     rt_loc: float = 0.0,
+    rt_mean: float | None = None,
+    rt_std: float | None = None,
     log10_decay_rate: float,
 ) -> npt.NDArray[np.floating]:
     """
@@ -413,17 +434,27 @@ def gamma_cdf(
     P(T0 <= (r - mu*rt_loc)/mu)`` which is the CDF of a shifted gamma distribution
     with location ``mu * rt_loc``.
 
+    The residence-time distribution is specified with either ``(rt_alpha, rt_beta)`` or
+    ``(rt_mean, rt_std)`` (optionally shifted by ``rt_loc``); both are routed through
+    :func:`gwtransport.gamma.parse_parameters`.
+
     Parameters
     ----------
     r : array-like
         Log removal values at which to compute the CDF.
-    rt_alpha : float
+    rt_alpha : float, optional
         Shape parameter of the gamma distribution for residence time. Must be positive.
-    rt_beta : float
+    rt_beta : float, optional
         Scale parameter of the gamma distribution for residence time (days). Must be positive.
     rt_loc : float, optional
         Location (minimum residence time, days) of the residence time distribution.
         Must be non-negative. Default is ``0.0``.
+    rt_mean : float, optional
+        Mean residence time (days). Alternative to ``rt_alpha``; supply with ``rt_std``.
+        Must be strictly greater than ``rt_loc``.
+    rt_std : float, optional
+        Standard deviation of the residence time (days). Alternative to ``rt_beta``;
+        supply with ``rt_mean``. Must be positive.
     log10_decay_rate : float
         Log10 decay rate mu (log10/day). Relates residence time to
         log removal via R = mu * T.
@@ -436,24 +467,26 @@ def gamma_cdf(
     Raises
     ------
     ValueError
-        If ``rt_loc`` is negative.
+        If parameter validation in :func:`gwtransport.gamma.parse_parameters` fails
+        (e.g. ``rt_loc`` negative, non-positive shape/scale, or neither/both
+        parameter pairs supplied).
 
     See Also
     --------
     gamma_pdf : Probability density function of log removal
     gamma_mean : Mean of the log removal distribution
     """
-    if rt_loc < 0:
-        msg = "rt_loc must be non-negative"
-        raise ValueError(msg)
+    rt_alpha, rt_beta, rt_loc = parse_parameters(mean=rt_mean, std=rt_std, loc=rt_loc, alpha=rt_alpha, beta=rt_beta)
     return stats.gamma.cdf(r, a=rt_alpha, loc=log10_decay_rate * rt_loc, scale=log10_decay_rate * rt_beta)
 
 
 def gamma_mean(
     *,
-    rt_alpha: float,
-    rt_beta: float,
+    rt_alpha: float | None = None,
+    rt_beta: float | None = None,
     rt_loc: float = 0.0,
+    rt_mean: float | None = None,
+    rt_std: float | None = None,
     log10_decay_rate: float,
 ) -> float:
     """
@@ -474,15 +507,25 @@ def gamma_mean(
     the arithmetic mean ``mu * (alpha * beta + rt_loc)`` because short residence
     time paths contribute disproportionately to the output concentration.
 
+    The residence-time distribution is specified with either ``(rt_alpha, rt_beta)`` or
+    ``(rt_mean, rt_std)`` (optionally shifted by ``rt_loc``); both are routed through
+    :func:`gwtransport.gamma.parse_parameters`.
+
     Parameters
     ----------
-    rt_alpha : float
+    rt_alpha : float, optional
         Shape parameter of the gamma distribution for residence time. Must be positive.
-    rt_beta : float
+    rt_beta : float, optional
         Scale parameter of the gamma distribution for residence time (days). Must be positive.
     rt_loc : float, optional
         Location (minimum residence time, days) of the residence time distribution.
         Must be non-negative. Default is ``0.0``.
+    rt_mean : float, optional
+        Mean residence time (days). Alternative to ``rt_alpha``; supply with ``rt_std``.
+        Must be strictly greater than ``rt_loc``.
+    rt_std : float, optional
+        Standard deviation of the residence time (days). Alternative to ``rt_beta``;
+        supply with ``rt_mean``. Must be positive.
     log10_decay_rate : float
         Log10 decay rate mu (log10/day).
 
@@ -494,7 +537,9 @@ def gamma_mean(
     Raises
     ------
     ValueError
-        If ``rt_loc`` is negative.
+        If parameter validation in :func:`gwtransport.gamma.parse_parameters` fails
+        (e.g. ``rt_loc`` negative, non-positive shape/scale, or neither/both
+        parameter pairs supplied).
 
     See Also
     --------
@@ -504,18 +549,18 @@ def gamma_mean(
     gamma_cdf : CDF of the log removal distribution
     :ref:`concept-pore-volume-distribution` : Why residence times are distributed
     """
-    if rt_loc < 0:
-        msg = "rt_loc must be non-negative"
-        raise ValueError(msg)
+    rt_alpha, rt_beta, rt_loc = parse_parameters(mean=rt_mean, std=rt_std, loc=rt_loc, alpha=rt_alpha, beta=rt_beta)
     return log10_decay_rate * rt_loc + rt_alpha * np.log1p(rt_beta * log10_decay_rate * np.log(10)) / np.log(10)
 
 
 def gamma_find_flow_for_target_mean(
     *,
     target_mean: float,
-    apv_alpha: float,
-    apv_beta: float,
+    apv_alpha: float | None = None,
+    apv_beta: float | None = None,
     apv_loc: float = 0.0,
+    apv_mean: float | None = None,
+    apv_std: float | None = None,
     log10_decay_rate: float,
 ) -> float:
     """
@@ -535,17 +580,27 @@ def gamma_find_flow_for_target_mean(
     For ``apv_loc > 0`` the equation is transcendental and solved numerically
     with :func:`scipy.optimize.brentq` by bracketing the root in ``1/Q``.
 
+    The pore-volume distribution is specified with either ``(apv_alpha, apv_beta)`` or
+    ``(apv_mean, apv_std)`` (optionally shifted by ``apv_loc``); both are routed through
+    :func:`gwtransport.gamma.parse_parameters`.
+
     Parameters
     ----------
     target_mean : float
         Target effective mean log removal value. Must be positive.
-    apv_alpha : float
+    apv_alpha : float, optional
         Shape parameter of the gamma distribution for aquifer pore volume. Must be positive.
-    apv_beta : float
+    apv_beta : float, optional
         Scale parameter of the gamma distribution for aquifer pore volume. Must be positive.
     apv_loc : float, optional
         Location (minimum aquifer pore volume) of the gamma distribution.
         Must be non-negative. Default is ``0.0``.
+    apv_mean : float, optional
+        Mean aquifer pore volume. Alternative to ``apv_alpha``; supply with ``apv_std``.
+        Must be strictly greater than ``apv_loc``.
+    apv_std : float, optional
+        Standard deviation of the aquifer pore volume. Alternative to ``apv_beta``;
+        supply with ``apv_mean``. Must be positive.
     log10_decay_rate : float
         Log10 decay rate mu (log10/day).
 
@@ -558,26 +613,20 @@ def gamma_find_flow_for_target_mean(
     Raises
     ------
     ValueError
-        If ``apv_loc`` is negative, if ``target_mean`` is not positive, if
-        ``log10_decay_rate`` is not positive (no decay can never produce a
-        positive target log removal), or if ``apv_alpha`` or ``apv_beta`` are
-        not positive.
+        If ``target_mean`` is not positive, if ``log10_decay_rate`` is not positive
+        (no decay can never produce a positive target log removal), or if parameter
+        validation in :func:`gwtransport.gamma.parse_parameters` fails (e.g. ``apv_loc``
+        negative, non-positive shape/scale, or neither/both parameter pairs supplied).
 
     See Also
     --------
     gamma_mean : Compute effective mean log removal for given parameters
     """
-    if apv_loc < 0:
-        msg = "apv_loc must be non-negative"
-        raise ValueError(msg)
+    apv_alpha, apv_beta, apv_loc = parse_parameters(
+        mean=apv_mean, std=apv_std, loc=apv_loc, alpha=apv_alpha, beta=apv_beta
+    )
     if target_mean <= 0:
         msg = "target_mean must be positive"
-        raise ValueError(msg)
-    if apv_alpha <= 0:
-        msg = "apv_alpha must be positive"
-        raise ValueError(msg)
-    if apv_beta <= 0:
-        msg = "apv_beta must be positive"
         raise ValueError(msg)
     if log10_decay_rate <= 0:
         # Without decay, the effective mean log removal is identically zero

--- a/src/gwtransport/percolation.py
+++ b/src/gwtransport/percolation.py
@@ -167,8 +167,9 @@ def root_zone_to_water_table_kinematic_wave(
     ------
     ValueError
         If inputs are inconsistent (wrong lengths, NaN, negative ``q_root_zone``
-        or ``k_scaling``, non-positive ``cumulative_pore_volumes_outlet`` or
-        ``k_s``), if neither or both sorption-parameter groups are supplied,
+        or ``k_scaling``, non-finite or non-positive
+        ``cumulative_pore_volumes_outlet`` or ``k_s``), if neither or both
+        sorption-parameter groups are supplied,
         if ``q_root_zone > f(t) * k_s`` at any bin (saturation/ponding limit),
         or if ``q_water_table_tedges`` does not equal ``tedges`` while
         ``k_scaling`` is provided.
@@ -318,14 +319,16 @@ def root_zone_to_water_table_kinematic_wave(
     if np.any(np.isnan(q_root_zone_arr)):
         msg = "q_root_zone must not contain NaN"
         raise ValueError(msg)
-    if cumulative_pore_volumes_outlet_arr.size == 0 or np.any(cumulative_pore_volumes_outlet_arr <= 0):
-        msg = "cumulative_pore_volumes_outlet must be non-empty with all entries positive"
+    if cumulative_pore_volumes_outlet_arr.size == 0 or not np.all(
+        np.isfinite(cumulative_pore_volumes_outlet_arr) & (cumulative_pore_volumes_outlet_arr > 0)
+    ):
+        msg = "cumulative_pore_volumes_outlet must be non-empty with all entries positive and finite"
         raise ValueError(msg)
     if not (0.0 <= theta_r < theta_s < 1.0):
         msg = f"theta_r, theta_s must satisfy 0 <= theta_r < theta_s < 1, got theta_r={theta_r}, theta_s={theta_s}"
         raise ValueError(msg)
-    if k_s <= 0:
-        msg = f"k_s must be positive, got {k_s}"
+    if not (np.isfinite(k_s) and k_s > 0):
+        msg = f"k_s must be positive and finite, got {k_s}"
         raise ValueError(msg)
     if (brooks_corey_lambda is None) == (van_genuchten_n is None):
         msg = "Exactly one of brooks_corey_lambda or van_genuchten_n must be provided"

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -125,6 +125,7 @@ from gwtransport._radial_asr_compose import single_cycle_echo_matrix
 from gwtransport._radial_asr_drift_kernels import _RS_FRAC, block_cout_deviation
 from gwtransport._radial_asr_reuse import cout_deviation
 from gwtransport._time import dt_to_days
+from gwtransport._validation import _validate_retardation_factor
 
 
 def _is_single_cycle(flow: npt.NDArray[np.floating]) -> bool:
@@ -196,9 +197,7 @@ def _validate(
     if molecular_diffusivity < 0.0:
         msg = "molecular_diffusivity must be non-negative"
         raise ValueError(msg)
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
+    _validate_retardation_factor(retardation_factor)
     if weights is not None and len(weights) != len(pore_heights):
         msg = "weights must have the same length as pore_heights"
         raise ValueError(msg)
@@ -273,29 +272,36 @@ def _reuse_ensemble(
     """Weight-averaged multi-cycle extracted-flux deviation over the streamtubes.
 
     Runs the reused-propagator-matrix multi-cycle engine once per streamtube (geometry constant
-    ``c_geo = pi b n``) and averages by ``weights``. Used by the forward (with ``cin``) and the reverse
-    (with unit pulses).
+    ``c_geo = pi b n``) and averages by ``weights``. ``cin_deviation`` may be ``(n,)`` or ``(n, k)`` -- a
+    column batch is transported through one engine pass per streamtube (the per-phase propagator / source /
+    readout matrices are cin-independent, so they are built once and applied to every column). Used by the
+    forward (with ``cin``) and the reverse (with the unit-pulse column batch).
 
     Returns
     -------
-    ndarray, shape (n,)
-        Weight-averaged extracted-flux deviation on extraction bins, ``0`` elsewhere.
+    ndarray, shape (n,) or (n, k)
+        Weight-averaged extracted-flux deviation on extraction bins (matching ``cin_deviation``), ``0``
+        elsewhere.
     """
-    acc = np.zeros(len(flow))
+    # cout_deviation returns NaN on injection / rest bins by contract (structural, expected). Only the
+    # extraction bins are accumulated, so those structural NaNs are dropped without a blanket nan_to_num --
+    # a genuine NaN on an EXTRACTION bin (a real numerical failure) then propagates and surfaces instead of
+    # silently reading as a physical zero.
+    ext_mask = flow < 0.0
+    acc = np.zeros(np.shape(cin_deviation))
     for c_geo, w_i in zip(c_geos, weights, strict=True):
-        acc += w_i * np.nan_to_num(
-            cout_deviation(
-                cin_deviation=cin_deviation,
-                flow=flow,
-                dt_days=dt_days,
-                c_geo=c_geo,
-                r_w=well_radius,
-                alpha_l=longitudinal_dispersivity,
-                molecular_diffusivity=molecular_diffusivity,
-                retardation_factor=retardation_factor,
-                n_quad=n_quad,
-            )
+        dev = cout_deviation(
+            cin_deviation=cin_deviation,
+            flow=flow,
+            dt_days=dt_days,
+            c_geo=c_geo,
+            r_w=well_radius,
+            alpha_l=longitudinal_dispersivity,
+            molecular_diffusivity=molecular_diffusivity,
+            retardation_factor=retardation_factor,
+            n_quad=n_quad,
         )
+        acc[ext_mask] += w_i * dev[ext_mask]
     return acc / np.sum(weights)
 
 
@@ -590,6 +596,12 @@ def extraction_to_infiltration(
     -------
     ndarray, shape (n,)
         Recovered injected concentration; NaN on extraction / rest bins.
+
+    Raises
+    ------
+    ValueError
+        If ``cout`` contains NaN on any extraction bin (``flow < 0``), which would poison the
+        least-squares solve. Structural NaN on injection / rest bins is allowed.
     """
     cout = np.asarray(cout, dtype=float)
     flow = np.asarray(flow, dtype=float)
@@ -610,6 +622,12 @@ def extraction_to_infiltration(
         regional_flux=regional_flux,
         n_modes=n_modes,
     )
+    # A NaN measurement on an extraction bin (the only bins the inverse reads) would poison the whole
+    # least-squares solve into an all-NaN cin; raise instead, as the advection / diffusion inverses do.
+    # Structural NaN on injection / rest bins is allowed (those bins are ignored by the inverse).
+    if np.any(np.isnan(cout[flow < 0.0])):
+        msg = "cout contains NaN values on extraction bins, which are not allowed"
+        raise ValueError(msg)
     c_geos = np.pi * pore_heights * porosity
     # A rest phase with molecular diffusion routes to the reuse engine (see the forward function); regional
     # drift never uses the radial echo operator (it breaks the azimuthal symmetry the echo relies on).
@@ -629,15 +647,17 @@ def extraction_to_infiltration(
             n_quad=n_quad,
         )
     else:
-        # Build the dense forward operator W by unit-pulse columns; the reverse cannot reuse the cheap
-        # single-solve forward path. The block (drift) engine transports all pulse columns in ONE pass
-        # (the per-phase kernels are shared across columns); the scalar reuse engine solves per column.
+        # Build the dense forward operator W whose columns are the unit-injection-pulse responses; the reverse
+        # cannot reuse the cheap single-solve forward path. The per-phase propagator / source / readout matrices
+        # are cin-independent (flow + geometry only), so the whole unit-pulse batch is transported in ONE engine
+        # pass -- the matrices are built once and applied to every column. The block (drift) engine carries
+        # the regional drift; the scalar reuse engine the drift-free case.
         inj_mask, ext_mask = flow > 0.0, flow < 0.0
         inj_idx = np.flatnonzero(inj_mask)
         dt_days = dt_to_days(tedges)
+        pulses = np.zeros((len(flow), len(inj_idx)))
+        pulses[inj_idx, np.arange(len(inj_idx))] = 1.0
         if regional_flux != 0.0:
-            pulses = np.zeros((len(flow), len(inj_idx)))
-            pulses[inj_idx, np.arange(len(inj_idx))] = 1.0
             cols = _block_ensemble(
                 pulses,
                 flow=flow,
@@ -653,25 +673,20 @@ def extraction_to_infiltration(
                 weights=weights_arr,
                 n_quad=n_quad,
             )
-            w_ens = cols[ext_mask, :]
         else:
-            w_ens = np.zeros((int(np.sum(ext_mask)), len(inj_idx)))
-            for j, idx in enumerate(inj_idx):
-                pulse = np.zeros(len(flow))
-                pulse[idx] = 1.0
-                col = _reuse_ensemble(
-                    pulse,
-                    flow=flow,
-                    dt_days=dt_days,
-                    c_geos=c_geos,
-                    well_radius=well_radius,
-                    longitudinal_dispersivity=longitudinal_dispersivity,
-                    molecular_diffusivity=molecular_diffusivity,
-                    retardation_factor=retardation_factor,
-                    weights=weights_arr,
-                    n_quad=n_quad,
-                )
-                w_ens[:, j] = col[ext_mask]
+            cols = _reuse_ensemble(
+                pulses,
+                flow=flow,
+                dt_days=dt_days,
+                c_geos=c_geos,
+                well_radius=well_radius,
+                longitudinal_dispersivity=longitudinal_dispersivity,
+                molecular_diffusivity=molecular_diffusivity,
+                retardation_factor=retardation_factor,
+                weights=weights_arr,
+                n_quad=n_quad,
+            )
+        w_ens = cols[ext_mask, :]
     # Tikhonov least-squares min ||W x - (cout-bg)||^2 + lambda ||x||^2 via the stable augmented
     # system [W; sqrt(lambda) I] x = [cout-bg; 0]. The echo / reuse operator has column sums ~1
     # (mass conservation per injection bin) and overdetermined rows, so a direct Tikhonov fit is used.
@@ -820,13 +835,17 @@ def _velocity_gamma_streamtubes(
     Raises
     ------
     ValueError
-        If ``screen_height`` or ``velocity_cv`` is not positive.
+        If ``screen_height`` is not positive or ``velocity_cv`` is negative.
     """
     if screen_height <= 0.0:
         msg = "screen_height must be positive"
         raise ValueError(msg)
-    if velocity_cv <= 0.0:
-        msg = "velocity_cv must be positive (use a single homogeneous screen for no macrodispersion)"
+    if velocity_cv < 0.0:
+        msg = "velocity_cv must be non-negative"
         raise ValueError(msg)
+    if velocity_cv == 0.0:
+        # A degenerate gamma (std 0) is not a valid distribution; velocity_cv = 0 is the homogeneous
+        # screen -- a single streamtube at the mean velocity (pore height H), matching the doc.
+        return np.array([screen_height]), np.array([1.0])
     bins = gamma.bins(mean=1.0, std=velocity_cv, n_bins=n_bins)
     return screen_height / bins["expected_values"], bins["probability_mass"]

--- a/src/gwtransport/recharge.py
+++ b/src/gwtransport/recharge.py
@@ -60,6 +60,7 @@ from gwtransport._validation import (
     _validate_no_nan,
     _validate_non_negative_array,
     _validate_positive_scalar,
+    _validate_retardation_factor,
     _validate_tedges_parity,
 )
 
@@ -215,9 +216,7 @@ def recharge_to_extraction(
     _validate_no_nan(rech, name="recharge")
     _validate_non_negative_array(rech, name="recharge")
     _validate_positive_scalar(aquifer_pore_depth, name="aquifer_pore_depth")
-    if retardation_factor < 1.0:
-        msg = "retardation_factor must be >= 1.0"
-        raise ValueError(msg)
+    _validate_retardation_factor(retardation_factor)
 
     t = tedges_to_days(tedges)
     tq = tedges_to_days(cout_tedges, ref=tedges[0])
@@ -320,37 +319,37 @@ def _backward_entries(*, queries, t, dt, k, q, apv, v_start=0.0, edge_side="righ
     """
     n = len(dt)
     nq = len(queries)
-    m = np.clip(np.searchsorted(t, queries, side="left" if edge_side == "left" else "right") - 1, 0, n - 1)
+    m = np.clip(np.searchsorted(t, queries, side=edge_side) - 1, 0, n - 1)
     s_out = np.full(nq, np.nan)
     v0 = np.full(nq, np.nan)
     pos = np.full(nq, float(v_start))
     open_ = np.ones(nq, dtype=bool)
-    for i in range(n - 1, -1, -1):
-        sel = np.nonzero(open_ & (m >= i))[0]
-        if sel.size == 0:
-            continue
-        starts_here = m[sel] == i
-        seg = np.where(starts_here, queries[sel] - t[i], dt[i])
-        t_hi = np.where(starts_here, queries[sel], t[i + 1])
-        vi = pos[sel]
-        if k[i] > 0:
-            v_r = q[i] / k[i]
-            va = v_r + (vi - v_r) * np.exp(-k[i] * seg)
-            ent = va >= apv
-            with np.errstate(invalid="ignore", divide="ignore"):
+    with np.errstate(invalid="ignore", divide="ignore"):  # stagnant boundary (vi == v_r == apv)
+        for i in range(n - 1, -1, -1):
+            sel = np.nonzero(open_ & (m >= i))[0]
+            if sel.size == 0:
+                continue
+            starts_here = m[sel] == i
+            seg = np.where(starts_here, queries[sel] - t[i], dt[i])
+            t_hi = np.where(starts_here, queries[sel], t[i + 1])
+            vi = pos[sel]
+            if k[i] > 0:
+                v_r = q[i] / k[i]
+                va = v_r + (vi - v_r) * np.exp(-k[i] * seg)
+                ent = va >= apv
                 back = -np.log((apv - v_r) / (vi[ent] - v_r)) / k[i]
-            back = np.where(np.isfinite(back), back, 0.0)  # stagnant boundary (vi == v_r == apv)
-        else:
-            va = vi + q[i] * seg
-            # The q > 0 guard keeps a parcel parked exactly on the boundary
-            # through a fully stagnant bin (no flow, no recharge) walking into
-            # earlier bins: nothing moves and nothing is lost there.
-            ent = (va >= apv) & (q[i] > 0.0)
-            back = (apv - vi[ent]) / q[i] if q[i] > 0 else vi[ent][:0]
-        s_ent = np.clip(t_hi[ent] - back, t[i], t_hi[ent])
-        s_out[sel[ent]] = s_ent
-        open_[sel[ent]] = False
-        pos[sel[~ent]] = va[~ent]
+                back = np.where(np.isfinite(back), back, 0.0)
+            else:
+                va = vi + q[i] * seg
+                # The q > 0 guard keeps a parcel parked exactly on the boundary
+                # through a fully stagnant bin (no flow, no recharge) walking into
+                # earlier bins: nothing moves and nothing is lost there.
+                ent = (va >= apv) & (q[i] > 0.0)
+                back = (apv - vi[ent]) / q[i] if q[i] > 0 else vi[ent][:0]
+            s_ent = np.clip(t_hi[ent] - back, t[i], t_hi[ent])
+            s_out[sel[ent]] = s_ent
+            open_[sel[ent]] = False
+            pos[sel[~ent]] = va[~ent]
     v0[open_] = pos[open_]
     return s_out, v0
 
@@ -449,15 +448,25 @@ def _bounded_average(*, t, dt, u, k, q, cr, cb, apv, tq, covered):
     # Kernel mass: full-bin sum for j in [lo, m), then the current-bin and
     # entry-bin partial corrections (telescopes to vol when cr == cb == 1).
     lo = np.where(pre, 0, js)
-    lo_eff = np.maximum(lo, np.clip(np.searchsorted(u, u2t - _KERNEL_CUTOFF, side="right") - 1, 0, None))
+    # The per-bin weight magnitude scales with exp(u[col+1] - u1t) (u1t <= u2t is
+    # the piece's smallest clock value), so the cutoff must key to u1t: keying it
+    # to u2t drops still-significant bins when one input bin flushes >_KERNEL_CUTOFF
+    # pore volumes.
+    lo_eff = np.maximum(lo, np.clip(np.searchsorted(u, u1t - _KERNEL_CUTOFF, side="right") - 1, 0, None))
     w_max = int((m - lo_eff).max(initial=0))
     ker = np.zeros(len(mids))
     if w_max > 0:
         cols = lo_eff[:, None] + np.arange(w_max)[None, :]
         valid = cols < m[:, None]
         colsc = np.clip(cols, 0, n - 1)
-        w_lo = np.exp(u[colsc + 1] - u1t[:, None]) - np.exp(u[colsc] - u1t[:, None])
-        w_hi = np.exp(u[colsc + 1] - u2t[:, None]) - np.exp(u[colsc] - u2t[:, None])
+        # Each bin weight is an adjacent difference of exp values at its two u
+        # edges; consecutive bins share an edge, so evaluating exp once per edge
+        # over the extended [lo_eff, m] edge array halves the exp count.
+        edges = np.clip(lo_eff[:, None] + np.arange(w_max + 1)[None, :], 0, n)
+        e_lo = np.exp(u[edges] - u1t[:, None])
+        e_hi = np.exp(u[edges] - u2t[:, None])
+        w_lo = e_lo[:, 1:] - e_lo[:, :-1]
+        w_hi = e_hi[:, 1:] - e_hi[:, :-1]
         wgt = np.where(kpos[:, None], w_lo - w_hi, w_hi)
         ker = np.einsum("pw,pw->p", np.where(valid, wgt, 0.0), cr[colsc])
     mass = cr[m] * vol - cr[m] * piece_integral(u[m]) + ker * fac

--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -61,7 +61,7 @@ longest for the largest pore volumes of a distribution.
 What happens in that region is governed by a ``spinup`` policy, following the package convention
 (see :mod:`gwtransport.advection`); :func:`full`, :func:`mean` and
 :func:`gamma` all share the contract ``spinup={'constant'} | None | float in
-[0, 1)`` and the default is ``"constant"`` everywhere:
+[0, 1]`` and the default is ``"constant"`` everywhere:
 
 * ``"constant"`` (default) **warm-starts** by extrapolating the boundary flow (flow held constant
   at its first/last value), so no in-record output is ``NaN``.
@@ -94,6 +94,13 @@ from scipy.stats import gamma as gamma_dist
 from gwtransport._time import tedges_to_days
 from gwtransport.gamma import parse_parameters
 from gwtransport.utils import cumulative_flow_volume, linear_interpolate
+
+# Relative slack on the covered-fraction spin-up gate. The covered sub-mass ``den`` equals its
+# fully-covered reference only up to summation-reassociation ulps, so an exact ``den >= threshold *
+# reference`` comparison spuriously rejects fully-covered bins at the strictest threshold (1.0). The
+# slack is far above that float noise (band widths reach ~1e4 pieces, ~1e-12 relative) yet negligible
+# as a physical coverage tolerance.
+_SPINUP_GATE_RELTOL = 1e-9
 
 
 def _boundary_extrapolated_map(
@@ -133,19 +140,19 @@ def _resolve_spinup(spinup: str | float | None) -> tuple[bool, float]:
     """Normalize the residence-time ``spinup`` policy to ``(extrapolate, threshold)``.
 
     The three sibling residence-time functions share one spin-up contract,
-    ``{'constant'} | None | float in [0, 1)``, matching the package convention (see
+    ``{'constant'} | None | float in [0, 1]``, matching the package convention (see
     :mod:`gwtransport.advection`):
 
     * ``'constant'`` -> ``(True, 0.0)`` -- warm-start by extrapolating the boundary flow.
     * ``None`` -> ``(False, 0.0)`` -- strict map (no extrapolation); a collapsed mean is emitted
       wherever any covered sub-mass / valid streamtube remains.
-    * ``float`` in ``[0, 1)`` -> ``(False, float)`` -- strict map, with the covered-fraction
+    * ``float`` in ``[0, 1]`` -> ``(False, float)`` -- strict map, with the covered-fraction
       threshold gating a collapsed mean. ``0.0`` matches ``None``; larger values require a larger
-      covered fraction before a bin is emitted.
+      covered fraction before a bin is emitted, and ``1.0`` is strictest (full coverage required).
 
     Parameters
     ----------
-    spinup : {'constant'}, None, or float in [0, 1)
+    spinup : {'constant'}, None, or float in [0, 1]
         Public spin-up policy.
 
     Returns
@@ -159,15 +166,15 @@ def _resolve_spinup(spinup: str | float | None) -> tuple[bool, float]:
     Raises
     ------
     ValueError
-        If ``spinup`` is not ``'constant'``, ``None``, or a float in ``[0, 1)``.
+        If ``spinup`` is not ``'constant'``, ``None``, or a float in ``[0, 1]``.
     """
     if spinup == "constant":
         return True, 0.0
     if spinup is None:
         return False, 0.0
-    if isinstance(spinup, int | float) and not isinstance(spinup, bool) and 0.0 <= spinup < 1.0:
+    if isinstance(spinup, int | float) and not isinstance(spinup, bool) and 0.0 <= spinup <= 1.0:
         return False, float(spinup)
-    msg = "spinup should be 'constant', None, or a float in [0, 1)"
+    msg = "spinup should be 'constant', None, or a float in [0, 1]"
     raise ValueError(msg)
 
 
@@ -282,7 +289,7 @@ def full(
     retardation_factor : float, optional
         Retardation factor of the compound in the aquifer [dimensionless]. A value greater
         than 1.0 indicates the compound moves slower than water. Default is 1.0.
-    spinup : {'constant'}, None, or float in [0, 1), optional
+    spinup : {'constant'}, None, or float in [0, 1], optional
         How to treat the spin-up zone, where a pore volume's retarded look-back/forward parcel
         leaves the flow record. Matches the package convention (see :mod:`gwtransport.advection`).
 
@@ -290,7 +297,7 @@ def full(
           the record at the boundary flow rates (flow held constant at its first/last value), so
           the residence time stays finite. No left-edge (extraction) or right-edge (infiltration)
           spin-up ``NaN``.
-        * ``None`` or a ``float`` in ``[0, 1)``: strict -- a pore volume whose parcel leaves the
+        * ``None`` or a ``float`` in ``[0, 1]``: strict -- a pore volume whose parcel leaves the
           record at any point within an output bin is ``NaN`` for that bin (all-or-nothing per bin),
           with no extrapolation. This function returns the full per-pore-volume array, so there is no
           pore-volume axis to collapse; the ``float`` covered-fraction threshold therefore behaves
@@ -304,6 +311,8 @@ def full(
     numpy.ndarray
         Mean residence time [days], shape ``(n_pore_volumes, n_output_bins)``. The first
         dimension corresponds to the pore volumes and the second to the ``cout_tedges`` bins.
+        Negative or ``NaN`` ``flow`` makes the cumulative-volume map non-monotone or undefined; the
+        whole array is returned as ``NaN`` (the function refuses rather than raising).
 
     Raises
     ------
@@ -311,7 +320,7 @@ def full(
         If ``tedges`` does not have exactly one more element than ``flow``. If
         ``direction`` is not ``'extraction_to_infiltration'`` or
         ``'infiltration_to_extraction'``. If ``spinup`` is not ``'constant'``, ``None``, or a float
-        in ``[0, 1)``.
+        in ``[0, 1]``.
 
     See Also
     --------
@@ -416,21 +425,25 @@ def full(
     phi_base = _eval_phi(vol_out, phi_v, phi_t, phi_knot, phi_rate, strict_nan=strict)  # (n_out + 1,)
     phi_shift = _eval_phi(vol_out[None, :] + shift[:, None], phi_v, phi_t, phi_knot, phi_rate, strict_nan=strict)
 
-    # Zero-throughflow output bin (dvol -> 0): the volume is fixed while output time advances, so the
-    # flow-weighted average degenerates to the pointwise tau at the bin time midpoint, sign*(T(V_lo +
-    # shift) - t_mid). A direct ratio there would catastrophically cancel.
-    t_mid = 0.5 * (cout_tedges_days[:-1] + cout_tedges_days[1:])
-    nan_outside = np.nan if strict else None
     tol = 1e6 * np.spacing(float(np.max(np.abs(flow_cum)))) if flow_cum.size else 0.0
     with np.errstate(divide="ignore", invalid="ignore"):
         result = (
             sign * ((phi_shift[:, 1:] - phi_shift[:, :-1]) - (phi_base[1:] - phi_base[:-1])[None, :]) / dvol[None, :]
         )
-        t_lookback = linear_interpolate(
-            x_ref=phi_v, y_ref=phi_t, x_query=v_lo[None, :] + shift[:, None], left=nan_outside, right=nan_outside
-        )
-        point = sign * (t_lookback - t_mid[None, :])
-    result = np.where(dvol[None, :] > tol, result, point)
+    # Zero-throughflow output bin (dvol -> 0): the volume is fixed while output time advances, so the
+    # flow-weighted average degenerates to the pointwise tau at the bin time midpoint, sign*(T(V_lo +
+    # shift) - t_mid). A direct ratio there would catastrophically cancel. Only in-record zero-flow
+    # bins reach it, so skip the interp entirely when none are present.
+    degenerate = bins_within & (dvol <= tol)
+    if np.any(degenerate):
+        t_mid = 0.5 * (cout_tedges_days[:-1] + cout_tedges_days[1:])
+        nan_outside = np.nan if strict else None
+        with np.errstate(divide="ignore", invalid="ignore"):
+            t_lookback = linear_interpolate(
+                x_ref=phi_v, y_ref=phi_t, x_query=v_lo[None, :] + shift[:, None], left=nan_outside, right=nan_outside
+            )
+            point = sign * (t_lookback - t_mid[None, :])
+        result = np.where(dvol[None, :] > tol, result, point)
     return np.where(bins_within[None, :], result, np.nan)
 
 
@@ -483,14 +496,15 @@ def mean(
         Default is 'extraction_to_infiltration'.
     retardation_factor : float, optional
         Retardation factor of the compound in the aquifer [dimensionless]. Default is 1.0.
-    spinup : {'constant'}, None, or float in [0, 1), optional
+    spinup : {'constant'}, None, or float in [0, 1], optional
         Spin-up policy, sharing the contract of :func:`gamma`. ``'constant'``
         (default) warm-starts by extrapolating the boundary flow so no in-record bin is ``NaN``;
         ``None`` leaves spin-up streamtubes ``NaN`` and the mean renormalizes over those that have
         broken through (emitted wherever at least one streamtube is valid). A ``float`` in
-        ``[0, 1)`` is the covered-fraction threshold: the renormalized mean is emitted only where
-        the fraction of valid streamtubes is at least ``spinup`` (``0.0`` matches ``None``; larger
-        values demand more streamtubes to have broken through). Use :func:`fraction_explained_mean` to
+        ``[0, 1]`` is the covered-fraction threshold: the renormalized mean is emitted only where
+        the fraction of valid streamtubes is at least ``spinup`` (``0.0`` matches ``None``; ``1.0``
+        demands every streamtube; larger values demand more streamtubes to have broken through). Use
+        :func:`fraction_explained_mean` to
         locate the spin-up region.
 
     Returns
@@ -499,7 +513,8 @@ def mean(
         Mean residence time [days], shape ``(n_output_bins,)``. Output bins with no valid
         streamtube (outside the flow record, or -- with ``spinup=None`` -- fully in the spin-up
         zone) are NaN; with a ``float`` ``spinup`` so are bins whose valid-streamtube fraction is
-        below the threshold.
+        below the threshold. Negative or ``NaN`` ``flow`` makes the cumulative-volume map non-monotone
+        or undefined; the whole series is returned as ``NaN`` (the function refuses rather than raising).
 
     See Also
     --------
@@ -621,17 +636,18 @@ def gamma(
         Default is 'extraction_to_infiltration'.
     retardation_factor : float, optional
         Retardation factor of the compound in the aquifer [dimensionless]. Default is 1.0.
-    spinup : {'constant'}, None, or float in [0, 1), optional
+    spinup : {'constant'}, None, or float in [0, 1], optional
         How to treat the spin-up zone, where part of the gamma APVD lacks flow history. Matches
         the package convention (see :mod:`gwtransport.advection`).
 
         * ``'constant'`` (default): warm-start -- extrapolate the cumulative-volume-to-time map past
           the record at the boundary flow rates (flow held constant at its first/last value) and
           integrate the full distribution, so no in-record bin is ``NaN``.
-        * ``None`` or a ``float`` in ``[0, 1)``: renormalize the mean over the covered sub-mass,
+        * ``None`` or a ``float`` in ``[0, 1]``: renormalize the mean over the covered sub-mass,
           emitting a bin only where the covered fraction of the distribution is at least the
           threshold. ``None`` and ``0.0`` both give the exact covered-sub-mass conditional mean
-          (emit whenever any sub-mass is covered); larger values demand a larger covered fraction.
+          (emit whenever any sub-mass is covered); larger values demand a larger covered fraction,
+          and ``1.0`` requires the full distribution to be covered.
 
         Output bins lying wholly outside ``tedges`` are ``NaN`` under either policy.
 
@@ -640,14 +656,15 @@ def gamma(
     numpy.ndarray
         APVD-mean residence time [days], shape ``(n_output_bins,)``. Output bins outside the flow
         record are NaN; with a ``float`` ``spinup`` so are bins whose covered fraction is below the
-        threshold.
+        threshold. Negative or ``NaN`` ``flow`` makes the cumulative-volume map non-monotone or
+        undefined; the whole series is returned as ``NaN`` (the function refuses rather than raising).
 
     Raises
     ------
     ValueError
         If ``tedges`` does not have exactly one more element than ``flow``. If ``direction``
         is not ``'extraction_to_infiltration'`` or ``'infiltration_to_extraction'``. If ``spinup``
-        is not ``'constant'``, ``None``, or a float in ``[0, 1)``. Gamma parameter validation is
+        is not ``'constant'``, ``None``, or a float in ``[0, 1]``. Gamma parameter validation is
         delegated to :func:`gwtransport.gamma.parse_parameters`.
 
     See Also
@@ -862,8 +879,10 @@ def gamma(
         covered = good & (den > 0)
         if spinup_threshold > 0.0:
             # float spinup: emit only where the covered fraction of the APVD reaches the threshold.
-            # den is the covered sub-mass; (v_hi - v_lo) * m0.sum is the fully-covered sub-mass.
-            covered &= den >= spinup_threshold * (v_hi - v_lo) * m0.sum(axis=1)
+            # den is the covered sub-mass; (v_hi - v_lo) * m0.sum is the fully-covered reference (equal
+            # up to reassociation ulps when fully covered). The relative slack keeps the strictest
+            # threshold (1.0) from rejecting fully-covered bins on that float noise.
+            covered &= den >= (spinup_threshold - _SPINUP_GATE_RELTOL) * (v_hi - v_lo) * m0.sum(axis=1)
         tile_result = np.full(nt, np.nan)
         tile_result[covered] = num[covered] / den[covered]
         result[t0:t1] = tile_result
@@ -880,11 +899,20 @@ def gamma(
         # Over a zero-flow bin the volume is fixed but output time advances, so tau ramps linearly with
         # output time; its bin-average is the value at the bin's time midpoint, not at T(v).
         t_v = (0.5 * (cout_tedges_days[:-1] + cout_tedges_days[1:]))[degenerate]
+        # Upper V_p integration bound, mirroring the main loop's spin-up handling. With
+        # spinup="constant" the extrapolated phi map warm-starts the full support; otherwise a V_p
+        # whose look-back/forward parcel leaves the record (e2i: v - r*V_p < 0, i2e: v + r*V_p >
+        # v_end) is in spin-up, so integrate only the covered sub-range [support_lo, vp_hi] and let the
+        # covered sub-mass renormalize the mean (den_pt below), keeping the parcel inside the raw phi map.
+        if extrapolate:
+            vp_hi = np.full(v.shape, support_hi)
+        else:
+            vp_hi = np.clip((v if sign < 0 else v_end - v) / r, support_lo, support_hi)
         # tau(v, V_p) = sign * (T(v + sign*r*V_p) - t_mid) is piecewise-linear in V_p with knots where
-        # v + sign*r*V_p crosses a phi_v edge; integrate it against the gamma density over the support.
-        bp = np.clip(sign * (phi_v[None, :] - v[:, None]) / r, support_lo, support_hi)
+        # v + sign*r*V_p crosses a phi_v edge; integrate it against the gamma density over the sub-range.
+        bp = np.clip(sign * (phi_v[None, :] - v[:, None]) / r, support_lo, vp_hi[:, None])
         bp.sort(axis=1)
-        edges_pt = np.concatenate([np.full((v.size, 1), support_lo), bp, np.full((v.size, 1), support_hi)], axis=1)
+        edges_pt = np.concatenate([np.full((v.size, 1), support_lo), bp, vp_hi[:, None]], axis=1)
         lo_pt, hi_pt = edges_pt[:, :-1], edges_pt[:, 1:]
         nodes_pt = np.stack([lo_pt, 0.5 * (lo_pt + hi_pt), hi_pt])  # (3, k, n_pieces)
         a_pt = v[None, :, None] + sign * r * nodes_pt
@@ -898,8 +926,18 @@ def gamma(
         m0_pt = np.diff(gamma_dist.cdf(cdf_pt, alpha, scale=beta), axis=1)
         m1_pt = alpha * beta * np.diff(gamma_dist.cdf(cdf_pt, alpha + 1, scale=beta), axis=1) + loc * m0_pt
         num_pt = (tau_mid * m0_pt + slope * (m1_pt - mid_pt * m0_pt)).sum(axis=1)
-        den_pt = m0_pt.sum(axis=1)
-        result[degenerate] = np.where(den_pt > 0, num_pt / den_pt, np.nan)
+        den_pt = m0_pt.sum(axis=1)  # covered sub-mass over [support_lo, vp_hi]
+        covered_pt = den_pt > 0
+        if spinup_threshold > 0.0:
+            # float spinup: emit only where the covered fraction reaches the threshold. den_pt is the
+            # covered sub-mass; the full-support mass is the fully-covered reference. The same relative
+            # slack as the main loop keeps threshold 1.0 robust to reassociation ulps in den_pt.
+            full_mass = gamma_dist.cdf(support_hi - loc, alpha, scale=beta) - gamma_dist.cdf(
+                support_lo - loc, alpha, scale=beta
+            )
+            covered_pt &= den_pt >= (spinup_threshold - _SPINUP_GATE_RELTOL) * full_mass
+        with np.errstate(divide="ignore", invalid="ignore"):
+            result[degenerate] = np.where(covered_pt, num_pt / den_pt, np.nan)
     return result
 
 
@@ -953,7 +991,9 @@ def fraction_explained_full(
     -------
     numpy.ndarray
         Advective coverage [dimensionless], shape ``(n_pore_volumes, n_output_bins)``, values in
-        ``[0, 1]``. Output bins lying wholly outside ``tedges`` are ``NaN``.
+        ``[0, 1]``. Output bins lying wholly outside ``tedges`` are ``NaN``. Negative or ``NaN``
+        ``flow`` makes the cumulative-volume map non-monotone or undefined; the whole array is
+        returned as ``NaN`` (the function refuses rather than raising).
 
     Raises
     ------
@@ -1055,7 +1095,9 @@ def fraction_explained_mean(
     -------
     numpy.ndarray
         Advective coverage [dimensionless], shape ``(n_output_bins,)``, values in ``[0, 1]``.
-        Output bins lying wholly outside ``tedges`` are ``NaN``.
+        Output bins lying wholly outside ``tedges`` are ``NaN``. Negative or ``NaN`` ``flow`` makes
+        the cumulative-volume map non-monotone or undefined; the whole series is returned as ``NaN``
+        (the function refuses rather than raising).
 
     See Also
     --------
@@ -1159,7 +1201,9 @@ def fraction_explained_gamma(
     -------
     numpy.ndarray
         Advective coverage [dimensionless], shape ``(n_output_bins,)``, values in ``[0, 1]``.
-        Output bins lying wholly outside ``tedges`` are ``NaN``.
+        Output bins lying wholly outside ``tedges`` are ``NaN``. Negative or ``NaN`` ``flow`` makes
+        the cumulative-volume map non-monotone or undefined; the whole series is returned as ``NaN``
+        (the function refuses rather than raising).
 
     Raises
     ------

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -28,25 +28,23 @@ Available functions:
   specified x-edges. Supports 1D or 2D edge arrays for batch processing. Handles NaN values
   and offers multiple extrapolation methods ('nan', 'outer', 'raise').
 
-- :func:`partial_isin` - Calculate fraction of each input bin overlapping with each output bin.
-  Returns dense matrix where element (i,j) represents overlap fraction. Uses vectorized
-  operations for efficiency.
-
 - :func:`time_bin_overlap` - Calculate fraction of time bins overlapping with specified time
   ranges. Similar to partial_isin but for time-based bin overlaps with list of (start, end)
   tuples.
 
 - :func:`simplify_bins` - Simplify a piecewise-constant time series by merging adjacent bins
   whose values are within a tolerance. Uses volume-weighted (flow x width) averaging when
-  flow is provided, otherwise width-weighted. Direction-independent via recursive splitting.
-
-- :func:`combine_bin_series` - Combine two binned series onto common set of unique edges. Maps
-  values from original bins to new combined structure with configurable extrapolation ('nearest'
-  or float value).
+  flow is provided, otherwise width-weighted. Direction-independent via largest-jump splitting.
 
 - :func:`compute_time_edges` - Compute DatetimeIndex of time bin edges from explicit edges,
   start times, or end times. Validates consistency with expected number of bins and handles
   uniform spacing extrapolation.
+
+The inverse solvers below are two intentionally coexisting families: a Tikhonov family (the dense
+:func:`solve_inverse_transport` and its banded equivalent :func:`solve_inverse_transport_banded`,
+both fed by :func:`compute_reverse_target` and built on :func:`solve_tikhonov`) for the
+overdetermined deconvolution in advection/diffusion, and a separate nullspace solver
+(:func:`solve_underdetermined_system`) for the underdetermined deposition inverse.
 
 - :func:`solve_tikhonov` - Solve linear system with Tikhonov regularization toward a target.
   Well-determined modes follow the data; poorly-determined modes are pulled toward the target.
@@ -593,123 +591,18 @@ def linear_average(
             bins_within_range = np.broadcast_to(bins_within_range, (n_series, bins_within_range.shape[1]))
         result[~bins_within_range] = np.nan
 
-        # With 2D y_data, propagate per-row NaNs from the y series itself: any output bin
-        # that touches an x_data segment with NaN y in this row must be NaN. Per-row NaN
-        # info is preserved in all_unique_y; mark bins whose [edge_left, edge_right]
-        # contains a NaN segment for this row.
-        if n_series_y > 1:
-            # For each unique-x segment, is it NaN in this row?
-            seg_nan = np.isnan(y_avg)  # shape (n_series_y, n_unique_x - 1)
-            # A bin spans segments [edge_indices[0, b], edge_indices[0, b+1])
-            # For each row, count NaN segments per bin via cumulative sums.
-            seg_nan_cum = np.concatenate([np.zeros((n_series_y, 1)), np.cumsum(seg_nan, axis=1)], axis=1)
-            nan_count_per_bin = seg_nan_cum[:, edge_indices[0, 1:]] - seg_nan_cum[:, edge_indices[0, :-1]]
-            row_has_nan_in_bin = nan_count_per_bin > 0
-            result[row_has_nan_in_bin] = np.nan
+    # With 2D y_data, propagate per-row NaNs from the y series itself: any output bin that
+    # touches an x_data segment with NaN y in this row must be NaN. This 2-D NaN contract is
+    # method-independent -- it also holds for 'outer'/'raise', which would otherwise return a
+    # silently wrong finite average (the NaN trapezoids were zeroed above). Per-row NaN info is
+    # preserved in y_avg; mark bins whose spanned segments contain a NaN segment for this row.
+    if n_series_y > 1:
+        seg_nan = np.isnan(y_avg)  # shape (n_series_y, n_unique_x - 1)
+        seg_nan_cum = np.concatenate([np.zeros((n_series_y, 1)), np.cumsum(seg_nan, axis=1)], axis=1)
+        nan_count_per_bin = seg_nan_cum[:, edge_indices[0, 1:]] - seg_nan_cum[:, edge_indices[0, :-1]]
+        result[nan_count_per_bin > 0] = np.nan
 
     return result
-
-
-def partial_isin(*, bin_edges_in: npt.ArrayLike, bin_edges_out: npt.ArrayLike) -> npt.NDArray[np.floating]:
-    """
-    Calculate the fraction of each input bin that overlaps with each output bin.
-
-    This function computes a matrix where element (i, j) represents the fraction
-    of input bin i that overlaps with output bin j. The computation uses
-    vectorized operations to avoid loops.
-
-    Parameters
-    ----------
-    bin_edges_in : array-like
-        1D array of input bin edges in ascending order. For n_in bins, there
-        should be n_in+1 edges.
-    bin_edges_out : array-like
-        1D array of output bin edges in ascending order. For n_out bins, there
-        should be n_out+1 edges.
-
-    Returns
-    -------
-    overlap_matrix : ndarray
-        Dense matrix of shape (n_in, n_out) where n_in is the number of input
-        bins and n_out is the number of output bins. Each element (i, j)
-        represents the fraction of input bin i that overlaps with output bin j.
-        Values range from 0 (no overlap) to 1 (complete overlap).
-
-    Raises
-    ------
-    ValueError
-        If ``bin_edges_in`` or ``bin_edges_out`` are not 1D arrays. If either edge
-        array has fewer than 2 elements. If ``bin_edges_in`` or ``bin_edges_out``
-        are not in ascending order.
-
-    Notes
-    -----
-    - Both input arrays must be sorted in ascending order
-    - The function leverages the sorted nature of both inputs for efficiency
-    - Uses vectorized operations to handle large bin arrays efficiently
-    - All overlaps sum to 1.0 for each input bin when output bins fully cover input range
-
-    Examples
-    --------
-    >>> import numpy as np
-    >>> from gwtransport.utils import partial_isin
-    >>> bin_edges_in = np.array([0, 10, 20, 30])
-    >>> bin_edges_out = np.array([5, 15, 25])
-    >>> partial_isin(
-    ...     bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out
-    ... )  # doctest: +NORMALIZE_WHITESPACE
-    array([[0.5, 0. ],
-           [0.5, 0.5],
-           [0. , 0.5]])
-    """
-    # Convert inputs to numpy arrays
-    bin_edges_in = np.asarray(bin_edges_in, dtype=float)
-    bin_edges_out = np.asarray(bin_edges_out, dtype=float)
-
-    # Validate inputs
-    if bin_edges_in.ndim != 1 or bin_edges_out.ndim != 1:
-        msg = "Both bin_edges_in and bin_edges_out must be 1D arrays"
-        raise ValueError(msg)
-    if len(bin_edges_in) < 2 or len(bin_edges_out) < 2:  # noqa: PLR2004
-        msg = "Both edge arrays must have at least 2 elements"
-        raise ValueError(msg)
-
-    # Edges must be non-decreasing (ignoring NaN). Zero-width input bins are
-    # allowed -- they arise e.g. from cumulative flow with zero-flow intervals --
-    # and produce zero overlap fractions (no water passed through).
-    diffs_in = np.diff(bin_edges_in)
-    valid_diffs_in = ~np.isnan(diffs_in)
-    if np.any(valid_diffs_in) and not np.all(diffs_in[valid_diffs_in] >= 0):
-        msg = "bin_edges_in must be non-decreasing"
-        raise ValueError(msg)
-
-    diffs_out = np.diff(bin_edges_out)
-    valid_diffs_out = ~np.isnan(diffs_out)
-    if np.any(valid_diffs_out) and not np.all(diffs_out[valid_diffs_out] >= 0):
-        msg = "bin_edges_out must be non-decreasing"
-        raise ValueError(msg)
-
-    # Build matrix using fully vectorized approach
-    # Create meshgrids for all possible input-output bin combinations
-    in_left = bin_edges_in[:-1, None]  # Shape: (n_bins_in, 1)
-    in_right = bin_edges_in[1:, None]  # Shape: (n_bins_in, 1)
-    in_width = diffs_in[:, None]  # Shape: (n_bins_in, 1); reuses the validated np.diff above
-
-    out_left = bin_edges_out[None, :-1]  # Shape: (1, n_bins_out)
-    out_right = bin_edges_out[None, 1:]  # Shape: (1, n_bins_out)
-
-    # Calculate overlaps for all combinations using broadcasting
-    overlap_left = np.maximum(in_left, out_left)  # Shape: (n_bins_in, n_bins_out)
-    overlap_right = np.minimum(in_right, out_right)  # Shape: (n_bins_in, n_bins_out)
-
-    # Calculate overlap widths (zero where no overlap)
-    overlap_widths = np.maximum(0, overlap_right - overlap_left)
-
-    # Zero-width input bins contribute no overlap (division-safe). NaN widths still
-    # propagate as NaN fractions (preserved for spin-up handling).
-    with np.errstate(divide="ignore", invalid="ignore"):
-        result = overlap_widths / in_width
-    return np.where(in_width == 0, 0.0, result)
 
 
 def time_bin_overlap(*, tedges: npt.ArrayLike, bin_tedges: list[tuple]) -> npt.NDArray[np.floating]:
@@ -776,6 +669,16 @@ def time_bin_overlap(*, tedges: npt.ArrayLike, bin_tedges: list[tuple]) -> npt.N
         msg = "bin_tedges must be non-empty"
         raise ValueError(msg)
 
+    # Normalize datetime-like inputs (datetime64 or object arrays of Timestamps/datetimes) to a
+    # common int64-nanosecond float scale so numeric, datetime64, and Timestamp inputs share one
+    # arithmetic path; ``np.maximum(0, Timedelta)`` on an object array would otherwise raise. Only
+    # differences enter the result, so the shared epoch origin cancels and the fractions are exact.
+    if not np.issubdtype(tedges.dtype, np.number):
+        tedges = pd.DatetimeIndex(tedges).asi8.astype(float)
+    if not np.issubdtype(bin_tedges_array.dtype, np.number):
+        flat = pd.DatetimeIndex(bin_tedges_array.ravel()).asi8.astype(float)
+        bin_tedges_array = flat.reshape(bin_tedges_array.shape)
+
     # Calculate overlaps for all combinations using broadcasting
     overlap_left = np.maximum(bin_tedges_array[:, [0]], tedges[None, :-1])
     overlap_right = np.minimum(bin_tedges_array[:, [1]], tedges[None, 1:])
@@ -802,9 +705,9 @@ def simplify_bins(
 ]:
     """Simplify a piecewise-constant time series by merging adjacent bins.
 
-    Recursively splits at the largest value jump until the peak-to-peak
-    range within every group does not exceed `tol`. The result is
-    independent of scan direction.
+    Splits at the largest value jump until the peak-to-peak range within
+    every group does not exceed `tol`. The result is independent of scan
+    direction.
 
     Parameters
     ----------
@@ -845,13 +748,23 @@ def simplify_bins(
     else:
         weights = widths
 
-    def _splits(lo: int, hi: int) -> list[int]:
+    # Iteratively split each segment at its largest value jump until every group's peak-to-peak
+    # range is within tol. An explicit LIFO stack replaces the natural recursion, which peels one
+    # element per level on smooth monotone data (argmax|diff| sits at a segment edge) and overflows
+    # the interpreter stack for a few thousand points. Every split index is interior to its
+    # (disjoint) segment, so sorting the collected splits reproduces the recursion's in-order
+    # output exactly -- the merged bins are identical.
+    splits: list[int] = []
+    stack: list[tuple[int, int]] = [(0, len(values))]
+    while stack:
+        lo, hi = stack.pop()
         if np.ptp(values[lo:hi]) <= tol:
-            return []
+            continue
         i = lo + int(np.argmax(np.abs(np.diff(values[lo:hi])))) + 1
-        return [*_splits(lo, i), i, *_splits(i, hi)]
-
-    s = np.array([0, *_splits(0, len(values))])
+        splits.append(i)
+        stack.extend(((lo, i), (i, hi)))
+    splits.sort()
+    s = np.array([0, *splits])
     idx = np.append(s, len(values))
     new_edges = edges[idx]
     new_widths = np.add.reduceat(widths, s)
@@ -869,96 +782,6 @@ def _generate_failed_coverage_badge() -> None:
 
     b = Badge(left_txt="coverage", right_txt="failed", color="red")
     b.write_to("coverage_failed.svg", use_shields=False)
-
-
-def combine_bin_series(
-    *,
-    a: npt.ArrayLike,
-    a_edges: npt.ArrayLike,
-    b: npt.ArrayLike,
-    b_edges: npt.ArrayLike,
-    extrapolation: str | float = 0.0,
-) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating], npt.NDArray[np.floating]]:
-    """
-    Combine two binned series onto a common set of unique edges.
-
-    This function takes two binned series (a and b) with their respective bin edges
-    and creates new series (c and d) that are defined on a combined set of unique
-    edges from both input edge arrays.
-
-    Parameters
-    ----------
-    a : array-like
-        Values for the first binned series.
-    a_edges : array-like
-        Bin edges for the first series. Must have len(a) + 1 elements.
-    b : array-like
-        Values for the second binned series.
-    b_edges : array-like
-        Bin edges for the second series. Must have len(b) + 1 elements.
-    extrapolation : str or float, optional
-        Method for handling combined bins that fall outside the original series ranges.
-        - 'nearest': Use the nearest original bin value
-        - float value (e.g., np.nan, 0.0): Fill with the specified value (default: 0.0)
-
-    Returns
-    -------
-    c : ndarray
-        Values from series a mapped to the combined edge structure.
-    c_edges : ndarray
-        Combined unique edges from a_edges and b_edges.
-    d : ndarray
-        Values from series b mapped to the combined edge structure.
-    d_edges : ndarray
-        Combined unique edges from a_edges and b_edges (same as c_edges).
-
-    Raises
-    ------
-    ValueError
-        If ``a_edges`` does not have ``len(a) + 1`` elements, or if ``b_edges`` does not
-        have ``len(b) + 1`` elements.
-
-    Notes
-    -----
-    The combined edges are created by taking the union of all unique values
-    from both a_edges and b_edges, sorted in ascending order. The values
-    are then broadcasted/repeated for each combined bin that falls within
-    the original bin's range.
-    """
-    a = np.asarray(a, dtype=float)
-    a_edges = np.asarray(a_edges, dtype=float)
-    b = np.asarray(b, dtype=float)
-    b_edges = np.asarray(b_edges, dtype=float)
-
-    if len(a_edges) != len(a) + 1:
-        msg = "a_edges must have len(a) + 1 elements"
-        raise ValueError(msg)
-    if len(b_edges) != len(b) + 1:
-        msg = "b_edges must have len(b) + 1 elements"
-        raise ValueError(msg)
-
-    combined_edges = np.unique(np.concatenate([a_edges, b_edges]))
-    combined_bin_centers = (combined_edges[:-1] + combined_edges[1:]) / 2
-
-    def _map(values: npt.NDArray[np.floating], edges: npt.NDArray[np.floating]) -> npt.NDArray[np.floating]:
-        # Map one series onto the combined bins, applying the chosen extrapolation.
-        assignment = np.clip(np.searchsorted(edges, combined_bin_centers, side="right") - 1, 0, len(values) - 1)
-        if extrapolation == "nearest":
-            return values[assignment]
-        out = np.zeros(len(combined_edges) - 1)
-        # A combined bin keeps the original value only when it lies fully inside that bin.
-        valid = (combined_edges[:-1] >= edges[assignment]) & (combined_edges[1:] <= edges[assignment + 1])
-        out[valid] = values[assignment[valid]]
-        out[~valid] = extrapolation
-        return out
-
-    c = _map(a, a_edges)
-    d = _map(b, b_edges)
-
-    c_edges = combined_edges
-    d_edges = combined_edges.copy()
-
-    return c, c_edges, d, d_edges
 
 
 def compute_time_edges(
@@ -1022,7 +845,7 @@ def compute_time_edges(
     """
     if tedges is not None:
         if number_of_bins != len(tedges) - 1:
-            msg = "tedges must have one more element than flow"
+            msg = "tedges must have one more element than number_of_bins"
             raise ValueError(msg)
         tedges = pd.DatetimeIndex(tedges)
         # Ensure nanosecond precision while preserving timezone
@@ -1032,7 +855,7 @@ def compute_time_edges(
         # Assume the index refers to the time at the start of the measurement interval
         tstart = pd.DatetimeIndex(tstart).as_unit("ns")
         if number_of_bins != len(tstart):
-            msg = "tstart must have the same number of elements as flow"
+            msg = "tstart must have the same number of elements as number_of_bins"
             raise ValueError(msg)
         if len(tstart) < 2:  # noqa: PLR2004
             msg = "tstart must have at least 2 elements to infer the bin width; pass tedges for a single bin"
@@ -1046,7 +869,7 @@ def compute_time_edges(
         # Assume the index refers to the time at the end of the measurement interval
         tend = pd.DatetimeIndex(tend).as_unit("ns")
         if number_of_bins != len(tend):
-            msg = "tend must have the same number of elements as flow"
+            msg = "tend must have the same number of elements as number_of_bins"
             raise ValueError(msg)
         if len(tend) < 2:  # noqa: PLR2004
             msg = "tend must have at least 2 elements to infer the bin width; pass tedges for a single bin"
@@ -1736,15 +1559,18 @@ def solve_inverse_transport_banded(
     weight matrix stored in banded layout: row ``k`` of the dense operator
     ``W`` is ``band_vals[k]`` placed at columns
     ``[col_start[k], col_start[k] + full_band)``. The Tikhonov normal
-    equations ``(WᵀW + λ D) x = Wᵀ observed + λ D x_target`` are assembled
-    **directly in banded form** -- ``WᵀW`` is symmetric with half-bandwidth
-    ``full_band - 1`` -- and Cholesky-factored with
-    :func:`scipy.linalg.cholesky_banded`. Forming ``WᵀW`` squares the condition
-    number, so the bare Cholesky solve loses accuracy in the under-determined
-    (spin-up nullspace) directions; **corrected semi-normal equations** restore
-    it by refining with the residual evaluated through ``W`` itself rather than
-    ``WᵀW`` (matching the dense least-squares solution to ~1e-10). Peak memory is
-    ``O(n_output * full_band)``, never the dense ``O(n_obs * n_output)``.
+    equations ``(WᵀW + λ D) x = Wᵀ observed + λ D x_target`` are stored **in
+    banded form** -- ``WᵀW`` is symmetric with half-bandwidth ``full_band - 1``
+    -- and Cholesky-factored with :func:`scipy.linalg.cholesky_banded`. The Gram
+    matrix ``WᵀW`` is built with a single dense BLAS matmul (``~24x`` a
+    per-diagonal scatter) before its sub-diagonals are read into the banded
+    layout. Forming ``WᵀW`` squares the condition number, so the bare Cholesky
+    solve loses accuracy in the under-determined (spin-up nullspace) directions;
+    **corrected semi-normal equations** restore it by refining with the residual
+    evaluated through ``W`` itself rather than ``WᵀW`` (matching the dense
+    least-squares solution to ~1e-10). The banded Cholesky factor, solve, and
+    refinement stay at ``O(n_output * full_band)``; only the one-shot Gram
+    assembly transiently materializes ``W`` and ``WᵀW`` densely.
 
     The regularization target ``x_target`` is the transpose-and-normalize of
     ``W`` applied to ``observed`` (the banded form of
@@ -1818,15 +1644,21 @@ def solve_inverse_transport_banded(
     with np.errstate(invalid="ignore", divide="ignore"):
         x_target = np.where(col_sum > _EPSILON_COEFF_SUM, wt_observed / col_sum, 0.0)
 
-    # Lower-banded WᵀW: band row d is the d-th sub-diagonal. A row's contribution to
-    # (i, j) with i = col_start + b1, j = col_start + b2 lands at offset d = b1 - b2 >= 0
-    # and column j. band_vals is zero outside each window, so off-window pairs add 0.
+    # Lower-banded WᵀW via a dense BLAS matmul. Materialize the forward operator W densely
+    # (row k is band_vals[k] at columns [col_start[k], col_start[k] + full_band)), form the
+    # symmetric Gram matrix WᵀW with a single optimized matmul, then read its lower sub-diagonals
+    # into the banded layout (band row d is the d-th sub-diagonal, WᵀW[j + d, j]). Each row's
+    # in-range band columns are distinct, so the scatter into W needs no accumulation. This is
+    # ~24x the per-diagonal np.add.at scatter; the matmul reorders the summation, so ab matches
+    # the scatter to ~1e-13 -- well inside the Tikhonov + refinement tolerance.
+    n_obs = band_vals.shape[0]
+    w_dense = np.zeros((n_obs, n_cin))
+    obs_idx = np.broadcast_to(np.arange(n_obs)[:, None], cols.shape)
+    w_dense[obs_idx[in_range], cols_clipped[in_range]] = band_vals[in_range]
+    gram = w_dense.T @ w_dense
     ab = np.zeros((full_band, n_cin))
     for d in range(full_band):
-        prod = band_vals[:, d:] * band_vals[:, : full_band - d]
-        c = cols_clipped[:, : full_band - d]
-        m = in_range[:, : full_band - d] & in_range[:, d:]
-        np.add.at(ab[d], c[m], prod[m])
+        ab[d, : n_cin - d] = np.diagonal(gram, offset=-d)
 
     lam = regularization_strength
     d_reg = lam * col_active

--- a/tests/regression/test_phase1_invariants.py
+++ b/tests/regression/test_phase1_invariants.py
@@ -406,22 +406,18 @@ def test_mass_balance_freundlich_nhalf_mirror_pointwise_breakthrough(n):
         err_msg=f"n={n} pointwise breakthrough mismatch:\nθ={theta_samples}\nnum={c_numerical}\nana={c_analytical}",
     )
 
-    # Asymptotic total: m_out_total = m_in - C_T(c_∞) · V_outlet (c_∞=4 here).
-    # NOTE: compute_total_outlet_mass uses the asymptotic formula directly
-    # (no wave list), so this is a smoke test for the formula wiring — it
-    # catches sign flips or missing c_∞ retrieval but not wave-list bugs.
-    mass_in = float(np.sum(cin * np.diff(tr.state.theta_edges)))
+    # Sustained ambient boundary: c_∞ = cin[-1] = 4 > 0, so the inlet keeps
+    # injecting forever and the θ → ∞ total outlet mass is unbounded. The
+    # corrected compute_total_outlet_mass returns +inf here (review O3); the
+    # old finite form ``m_in − C_T(c_∞)·V_outlet`` mixed a finite record
+    # integral with an infinite-time steady-state fill and could go negative.
     mass_out = compute_total_outlet_mass(
         v_outlet=v_outlet,
         sorption=sorption,
         cin=cin,
         theta_edges=tr.state.theta_edges,
     )
-    c_inf = float(cin[-1])
-    expected_m_out = mass_in - float(sorption.total_concentration(c_inf)) * v_outlet
-    assert np.isclose(mass_out, expected_m_out, rtol=1e-12), (
-        f"n={n} mirror asymptotic: mass_out={mass_out:.4f}, expected={expected_m_out:.4f}"
-    )
+    assert mass_out == float("inf"), f"n={n} mirror: sustained c_∞>0 total outlet mass must be +inf, got {mass_out}"
 
 
 def test_mass_balance_freundlich_n2_multipulse():

--- a/tests/src/_oracles.py
+++ b/tests/src/_oracles.py
@@ -1,0 +1,124 @@
+"""Independent test-support oracles for gwtransport.
+
+This module holds reference implementations that the test suite uses to cross-check the
+package's production code, but that are not themselves part of the public ``gwtransport`` API.
+Keeping them here (rather than in ``src/gwtransport``) means the shipped package carries no
+runtime code that only the tests exercise, while the tests retain an independent oracle to
+validate against.
+
+The underscore prefix keeps pytest from collecting this module as a test file. It is importable
+by bare name from any test because ``tests/src`` is placed on ``sys.path`` by
+``tests/src/conftest.py`` (mirroring ``_radial_asr_fv_oracle``).
+
+Oracles
+-------
+- :func:`partial_isin` -- fraction of each input bin overlapping each output bin. An independent
+  bin-overlap reference for the advection weight builder and the diffusion_fast band checks.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import numpy.typing as npt
+
+
+def partial_isin(*, bin_edges_in: npt.ArrayLike, bin_edges_out: npt.ArrayLike) -> npt.NDArray[np.floating]:
+    """
+    Calculate the fraction of each input bin that overlaps with each output bin.
+
+    This function computes a matrix where element (i, j) represents the fraction
+    of input bin i that overlaps with output bin j. The computation uses
+    vectorized operations to avoid loops.
+
+    Parameters
+    ----------
+    bin_edges_in : array-like
+        1D array of input bin edges in ascending order. For n_in bins, there
+        should be n_in+1 edges.
+    bin_edges_out : array-like
+        1D array of output bin edges in ascending order. For n_out bins, there
+        should be n_out+1 edges.
+
+    Returns
+    -------
+    overlap_matrix : ndarray
+        Dense matrix of shape (n_in, n_out) where n_in is the number of input
+        bins and n_out is the number of output bins. Each element (i, j)
+        represents the fraction of input bin i that overlaps with output bin j.
+        Values range from 0 (no overlap) to 1 (complete overlap).
+
+    Raises
+    ------
+    ValueError
+        If ``bin_edges_in`` or ``bin_edges_out`` are not 1D arrays. If either edge
+        array has fewer than 2 elements. If ``bin_edges_in`` or ``bin_edges_out``
+        are not in ascending order.
+
+    Notes
+    -----
+    - Both input arrays must be sorted in ascending order
+    - The function leverages the sorted nature of both inputs for efficiency
+    - Uses vectorized operations to handle large bin arrays efficiently
+    - All overlaps sum to 1.0 for each input bin when output bins fully cover input range
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from _oracles import partial_isin
+    >>> bin_edges_in = np.array([0, 10, 20, 30])
+    >>> bin_edges_out = np.array([5, 15, 25])
+    >>> partial_isin(
+    ...     bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out
+    ... )  # doctest: +NORMALIZE_WHITESPACE
+    array([[0.5, 0. ],
+           [0.5, 0.5],
+           [0. , 0.5]])
+    """
+    # Convert inputs to numpy arrays
+    bin_edges_in = np.asarray(bin_edges_in, dtype=float)
+    bin_edges_out = np.asarray(bin_edges_out, dtype=float)
+
+    # Validate inputs
+    if bin_edges_in.ndim != 1 or bin_edges_out.ndim != 1:
+        msg = "Both bin_edges_in and bin_edges_out must be 1D arrays"
+        raise ValueError(msg)
+    if len(bin_edges_in) < 2 or len(bin_edges_out) < 2:  # noqa: PLR2004
+        msg = "Both edge arrays must have at least 2 elements"
+        raise ValueError(msg)
+
+    # Edges must be non-decreasing (ignoring NaN). Zero-width input bins are
+    # allowed -- they arise e.g. from cumulative flow with zero-flow intervals --
+    # and produce zero overlap fractions (no water passed through).
+    diffs_in = np.diff(bin_edges_in)
+    valid_diffs_in = ~np.isnan(diffs_in)
+    if np.any(valid_diffs_in) and not np.all(diffs_in[valid_diffs_in] >= 0):
+        msg = "bin_edges_in must be non-decreasing"
+        raise ValueError(msg)
+
+    diffs_out = np.diff(bin_edges_out)
+    valid_diffs_out = ~np.isnan(diffs_out)
+    if np.any(valid_diffs_out) and not np.all(diffs_out[valid_diffs_out] >= 0):
+        msg = "bin_edges_out must be non-decreasing"
+        raise ValueError(msg)
+
+    # Build matrix using fully vectorized approach
+    # Create meshgrids for all possible input-output bin combinations
+    in_left = bin_edges_in[:-1, None]  # Shape: (n_bins_in, 1)
+    in_right = bin_edges_in[1:, None]  # Shape: (n_bins_in, 1)
+    in_width = diffs_in[:, None]  # Shape: (n_bins_in, 1); reuses the validated np.diff above
+
+    out_left = bin_edges_out[None, :-1]  # Shape: (1, n_bins_out)
+    out_right = bin_edges_out[None, 1:]  # Shape: (1, n_bins_out)
+
+    # Calculate overlaps for all combinations using broadcasting
+    overlap_left = np.maximum(in_left, out_left)  # Shape: (n_bins_in, n_bins_out)
+    overlap_right = np.minimum(in_right, out_right)  # Shape: (n_bins_in, n_bins_out)
+
+    # Calculate overlap widths (zero where no overlap)
+    overlap_widths = np.maximum(0, overlap_right - overlap_left)
+
+    # Zero-width input bins contribute no overlap (division-safe). NaN widths still
+    # propagate as NaN fractions (preserved for spin-up handling).
+    with np.errstate(divide="ignore", invalid="ignore"):
+        result = overlap_widths / in_width
+    return np.where(in_width == 0, 0.0, result)

--- a/tests/src/_radial_asr_gridfree_oracle.py
+++ b/tests/src/_radial_asr_gridfree_oracle.py
@@ -307,6 +307,13 @@ def _propagate_rest(
     ndarray
         Propagated resident deviation at each node, shape ``(n_quad,)``.
     """
+    # Resolution limit (mirrors _radial_asr_reuse._rest_propagator_matrix): once the diffusion length
+    # sqrt(D_m tau) drops below half the coarsest node gap the grid cannot resolve the near-delta diffusive
+    # Green's function and the quadratured resolvent amplifies mass (dv^T P > 1). There the propagator is the
+    # identity to grid accuracy (diffusion has not crossed a cell), so the field passes through unchanged
+    # (mass-exact). Keeping this in sync with the reuse engine keeps the two agreeing at any n_quad.
+    if np.sqrt(d_m_eff * tau) < 0.5 * float(np.diff(r_nodes).max()):
+        return field.copy()
     weighted = field * (r_nodes / d_m_eff) * dr_weights
     if not np.any(weighted != 0.0):
         return np.zeros_like(field)

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -4,6 +4,7 @@ from fractions import Fraction
 import numpy as np
 import pandas as pd
 import pytest
+from _oracles import partial_isin  # ty: ignore[unresolved-import]  # tests/src on path via conftest
 
 from gwtransport import advection as adv_mod
 from gwtransport import advection_utils, gamma
@@ -31,7 +32,6 @@ from gwtransport.utils import (
     compute_time_edges,
     cumulative_flow_volume,
     linear_interpolate,
-    partial_isin,
     solve_inverse_transport,
     solve_inverse_transport_banded,
 )
@@ -3586,6 +3586,21 @@ def _good_advection_inputs():
     }
 
 
+def test_advection_public_rejects_nan_retardation_factor():
+    """NaN retardation slipped past ``< 1.0`` and silently produced all-NaN output; must raise."""
+    n = 5
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    with pytest.raises(ValueError, match=r"retardation_factor must be >= 1\.0"):
+        infiltration_to_extraction(
+            cin=np.ones(n),
+            flow=np.full(n, 100.0),
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([500.0]),
+            retardation_factor=np.nan,
+        )
+
+
 def test_validate_advection_inputs_silent_on_good_input_forward():
     """No exception when the forward (cin) inputs are valid."""
     kwargs = _good_advection_inputs()
@@ -4383,3 +4398,125 @@ def test_advection_empty_pore_volumes_all_nan():
         cout=np.ones(n), flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=empty
     )
     assert np.all(np.isnan(cin_rec))
+
+
+# =============================================================================
+# Regression: nonlinear-sorption output wrapper zero-flow / left-edge handling
+# (review item A1 / M3). Baseline (pre-fix) raised ValueError "Invalid θ-bin"
+# because a zero-flow input span collapses θ-edges and a cout edge left of the
+# flow record clamps to θ=0; both produce a zero-width θ sub-bin. The linear
+# sibling handles both gracefully, so it is the physics oracle here (front
+# tracking with ConstantRetardation == linear advection at the same R).
+# =============================================================================
+
+
+def test_nonlinear_sorption_interior_zero_flow_coarse_cout_matches_linear():
+    """A1(a): an interior zero-flow input bin must not crash the front-tracking
+    output wrapper. With a coarse (3-day) cout grid the zero-flow day is absorbed
+    into a bin with positive throughflow, so every output bin is finite and equals
+    the linear sibling to machine precision."""
+    n = 20
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cin = np.zeros(n)
+    cin[2:5] = 10.0
+    flow = np.full(n, 100.0)
+    flow[10] = 0.0  # single interior zero-flow bin (validator allows flow == 0)
+    cout_tedges = pd.date_range("2020-01-01", periods=7, freq="3D")  # fully inside the flow record
+    apv = np.array([300.0])
+
+    cout_nl, _ = infiltration_to_extraction_nonlinear_sorption(
+        cin=cin, flow=flow, tedges=tedges, cout_tedges=cout_tedges, aquifer_pore_volumes=apv, retardation_factor=2.0
+    )
+    cout_lin = infiltration_to_extraction(
+        cin=cin, flow=flow, tedges=tedges, cout_tedges=cout_tedges, aquifer_pore_volumes=apv, retardation_factor=2.0
+    )
+
+    np.testing.assert_array_equal(np.isnan(cout_nl), np.isnan(cout_lin))
+    assert not np.any(np.isnan(cout_nl))  # zero-flow day absorbed -> no undefined bin
+    np.testing.assert_allclose(cout_nl, cout_lin, atol=1e-13)
+
+
+def test_nonlinear_sorption_zero_throughflow_output_bin_is_nan():
+    """A1(a): when the cout grid isolates the zero-flow input bin (daily cout
+    aligned with the flow grid), that output bin has zero throughflow and an
+    undefined flow-weighted average. It must be returned as NaN -- exactly where
+    the linear sibling is NaN -- while every other bin matches to machine
+    precision."""
+    n = 20
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cin = np.zeros(n)
+    cin[2:5] = 10.0
+    flow = np.full(n, 100.0)
+    flow[10] = 0.0
+    apv = np.array([300.0])
+
+    cout_nl, _ = infiltration_to_extraction_nonlinear_sorption(
+        cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, retardation_factor=2.0
+    )
+    cout_lin = infiltration_to_extraction(
+        cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, retardation_factor=2.0
+    )
+
+    assert np.isnan(cout_nl[10])  # the isolated zero-throughflow output bin
+    np.testing.assert_array_equal(np.isnan(cout_nl), np.isnan(cout_lin))
+    finite = ~np.isnan(cout_lin)
+    np.testing.assert_allclose(cout_nl[finite], cout_lin[finite], atol=1e-13)
+
+
+def test_nonlinear_sorption_cout_before_record_returns_zero_left_bins():
+    """A1(b): a cout grid starting before tedges[0] must not crash. The left
+    underflow fixup extrapolates the θ map at flow[0] (mirroring the right-edge
+    rule), so pre-record output bins read θ <= 0 -> mass 0 -> exactly 0.0 (the
+    documented out-of-range contract), and the in-record window matches the linear
+    sibling to machine precision."""
+    n = 20
+    tedges = pd.date_range("2020-01-10", periods=n + 1, freq="D")
+    cin = np.zeros(n)
+    cin[2:5] = 10.0
+    flow = np.full(n, 100.0)
+    apv = np.array([300.0])
+    cout_tedges = pd.date_range("2020-01-07", periods=27, freq="D")  # starts 3 days before tedges[0]
+
+    cout_nl, _ = infiltration_to_extraction_nonlinear_sorption(
+        cin=cin, flow=flow, tedges=tedges, cout_tedges=cout_tedges, aquifer_pore_volumes=apv, retardation_factor=2.0
+    )
+    cout_lin = infiltration_to_extraction(
+        cin=cin, flow=flow, tedges=tedges, cout_tedges=cout_tedges, aquifer_pore_volumes=apv, retardation_factor=2.0
+    )
+
+    assert not np.any(np.isnan(cout_nl))  # positive flow throughout -> out-of-range reads as 0
+    # Bins wholly before the flow record (2020-01-07..10) are exactly 0.0.
+    np.testing.assert_array_equal(cout_nl[:3], np.zeros(3))
+    # Where the linear sibling is defined, the breakthrough pulse matches exactly.
+    finite = ~np.isnan(cout_lin)
+    np.testing.assert_allclose(cout_nl[finite], cout_lin[finite], atol=1e-13)
+
+
+def test_infiltration_to_extraction_negative_pore_volume_raises():
+    """A2: a negative aquifer pore volume back-projects a cout bin to future
+    infiltration (anti-causal). The linear forward path must reject it, matching
+    the nonlinear and diffusion paths, rather than returning a silent wrong value."""
+    n = 10
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    with pytest.raises(ValueError, match="aquifer_pore_volumes must be positive"):
+        infiltration_to_extraction(
+            cin=np.ones(n),
+            flow=np.full(n, 100.0),
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([-300.0]),
+        )
+
+
+def test_extraction_to_infiltration_negative_pore_volume_raises():
+    """A2: the reverse (deconvolution) path must reject a negative pore volume too."""
+    n = 10
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    with pytest.raises(ValueError, match="aquifer_pore_volumes must be positive"):
+        extraction_to_infiltration(
+            cout=np.ones(n),
+            flow=np.full(n, 100.0),
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([-300.0]),
+        )

--- a/tests/src/test_deposition.py
+++ b/tests/src/test_deposition.py
@@ -262,8 +262,16 @@ def test_forward_pins_extraction_to_infiltration_direction_genuinely_variable_fl
 
 
 def test_exact_analytical_retardation_factor():
-    """
-    Test exact analytical solution with different retardation factors.
+    """Test exact analytical solution with different retardation factors.
+
+    The steady-state extracted concentration is R-independent: the areal mass
+    balance ``Q * cout = dep * A_plan`` holds regardless of retardation
+    (retardation delays breakthrough but does not change the outlet
+    concentration once the deposition history is fully resolved). So the
+    expected value is the R-independent steady state
+    ``dep * V_pv / (porosity * thickness * Q)`` -- equivalently the water
+    (R=1) residence time ``rt[0] / retardation_factor`` times
+    ``dep / (porosity * thickness)``.
     """
     dates = pd.date_range("2020-01-01", "2020-01-12", freq="D")
     tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
@@ -305,7 +313,16 @@ def test_exact_analytical_retardation_factor():
             direction="extraction_to_infiltration",
         )
 
-        expected = (rt[0] * deposition_rate) / (params["porosity"] * params["thickness"])
+        # R-independent steady state: divide the R-scaled residence time rt[0]
+        # by R to recover the water residence time V_pv/Q, matching the
+        # closed-form dep * V_pv / (porosity * thickness * Q).
+        expected = (rt[0] / retardation_factor * deposition_rate) / (params["porosity"] * params["thickness"])
+        closed_form = (
+            deposition_rate
+            * base_params["aquifer_pore_volume"]
+            / (base_params["porosity"] * base_params["thickness"] * flow_rate)
+        )
+        np.testing.assert_allclose(expected, closed_form, rtol=1e-12, atol=0)
 
         valid_result = cout_result[~np.isnan(cout_result)]
         valid_expected = expected[: len(valid_result)]
@@ -319,6 +336,119 @@ def test_exact_analytical_retardation_factor():
             rtol=1e-12,
             atol=0,
             err_msg=f"R={retardation_factor}",
+        )
+
+
+def test_steady_state_cout_r_independent_mass_balance():
+    """Steady-state extracted concentration is R-independent (areal mass balance).
+
+    The steady-state areal mass balance ``Q * cout = dep * A_plan`` is
+    model-independent: retardation delays breakthrough but cannot change the
+    steady-state outlet concentration, because at steady state the mass entering
+    areally (``dep * A_plan``) must leave advectively (``Q * cout``) regardless
+    of how much solute is sorbed on the immobile matrix. Here
+    ``A_plan = aquifer_pore_volume / (porosity * thickness)``.
+
+    Pre-fix the forward operator divided the R-scaled contact measure only by
+    ``porosity * thickness`` (not additionally by ``R``), so ``cout`` scaled
+    exactly proportional to ``R`` (``mass_out / mass_in == R`` instead of 1).
+    This pins the corrected R-independent steady state and the exact
+    flow-weighted mass balance for R in {1, 1.5, 2, 3}.
+    """
+    n = 60
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow_rate = 100.0
+    flow = np.full(n, flow_rate)
+    deposition_rate = 50.0
+    dep = np.full(n, deposition_rate)
+    aquifer_pore_volume, porosity, thickness = 500.0, 0.25, 4.0
+    # cout bin well past the longest spin-up (R=3 -> RT = 15 days) and inside the record.
+    cout_tedges = tedges[40:42]
+
+    a_plan = aquifer_pore_volume / (porosity * thickness)
+    expected_cout = deposition_rate * a_plan / flow_rate  # R-independent steady-state outlet
+
+    cout_by_r = {}
+    for retardation_factor in (1.0, 1.5, 2.0, 3.0):
+        cout = deposition_to_extraction(
+            dep=dep,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            aquifer_pore_volume=aquifer_pore_volume,
+            porosity=porosity,
+            thickness=thickness,
+            retardation_factor=retardation_factor,
+        )
+        valid = cout[~np.isnan(cout)]
+        assert len(valid) >= 1, f"need a valid steady-state bin for R={retardation_factor}"
+        cout_by_r[retardation_factor] = valid
+        # Flow-weighted areal mass balance: Q*cout == dep*A_plan (mass_out/mass_in == 1).
+        np.testing.assert_allclose(
+            flow_rate * valid,
+            deposition_rate * a_plan,
+            rtol=1e-12,
+            atol=0,
+            err_msg=f"mass balance violated for R={retardation_factor}",
+        )
+        np.testing.assert_allclose(valid, expected_cout, rtol=1e-12, atol=0, err_msg=f"R={retardation_factor}")
+
+    # Steady-state cout identical across all R.
+    reference = cout_by_r[1.0]
+    for retardation_factor, valid in cout_by_r.items():
+        np.testing.assert_allclose(valid, reference, rtol=1e-12, atol=0, err_msg=f"R={retardation_factor} vs R=1")
+
+
+def test_forward_reverse_exact_adjoints_at_retardation():
+    """Forward and reverse are exact adjoints at R>1 on a well-posed operator.
+
+    Completeness-critic flagged a "reverse inverts a different operator than the
+    forward at R>1" from a roundtrip that degraded at R=2 but not R=1. That is a
+    false positive: the failing configuration made ``RT/dt`` land on an integer
+    (a uniform moving average with exact transfer-function zeros -- the
+    rank-deficiency the module already documents), which strikes specific R
+    values (R=2 -> RT/dt=10 here) and not others (R=1.5, 2.5, 3 all recover
+    cleanly). With a genuinely well-posed operator (non-integer ``RT/dt`` at
+    every R, overdetermined half-day cout), the deposition roundtrip is
+    machine-exact at R>1 exactly as at R=1, confirming the two directions are
+    consistent adjoints. This guards adjoint consistency across R in a
+    well-posed configuration; the R-independent steady-state magnitude of the
+    DEP1 fix itself is guarded separately by the steady-state mass-balance test.
+    """
+    dates = pd.date_range("2020-01-01", "2020-02-01", freq="D")
+    n = len(dates)
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    cout_dates = pd.date_range("2020-01-01", "2020-02-01", freq="12h")
+    cout_tedges = pd.date_range("2020-01-01", periods=len(cout_dates) + 1, freq="12h")
+
+    flow = np.full(n, 100.0)
+    t = np.arange(n, dtype=float)
+    original_deposition = 20.0 + 10.0 * np.sin(2 * np.pi * t / n)
+    # RT/dt = 3.3 * R -- non-integer at R in {1, 1.5, 2}, so no transfer-function zeros.
+    params = {"aquifer_pore_volume": 330.0, "porosity": 0.25, "thickness": 4.0}
+
+    for retardation_factor in (1.0, 1.5, 2.0):
+        concentration = deposition_to_extraction(
+            dep=original_deposition,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            retardation_factor=retardation_factor,
+            **params,
+        )
+        recovered = extraction_to_deposition(
+            cout=concentration,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            retardation_factor=retardation_factor,
+            regularization_strength=1e-13,
+            **params,
+        )
+        valid = ~np.isnan(recovered)
+        assert valid.sum() == n, f"expected full recovery coverage for R={retardation_factor}"
+        np.testing.assert_allclose(
+            recovered[valid], original_deposition[valid], rtol=0, atol=1e-6, err_msg=f"R={retardation_factor}"
         )
 
 
@@ -643,6 +773,39 @@ def test_input_validation_public_api_wires_validator():
             cout_tedges=tedges[:3],
             **params,
         )
+
+
+def _good_deposition_public_kwargs():
+    """Minimal valid keyword arguments for the public forward deposition entry point."""
+    n = 4
+    dates = pd.date_range("2020-01-01", periods=n, freq="D")
+    tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=n)
+    return {
+        "dep": np.ones(n),
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "aquifer_pore_volume": 200.0,
+        "porosity": 0.3,
+        "thickness": 5.0,
+        "retardation_factor": 1.0,
+    }
+
+
+def test_deposition_public_rejects_inf_thickness():
+    """thickness=+inf slipped past ``<= 0`` and silently returned all-zeros (the worst case); must raise."""
+    kwargs = _good_deposition_public_kwargs()
+    kwargs["thickness"] = np.inf
+    with pytest.raises(ValueError, match="Thickness must be positive"):
+        deposition_to_extraction(**kwargs)
+
+
+def test_deposition_public_rejects_nan_aquifer_pore_volume():
+    """NaN aquifer_pore_volume slipped past ``<= 0``; must raise."""
+    kwargs = _good_deposition_public_kwargs()
+    kwargs["aquifer_pore_volume"] = np.nan
+    with pytest.raises(ValueError, match="Aquifer pore volume must be positive"):
+        deposition_to_extraction(**kwargs)
 
 
 def test_rank_deficient_integer_rt_no_warning_regularized_solution():
@@ -1196,7 +1359,7 @@ def test_compute_deposition_weights_causality():
 
 
 def test_compute_deposition_weights_with_retardation():
-    """Row-sum scales with R: sum(W[i,:]) * porosity * thickness == RT_i at both R=1 and R=2.
+    """Row-sum invariant sum(W[i,:]) * R * porosity * thickness == RT_i at R=1 and R=2.
 
     Replaces the prior `not np.allclose(weights_r1, weights_r2)` diff-only
     assertion, which a wrong-but-different implementation would pass. The pore
@@ -1205,6 +1368,13 @@ def test_compute_deposition_weights_with_retardation():
     extraction_to_infiltration residence time is fully defined for every cout
     bin at both R; the row-sum invariant is then asserted on real (finite)
     values rather than vacuously on NaN.
+
+    Because the steady-state outlet concentration is R-independent (the areal
+    mass balance ``Q * cout = dep * A_plan`` does not depend on retardation),
+    each row sums to ``RT_i / (R * porosity * thickness)``, so the invariant
+    carries an explicit factor of R on the left. Multiplying the (R-scaled) RT_i
+    reference by ``1/R`` here catches a regression that drops the R division in
+    the weight numerator (which would make the row sum R times too large).
     """
     dates = pd.date_range(start="2020-01-01", periods=50, freq="D")
     tedges = pd.date_range(start="2020-01-01", periods=51, freq="D")
@@ -1237,10 +1407,12 @@ def test_compute_deposition_weights_with_retardation():
         rt_per_bin = rt[:-1]
         valid = np.isfinite(rt_per_bin) & ~np.isnan(weights).any(axis=1)
         assert valid.sum() >= 1, f"setup must produce at least one finite row for R={retardation_factor}"
-        # Row sum scales linearly with R through RT_i; under R=2 the sums are
-        # twice the R=1 sums, so this is not vacuously satisfiable.
+        # Row sum = RT_i / (R * porosity * thickness). Multiplying by
+        # R * porosity * thickness must recover the R-scaled RT_i, which is
+        # twice as large at R=2 as at R=1 -- not vacuously satisfiable, and
+        # sensitive to a dropped R division in the numerator.
         np.testing.assert_allclose(
-            weights[valid].sum(axis=1) * porosity * thickness,
+            weights[valid].sum(axis=1) * retardation_factor * porosity * thickness,
             rt_per_bin[valid],
             rtol=0,
             atol=1e-12,
@@ -1871,18 +2043,19 @@ def test_extraction_to_deposition_spinup_constant_recovers_full_window():
     ids=["constant_flow_R1", "variable_flow_R1", "constant_flow_R2"],
 )
 def test_mass_conservation_pulse_dep(flow_pattern, retardation_factor, pulse_start, pulse_end):
-    """Closed-window mass balance: Σ cout · Q · Δt = D · A_eff · pulse_width.
+    """Closed-window mass balance: Σ cout · Q · Δt = D · A_plan · pulse_width.
 
     Dep is a constant pulse over [pulse_start, pulse_end] (well past spin-up),
     zero elsewhere. The cout window matches the dep window and is long enough
-    that the entire response decays into machine-zero bins inside it. Mass
-    balance holds exactly when ``A_eff = R · V_pore / (n · b)``.
+    that the entire response decays into machine-zero bins inside it.
 
-    The 1/r_i^2-weighted-LS framing of row normalization (see Notes block in
-    ``extraction_to_deposition``) is a forward-pass model identity: any per-bin
-    contribution ``cout[i] = sum_j W[i,j] dep[j]`` summed against ``Q * dt``
-    recovers ``D * A_eff * pulse_width`` exactly. A 1.5x scaling bug in
-    ``compute_deposition_weights`` would fail this at the 50 percent relative level.
+    The injected areal mass is ``D · A_plan · pulse_width`` with plan area
+    ``A_plan = V_pore / (porosity · thickness)`` -- independent of retardation:
+    linear reversible sorption stores solute on the immobile matrix during
+    transit but every gram eventually elutes, so the closed-window extracted
+    mass equals the injected mass regardless of R. (A pre-fix bug scaled cout
+    -- and hence extracted mass -- by R; this pins the R-independent balance,
+    failing at the 50 percent relative level for R=2 on that bug.)
     """
     n = 80
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
@@ -1909,8 +2082,8 @@ def test_mass_conservation_pulse_dep(flow_pattern, retardation_factor, pulse_sta
     valid = ~np.isnan(cout)
     mass_extracted = np.sum(cout[valid] * flow[valid] * 1.0)  # Δt_cout = 1 day
 
-    a_eff = retardation_factor * params["aquifer_pore_volume"] / (params["porosity"] * params["thickness"])
-    mass_injected = deposition_rate * a_eff * (pulse_end - pulse_start)
+    a_plan = params["aquifer_pore_volume"] / (params["porosity"] * params["thickness"])
+    mass_injected = deposition_rate * a_plan * (pulse_end - pulse_start)
 
     np.testing.assert_allclose(mass_extracted, mass_injected, rtol=1e-10)
 
@@ -2038,6 +2211,47 @@ def test_spinup_duration_first_bin_zero_flow():
 
     duration = spinup_duration(flow=flow, tedges=tedges, aquifer_pore_volume=500.0, retardation_factor=1.0)
     np.testing.assert_allclose(duration, 8.0, rtol=0, atol=1e-12)
+
+
+def test_spinup_duration_default_retardation_factor():
+    """spinup_duration defaults retardation_factor to 1.0 (package standard).
+
+    Omitting ``retardation_factor`` must behave as R=1 (spin-up = V_pore / Q
+    under constant flow), matching every other public function's default and the
+    explicit R=1 call. Pins the DEP5 API default, previously a required argument.
+    """
+    n = 30
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+
+    duration = spinup_duration(flow=flow, tedges=tedges, aquifer_pore_volume=500.0)
+    np.testing.assert_allclose(duration, 5.0, rtol=0, atol=1e-12)
+
+    explicit = spinup_duration(flow=flow, tedges=tedges, aquifer_pore_volume=500.0, retardation_factor=1.0)
+    np.testing.assert_array_equal(duration, explicit)
+
+
+def test_spinup_float_raises_not_implemented():
+    """A float ``spinup`` raises NotImplementedError in every deposition entry point.
+
+    The fraction-threshold spin-up mode is not implemented for deposition
+    (matching the diffusion family). A float was previously accepted and
+    silently ignored (behaviour identical to ``None``); all three public entry
+    points now reject it explicitly via ``_validate_deposition_inputs``.
+    """
+    n = 6
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    params = {"aquifer_pore_volume": 200.0, "porosity": 0.3, "thickness": 5.0}
+
+    with pytest.raises(NotImplementedError, match="spinup"):
+        deposition_to_extraction(dep=np.ones(n), flow=flow, tedges=tedges, cout_tedges=tedges, spinup=0.5, **params)
+    with pytest.raises(NotImplementedError, match="spinup"):
+        extraction_to_deposition(cout=np.ones(n), flow=flow, tedges=tedges, cout_tedges=tedges, spinup=0.5, **params)
+    with pytest.raises(NotImplementedError, match="spinup"):
+        extraction_to_deposition_full(
+            cout=np.ones(n), flow=flow, tedges=tedges, cout_tedges=tedges, spinup=0.5, **params
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -1391,6 +1391,49 @@ class TestFlowWeightedDiffusion:
         ratios = mass_out_per_cin[10:42] / v_in_interior
         np.testing.assert_allclose(ratios, 1.0, atol=1e-10, rtol=0)
 
+    @pytest.mark.parametrize("seed", [3, 42])
+    @pytest.mark.parametrize("d_m", [1e-5, 0.01])
+    def test_column_mass_conservation_near_zero_dispersion(self, d_m, seed):
+        """Sharp-front regime: column mass conserved for near-zero dispersivity under variable flow.
+
+        Regression for the fixed-order Gauss-Legendre quadrature being unable to resolve the
+        breakthrough front when its width ``sqrt(4 * D_t)`` is far below the flow-bin volume
+        width (``alpha_L = 0``, tiny ``D_m``). The bin-averaged Kreft-Zuber flux concentration
+        must still make the flux-weighted column sum
+        ``sum_i W[i, j] * Q_out[i] * dt_out[i] == Q_in[j] * dt_in[j]`` hold. Pre-fix (fixed
+        16-point GL) the ratio drifts to ~1.13 at ``D_m = 1e-5``; the resolution-aware
+        composite quadrature restores it to 1 within 1e-9.
+        """
+        n = 90
+        tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+        cout_tedges = tedges
+
+        rng = np.random.default_rng(seed)
+        flow = rng.uniform(20.0, 200.0, n)
+        aquifer_pore_volumes = np.array([500.0])
+        streamline_length = np.array([100.0])
+
+        coeff, _ = _infiltration_to_extraction_coeff_matrix(
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=cout_tedges,
+            aquifer_pore_volumes=aquifer_pore_volumes,
+            streamline_length=streamline_length,
+            molecular_diffusivity=np.array([d_m]),
+            longitudinal_dispersivity=np.array([0.0]),
+            retardation_factor=1.0,
+        )
+
+        # Interior cin bins 10..59 fully transit the 90-day cout window (RT = V/Q in
+        # [2.5, 25] days for Q in [20, 200]), so their flux-weighted column sums must
+        # equal the infiltrated volume.
+        dt = np.diff(tedges) / pd.Timedelta("1D")
+        v_out = flow * dt
+        v_in_interior = flow[10:60] * 1.0
+        mass_out_per_cin = (v_out[:, None] * coeff).sum(axis=0)
+        ratios = mass_out_per_cin[10:60] / v_in_interior
+        np.testing.assert_allclose(ratios, 1.0, atol=1e-9, rtol=0)
+
     @pytest.mark.parametrize("seed", [1, 3, 7, 42, 999])
     @pytest.mark.parametrize(
         ("d_m", "alpha_l"),
@@ -1982,6 +2025,50 @@ def _good_diffusion_inputs():
         "longitudinal_dispersivity": np.full(n_pv, 0.0),
         "retardation_factor": 1.0,
     }
+
+
+def _good_diffusion_public_kwargs():
+    """Minimal valid keyword arguments for the public forward diffusion entry point."""
+    n = 5
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    return {
+        "cin": np.ones(n),
+        "flow": np.full(n, 100.0),
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "aquifer_pore_volumes": np.array([500.0]),
+        "streamline_length": np.array([100.0]),
+        "molecular_diffusivity": 0.01,
+        "longitudinal_dispersivity": 0.5,
+        "retardation_factor": 1.0,
+    }
+
+
+@pytest.mark.parametrize("bad", [np.inf, np.nan])
+def test_diffusion_public_rejects_non_finite_aquifer_pore_volumes(bad):
+    """+inf/NaN pore volume slipped past the ``<= 0`` guard and produced all-NaN output; must raise."""
+    kwargs = _good_diffusion_public_kwargs()
+    kwargs["aquifer_pore_volumes"] = np.array([500.0, bad])
+    kwargs["streamline_length"] = np.array([100.0, 100.0])
+    with pytest.raises(ValueError, match="aquifer_pore_volumes must be positive"):
+        infiltration_to_extraction(**kwargs)
+
+
+@pytest.mark.parametrize("bad", [np.inf, np.nan])
+def test_diffusion_public_rejects_non_finite_molecular_diffusivity(bad):
+    """+inf/NaN molecular_diffusivity slipped past the ``< 0`` guard; must raise."""
+    kwargs = _good_diffusion_public_kwargs()
+    kwargs["molecular_diffusivity"] = bad
+    with pytest.raises(ValueError, match="molecular_diffusivity must be non-negative"):
+        infiltration_to_extraction(**kwargs)
+
+
+def test_diffusion_public_rejects_nan_retardation_factor():
+    """NaN retardation slipped past ``< 1.0`` and silently produced all-NaN output; must raise."""
+    kwargs = _good_diffusion_public_kwargs()
+    kwargs["retardation_factor"] = np.nan
+    with pytest.raises(ValueError, match=r"retardation_factor must be >= 1\.0"):
+        infiltration_to_extraction(**kwargs)
 
 
 def test_validate_diffusion_inputs_silent_on_good_input_forward():

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -3,6 +3,7 @@ import warnings as warn_module
 import numpy as np
 import pandas as pd
 import pytest
+from _oracles import partial_isin  # ty: ignore[unresolved-import]  # tests/src on path via conftest
 from numpy.testing import assert_allclose
 from scipy.integrate import quad
 from scipy.special import erf, erfc
@@ -28,7 +29,7 @@ from gwtransport.diffusion_fast import (
     infiltration_to_extraction,
 )
 from gwtransport.gamma import mean_std_loc_to_alpha_beta
-from gwtransport.utils import cumulative_flow_volume, partial_isin
+from gwtransport.utils import cumulative_flow_volume
 
 # =============================================================================
 # Helper: create common test data for transport functions
@@ -2383,6 +2384,15 @@ def _good_diffusion_fast_inputs():
             lambda k: {**k, "molecular_diffusivity": -0.1},
             r"molecular_diffusivity must be non-negative",
         ),
+        # Non-finite molecular_diffusivity slips past the ``< 0`` comparison (shared validator).
+        (
+            lambda k: {**k, "molecular_diffusivity": np.inf},
+            r"molecular_diffusivity must be non-negative",
+        ),
+        (
+            lambda k: {**k, "molecular_diffusivity": np.nan},
+            r"molecular_diffusivity must be non-negative",
+        ),
         (
             lambda k: {**k, "longitudinal_dispersivity": -0.1},
             r"longitudinal_dispersivity must be non-negative",
@@ -2403,6 +2413,15 @@ def _good_diffusion_fast_inputs():
             lambda k: {**k, "aquifer_pore_volumes": np.array([0.0])},
             r"aquifer_pore_volumes must be positive",
         ),
+        # Non-finite aquifer_pore_volumes slips past the ``<= 0`` comparison (shared validator).
+        (
+            lambda k: {**k, "aquifer_pore_volumes": np.array([np.inf])},
+            r"aquifer_pore_volumes must be positive",
+        ),
+        (
+            lambda k: {**k, "aquifer_pore_volumes": np.array([np.nan])},
+            r"aquifer_pore_volumes must be positive",
+        ),
         (
             lambda k: {**k, "streamline_length": 0.0},
             r"streamline_length must be positive",
@@ -2421,6 +2440,11 @@ def _good_diffusion_fast_inputs():
         ),
         (
             lambda k: {**k, "retardation_factor": 0.5},
+            r"retardation_factor must be >= 1\.0",
+        ),
+        # NaN retardation slips past the ``< 1.0`` comparison (shared validator).
+        (
+            lambda k: {**k, "retardation_factor": np.nan},
             r"retardation_factor must be >= 1\.0",
         ),
     ],

--- a/tests/src/test_diffusion_fast_fast.py
+++ b/tests/src/test_diffusion_fast_fast.py
@@ -490,6 +490,36 @@ def test_zero_diffusion_matches_advection():
     assert _peak_rel(cout_ff, cout_adv) < 1e-12
 
 
+def test_forward_zero_flow_gap_no_smear_into_neighbours():
+    """A pump-off gap (zero through-flow) puts a hard 0 in cout_micro at the gap bins; the molecular
+    time-Gaussian must NOT smear those zeros into the valid neighbours. With a constant input the
+    mask-aware convolution G(cout_micro*m)/G(m) preserves the constant EXACTLY across the gap (every
+    valid bin == cin) while the gap-interior bins stay NaN. A plain gaussian_filter1d of the hard
+    zeros instead drops the immediate neighbours ~12% below the constant (baseline: 6.39 vs 7.3).
+    sigma_bins ~0.5 here, so the molecular Gaussian is genuinely active and the mask is load-bearing.
+    """
+    n = 120
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    flow[40:44] = 0.0  # 4-bin pump-off gap
+    kw = {
+        "cin": np.full(n, 7.3),
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges.copy(),
+        "aquifer_pore_volumes": gamma.bins(mean=500.0, std=200.0, n_bins=25)["expected_values"],
+        "streamline_length": 10.0,
+        "molecular_diffusivity": 0.1,
+        "longitudinal_dispersivity": 0.5,
+    }
+    cout_ff = infiltration_to_extraction(**kw)
+    cout_df = df_i2e(**kw)
+    assert np.array_equal(np.isnan(cout_ff), np.isnan(cout_df))  # gap-interior bins NaN in both
+    valid = ~np.isnan(cout_ff)
+    assert valid.sum() > 100
+    assert_allclose(cout_ff[valid], 7.3, atol=1e-12, rtol=0)  # constant preserved across the gap
+
+
 # =============================================================================
 # Mass conservation: tight at constant flow; characterised (NOT conserved) at variable flow.
 # =============================================================================
@@ -836,6 +866,31 @@ def test_reverse_zero_cout_gives_zero_cin():
         longitudinal_dispersivity=1.0,
     )
     assert_allclose(cin[~np.isnan(cin)], 0.0, atol=1e-12)
+
+
+def test_reverse_zero_flow_gap_preserves_constant():
+    """Reverse analogue of test_forward_zero_flow_gap_no_smear_into_neighbours: a constant extraction
+    with a pump-off gap must deconvolve to a constant infiltration on the valid bins, without the
+    gap's zero G@M rows corrupting the neighbours. The banded solver row-normalizes W (that IS the
+    mask-aware normalization for the reverse: it divides each row by G@(row masses), so the gap rows'
+    zero mass drops out), so constants are preserved to solver precision across the gap."""
+    n = 120
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    flow[40:44] = 0.0  # 4-bin pump-off gap
+    cin = extraction_to_infiltration(
+        cout=np.full(n, 7.3),
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges.copy(),
+        aquifer_pore_volumes=gamma.bins(mean=500.0, std=200.0, n_bins=25)["expected_values"],
+        streamline_length=10.0,
+        molecular_diffusivity=0.1,
+        longitudinal_dispersivity=0.5,
+    )
+    valid = ~np.isnan(cin)
+    assert valid.sum() > 100
+    assert_allclose(cin[valid], 7.3, atol=1e-9, rtol=0)  # measured ~3.5e-13 on the row-normalized W
 
 
 def test_reverse_forwards_retardation_and_flow_out():

--- a/tests/src/test_examples.py
+++ b/tests/src/test_examples.py
@@ -173,3 +173,69 @@ def test_vectorized_event_accumulation_matches_loop(seed, event_duration):
     )
 
     np.testing.assert_array_equal(actual_series.to_numpy(), expected)
+
+
+def test_deposition_seasonal_is_annual_for_nondaily_freq():
+    """The deposition seasonal must have a one-year period for any ``freq``, not one year of samples.
+
+    Isolates the seasonal component (base/noise/events zeroed) at weekly resolution and compares
+    against the closed form ``seasonal_amplitude * sin(2*pi*elapsed_days/365.25)``. Before the fix the
+    code used the sample index, so one year after the start the seasonal was ~0.78 instead of ~0.
+    """
+    date_start, date_end, freq = "2018-01-01", "2019-12-31", "W"
+    seasonal_amplitude = 1.0
+
+    series, _ = generate_example_deposition_timeseries(
+        date_start=date_start,
+        date_end=date_end,
+        freq=freq,
+        base=0.0,
+        seasonal_amplitude=seasonal_amplitude,
+        noise_scale=0.0,
+        event_dates=[],
+        ensure_non_negative=False,
+        rng=0,
+    )
+
+    dates = pd.date_range(date_start, date_end, freq=freq).tz_localize("UTC")
+    elapsed_days = (dates - dates[0]) / pd.Timedelta(days=1)
+    expected = seasonal_amplitude * np.sin(2 * np.pi * np.asarray(elapsed_days) / 365.25)
+
+    np.testing.assert_allclose(series.to_numpy(), expected)
+
+    # One year after the start the annual seasonal must return to ~0 (the sample-index bug gave ~0.78).
+    one_year = int(np.argmin(np.abs(np.asarray(elapsed_days) - 365.25)))
+    assert abs(series.to_numpy()[one_year]) < 0.03
+
+
+def test_flow_seasonal_varies_within_day_for_subdaily_freq():
+    """Sub-daily flow must resolve the seasonal within a calendar day, not stair-step per integer day.
+
+    With ``flow_noise=0`` and a short (spill-free) window the flow column equals the noiseless
+    seasonal floored at 5 m3/day. Before the fix the integer day count held the seasonal constant
+    across the four 6-hourly samples of each day; the closed form below distinguishes the two.
+    """
+    date_start, date_end, date_freq = "2020-01-01", "2020-01-05", "6h"
+    flow_mean, flow_amplitude = 100.0, 30.0
+
+    df, _ = generate_example_data(
+        date_start=date_start,
+        date_end=date_end,
+        date_freq=date_freq,
+        flow_mean=flow_mean,
+        flow_amplitude=flow_amplitude,
+        flow_noise=0.0,
+        measurement_noise=0.0,
+        rng=0,
+    )
+
+    dates = pd.date_range(date_start, date_end, freq=date_freq).tz_localize("UTC")
+    frac_days = (dates - dates[0]) / pd.Timedelta(days=1)
+    expected_flow = np.maximum(
+        flow_mean + flow_amplitude * np.sin(2 * np.pi * np.asarray(frac_days) / 365 + np.pi), 5.0
+    )
+
+    np.testing.assert_allclose(df["flow"].to_numpy(), expected_flow)
+
+    # The four 6-hourly samples of the first day must differ (the bug made them identical).
+    assert np.unique(df["flow"].to_numpy()[:4]).size == 4

--- a/tests/src/test_front_tracking_api.py
+++ b/tests/src/test_front_tracking_api.py
@@ -8,6 +8,7 @@ import pytest
 
 from gwtransport.advection import infiltration_to_extraction_nonlinear_sorption
 from gwtransport.fronttracking.math import FreundlichSorption, LangmuirSorption, compute_first_front_arrival_theta
+from gwtransport.fronttracking.solver import FrontTracker, find_unresolved_interaction
 from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
 from gwtransport.utils import compute_time_edges
 
@@ -636,3 +637,227 @@ class TestFrontTrackingAPI:
                 langmuir_k_l=5.0,
                 # missing bulk_density and porosity
             )
+
+
+class TestMultiPeakInteractionRefused:
+    """End-to-end: a multi-peak cin whose fans overlap is refused, not silently mis-answered.
+
+    A later pulse's front sweeps into the first pulse's decaying-shock fan — an unresolved wave
+    interaction the front tracker does not compose. The single-owner reader then either drops the
+    earlier pulse's near-inlet mass (leaking a spurious inlet→outlet echo in the conservation-form
+    ``cout``) or over-counts it; neither is the true field. Rather than return that mass-losing
+    output, the public API refuses the input with ``NotImplementedError`` (an output-side mitigation
+    was tried and reverted because it fixed neither the physics nor a percolation regression). Exact
+    multi-front interaction is deferred to a solver-level follow-up.
+    """
+
+    def test_multipeak_raises_not_implemented(self):
+        """Overlapping-fan multi-peak input raises ``NotImplementedError`` at the public boundary."""
+        cin = np.array([0.0, 10.0, 10.0, 0.0, 0.0, 0.0, 5.0, 5.0, 0.0])
+        flow = np.full(len(cin), 100.0)
+        tedges = pd.date_range("2020-01-01", periods=len(cin) + 1, freq="D")
+        cout_tedges = pd.date_range("2020-01-01", periods=len(cin) + 1, freq="D")
+
+        with pytest.raises(NotImplementedError, match="interacting fronts"):
+            infiltration_to_extraction_nonlinear_sorption(
+                cin=cin,
+                flow=flow,
+                tedges=tedges,
+                cout_tedges=cout_tedges,
+                aquifer_pore_volumes=np.array([40.0]),
+                freundlich_k=0.05,
+                freundlich_n=2.0,
+                bulk_density=1600.0,
+                porosity=0.35,
+            )
+
+
+def _fv_outlet_cout_freundlich_n2(cin, flow, v_pv, k_f, bulk_density, porosity, *, n_cells=2500, cfl=0.4):
+    """Independent first-order upwind (Godunov) outlet oracle for Freundlich ``n = 2``.
+
+    Marches the conserved variable ``U = C_T(c) = c + A·√c`` (``A = (ρ_b/φ)·k_f``) on a uniform
+    ``V``-grid in cumulative flow θ, upwind flux ``F = c`` (all characteristic speeds ``dF/dU = 1/R``
+    are in ``(0, 1]``, so upwind == Godunov and is entropy-correct for this convex flux). Returns the
+    flow-weighted bin-averaged outlet concentration on the daily grid the public API uses, so the two
+    are compared apples-to-apples over the same truncated window. Memory-safe: only the current cell
+    profile plus scalar accumulators are stored.
+
+    Parameters
+    ----------
+    cin : ndarray
+        Inlet concentration per daily bin.
+    flow : float
+        Constant flow rate ``Q`` [m³/day].
+    v_pv : float
+        Outlet pore volume [m³].
+    k_f, bulk_density, porosity : float
+        Freundlich ``k_f`` and the ``ρ_b``, ``φ`` used to form ``A``.
+    n_cells, cfl : int, float
+        FV grid resolution and CFL number.
+
+    Returns
+    -------
+    ndarray
+        Daily bin-averaged outlet concentration, length ``len(cin)``.
+    """
+    a = (bulk_density / porosity) * k_f
+    q = float(flow)
+    cin = np.asarray(cin, dtype=float)
+    nb = len(cin)
+    theta_in_edges = q * np.arange(nb + 1)
+    theta_out_edges = q * np.arange(nb + 1)
+    dv = v_pv / n_cells
+    cmax = max(cin.max(), 1e-12)
+    r_min = 1.0 + a / (2.0 * np.sqrt(cmax))  # min retardation at cmax → max characteristic speed 1/r_min
+    dtheta = cfl * dv * r_min
+
+    def c_from_u(u):
+        u = np.maximum(u, 0.0)
+        x = (-a + np.sqrt(a * a + 4.0 * u)) / 2.0  # √c from x² + A x − U = 0
+        return x * x
+
+    c = np.zeros(n_cells)
+    u = c + a * np.sqrt(c)
+    theta = 0.0
+    cum_out = 0.0
+    out_edge_mass = np.zeros(len(theta_out_edges))
+    next_edge = 0
+    lam = dtheta / dv
+    theta_max = theta_out_edges[-1]
+    while theta < theta_max - 1e-12:
+        while next_edge < len(theta_out_edges) and theta_out_edges[next_edge] <= theta + 1e-12:
+            out_edge_mass[next_edge] = cum_out
+            next_edge += 1
+        if next_edge >= len(theta_out_edges):
+            break
+        cin_now = cin[min(int(theta // q), nb - 1)] if theta < theta_in_edges[-1] else cin[-1]
+        c_left = np.empty(n_cells)
+        c_left[0] = cin_now
+        c_left[1:] = c[:-1]
+        u -= lam * (c - c_left)
+        c = c_from_u(u)
+        cum_out += c[-1] * dtheta
+        theta += dtheta
+    while next_edge < len(theta_out_edges):
+        out_edge_mass[next_edge] = cum_out
+        next_edge += 1
+    return np.diff(out_edge_mass) / np.diff(theta_out_edges)
+
+
+class TestUnresolvedMultiFrontInteractionRaises:
+    """The public API refuses inputs whose fronts interact unresolved, and runs non-interacting ones.
+
+    The front tracker resolves shock↔shock / shock↔rarefaction collisions (the latter into a
+    ``DecayingShockWave``) but never composes a later front overtaking an existing decaying-shock fan
+    (nor two fans overlapping). Such an unresolved interaction makes the public ``cout`` a linear
+    superposition of a nonlinear operator — mass-losing and silently wrong — so
+    :func:`~gwtransport.advection.infiltration_to_extraction_nonlinear_sorption` raises
+    ``NotImplementedError`` (via
+    :func:`gwtransport.fronttracking.solver.find_unresolved_interaction`) rather than returning it.
+    A single front, or well-separated pulses that break through before overtaking one another, run
+    and match an independent Godunov FV oracle. Acceptance params: Freundlich ``n=2``, ``k_f=0.01``,
+    ``ρ_b=1500``, ``φ=0.3``, ``flow=100``.
+    """
+
+    K_F, N, RHO_B, POR, FLOW = 0.01, 2.0, 1500.0, 0.3, 100.0
+
+    def _run(self, pulse, v_pv, *, n_trail):
+        cin = np.array(list(pulse) + [0.0] * n_trail, dtype=float)
+        nb = len(cin)
+        tedges = pd.date_range("2020-01-01", periods=nb + 1, freq="D")
+        return infiltration_to_extraction_nonlinear_sorption(
+            cin=cin,
+            flow=np.full(nb, self.FLOW),
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([v_pv]),
+            freundlich_k=self.K_F,
+            freundlich_n=self.N,
+            bulk_density=self.RHO_B,
+            porosity=self.POR,
+        )
+
+    @pytest.mark.parametrize(
+        ("pulse", "v_pv", "n_trail"),
+        [
+            # Geometric fan-overlap class (two fans share an in-domain point):
+            ([0, 10, 10, 0, 0, 0, 5, 5, 0], 40.0, 111),  # multi-peak: pulse 2 sweeps pulse 1's decayed tail
+            ([0, 5, 10, 10, 5, 0], 40.0, 74),  # plateau: internal c=10 shock catches the 0→5 shock before outlet
+            ([0, 10, 10, 2, 2, 2, 5, 5, 0], 40.0, 111),  # nonzero-dip: a fan overtakes an earlier decaying fan
+            # Conservation-symptom class (pulse-2 shock overtakes pulse-1's decaying-shock fan; the
+            # two fans only cross BEYOND v_outlet, so the geometric scan cannot see it — the
+            # cumulative-outlet-mass monotonicity check refuses the fabricated mass instead). These
+            # are the seasonal/oscillating two-pulse signals a prior guard silently mis-answered.
+            ([0, 10, 10, 0, 10, 10, 0], 40.0, 53),  # 2-pulse equal
+            ([0, 5, 5, 0, 10, 10, 0], 40.0, 53),  # 2-pulse rising
+            ([0, 10, 10, 0, 5, 5, 0], 40.0, 53),  # 2-pulse falling
+        ],
+    )
+    def test_interacting_multifront_raises(self, pulse, v_pv, n_trail):
+        """An in-domain unresolved wave interaction raises ``NotImplementedError``."""
+        with pytest.raises(NotImplementedError, match="interacting fronts"):
+            self._run(pulse, v_pv, n_trail=n_trail)
+
+    def test_conservation_symptom_flags_fans_crossing_beyond_outlet(self):
+        """The two-pulse refusal is driven by the mass-monotonicity net, not the geometric scan.
+
+        For ``cin=[0,10,10,0,10,10,0]`` at ``V=40`` pulse-2's shock overtakes pulse-1's
+        decaying-shock fan, but the two fans only cross at ``V≈97 ≫ v_outlet``: no in-domain point
+        is ever covered by two fans, so the geometric fan-overlap scan returns clean. Cumulative
+        outlet mass nonetheless drops (the reader over-counts stored mass), which the monotonicity
+        detector reports. This pins that the added net — not the pre-existing geometric scan — is
+        what catches this dominant multi-pulse class.
+        """
+        cin = np.array([0, 10, 10, 0, 10, 10, 0] + [0.0] * 53, dtype=float)
+        nb = len(cin)
+        tedges = pd.date_range("2020-01-01", periods=nb + 1, freq="D")
+        sorption = FreundlichSorption(k_f=self.K_F, n=self.N, bulk_density=self.RHO_B, porosity=self.POR)
+        tracker = FrontTracker(
+            cin=cin, flow=np.full(nb, self.FLOW), tedges=tedges, aquifer_pore_volume=40.0, sorption=sorption
+        )
+        tracker.run()
+        reason = find_unresolved_interaction(tracker.state)
+        assert reason is not None, "interacting two-pulse input was not flagged"
+        assert "cumulative outlet mass" in reason, f"expected mass-monotonicity attribution, got: {reason}"
+
+    def test_plateau_below_interaction_volume_runs_and_matches_fv(self):
+        """The SAME plateau input at a shorter column (V=30) exits before interacting — runs, matches FV.
+
+        The c=10 shock would overtake the 0→5 shock near V≈31.6, past a V=30 outlet, so every front
+        crosses the outlet before any unresolved collision: the detector must NOT fire (no false
+        positive), and the outlet mass tracks the independent FV oracle to well within 1%.
+        """
+        pulse, v_pv, n_trail = [0, 5, 10, 10, 5, 0], 30.0, 74
+        cout, _ = self._run(pulse, v_pv, n_trail=n_trail)
+        cin = np.array(pulse + [0.0] * n_trail, dtype=float)
+        cout_fv = _fv_outlet_cout_freundlich_n2(cin, self.FLOW, v_pv, self.K_F, self.RHO_B, self.POR)
+        m_pub = float(np.nansum(cout))
+        m_fv = float(np.nansum(cout_fv))
+        assert abs(m_pub - m_fv) < 0.01 * m_fv, f"plateau V30 outlet mass {m_pub:.3f} vs FV {m_fv:.3f}"
+
+    @pytest.mark.parametrize("v_pv", [20.0, 30.0, 40.0])
+    def test_single_pulse_runs_and_matches_fv(self, v_pv):
+        """A single returning-to-zero pulse is a single front (one DSW) — runs and matches FV to <1%."""
+        pulse, n_trail = [0, 10, 10, 0], 40
+        cout, _ = self._run(pulse, v_pv, n_trail=n_trail)
+        cin = np.array(pulse + [0.0] * n_trail, dtype=float)
+        cout_fv = _fv_outlet_cout_freundlich_n2(cin, self.FLOW, v_pv, self.K_F, self.RHO_B, self.POR)
+        m_pub = float(np.nansum(cout))
+        m_fv = float(np.nansum(cout_fv))
+        assert abs(m_pub - m_fv) < 0.01 * m_fv, f"single pulse V{v_pv} outlet mass {m_pub:.3f} vs FV {m_fv:.3f}"
+
+    def test_monotone_staircase_runs_and_matches_fv(self):
+        """A rising multi-step input (single rarefaction, no interaction) must NOT trip the net.
+
+        ``cin=[0,3,6,9,12,0]`` climbs monotonically, forming one spreading rarefaction plus the
+        trailing shock — no shock overtakes another fan, cumulative outlet mass stays monotone.
+        Guards the conservation-symptom detector against false-firing on legitimate multi-structure
+        (non-single-pulse) inputs; outlet mass tracks the FV oracle to well within 1%.
+        """
+        pulse, v_pv, n_trail = [0, 3, 6, 9, 12, 0], 40.0, 74
+        cout, _ = self._run(pulse, v_pv, n_trail=n_trail)
+        cin = np.array(pulse + [0.0] * n_trail, dtype=float)
+        cout_fv = _fv_outlet_cout_freundlich_n2(cin, self.FLOW, v_pv, self.K_F, self.RHO_B, self.POR)
+        m_pub = float(np.nansum(cout))
+        m_fv = float(np.nansum(cout_fv))
+        assert abs(m_pub - m_fv) < 0.01 * m_fv, f"staircase V{v_pv} outlet mass {m_pub:.3f} vs FV {m_fv:.3f}"

--- a/tests/src/test_front_tracking_handlers.py
+++ b/tests/src/test_front_tracking_handlers.py
@@ -283,9 +283,7 @@ class TestInletWaveCreation:
         # For n>1: higher C → higher R → slower velocity
         # So C: 0→10 means slow→slower velocity, but initial C=0 has R=1 (fastest)
         # Actually C: 0→10 means fast→slow, which is expansion (rarefaction)
-        waves = create_inlet_waves_at_theta(
-            c_prev=0.0, c_new=10.0, theta=10.0, sorption=freundlich_sorption, v_inlet=0.0
-        )
+        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=10.0, theta=10.0, sorption=freundlich_sorption)
 
         # For n=2 (n>1), C: 0→10 is rarefaction
         assert len(waves) == 1
@@ -296,9 +294,7 @@ class TestInletWaveCreation:
         # vel(10) = 100/R(10), vel(2) = 100/R(2)
         # Since R(10) > R(2), vel(10) < vel(2)
         # vel_new > vel_prev → expansion → rarefaction
-        waves = create_inlet_waves_at_theta(
-            c_prev=10.0, c_new=2.0, theta=10.0, sorption=freundlich_sorption, v_inlet=0.0
-        )
+        waves = create_inlet_waves_at_theta(c_prev=10.0, c_new=2.0, theta=10.0, sorption=freundlich_sorption)
 
         # MUST create exactly one rarefaction
         assert len(waves) == 1, "Expected exactly one wave"
@@ -309,9 +305,7 @@ class TestInletWaveCreation:
         # For n>1: C: 2→10
         # vel(2) > vel(10) → new water is slower
         # vel_new < vel_prev → compression → shock
-        waves = create_inlet_waves_at_theta(
-            c_prev=2.0, c_new=10.0, theta=10.0, sorption=freundlich_sorption, v_inlet=0.0
-        )
+        waves = create_inlet_waves_at_theta(c_prev=2.0, c_new=10.0, theta=10.0, sorption=freundlich_sorption)
 
         # MUST create exactly one shock with proper entropy
         assert len(waves) == 1, "Expected exactly one wave"
@@ -320,9 +314,7 @@ class TestInletWaveCreation:
 
     def test_no_change_creates_nothing(self, freundlich_sorption):
         """Test that no concentration change creates no waves."""
-        waves = create_inlet_waves_at_theta(
-            c_prev=5.0, c_new=5.0, theta=10.0, sorption=freundlich_sorption, v_inlet=0.0
-        )
+        waves = create_inlet_waves_at_theta(c_prev=5.0, c_new=5.0, theta=10.0, sorption=freundlich_sorption)
 
         assert len(waves) == 0
 
@@ -330,9 +322,7 @@ class TestInletWaveCreation:
         """Test that created shocks satisfy entropy condition."""
         # Create a scenario that definitely produces a shock
         # For n>1: C: 2→10 means fast→slow, compression→shock
-        waves = create_inlet_waves_at_theta(
-            c_prev=2.0, c_new=10.0, theta=10.0, sorption=freundlich_sorption, v_inlet=0.0
-        )
+        waves = create_inlet_waves_at_theta(c_prev=2.0, c_new=10.0, theta=10.0, sorption=freundlich_sorption)
 
         # This MUST create shock (C: 2→10, fast→slow, compression)
         assert len(waves) == 1, "Expected exactly one wave"
@@ -343,9 +333,7 @@ class TestInletWaveCreation:
         """Test wave creation with constant retardation."""
         # With constant retardation, all concentrations have same velocity
         # So any change is a contact discontinuity (characteristic)
-        waves = create_inlet_waves_at_theta(
-            c_prev=5.0, c_new=10.0, theta=10.0, sorption=constant_retardation, v_inlet=0.0
-        )
+        waves = create_inlet_waves_at_theta(c_prev=5.0, c_new=10.0, theta=10.0, sorption=constant_retardation)
 
         # With constant R, all velocities are same, so contact discontinuity
         assert len(waves) == 1
@@ -353,9 +341,7 @@ class TestInletWaveCreation:
 
     def test_wave_properties_correct(self, freundlich_sorption):
         """Test that created waves have correct properties."""
-        waves = create_inlet_waves_at_theta(
-            c_prev=2.0, c_new=10.0, theta=15.0, sorption=freundlich_sorption, v_inlet=0.0
-        )
+        waves = create_inlet_waves_at_theta(c_prev=2.0, c_new=10.0, theta=15.0, sorption=freundlich_sorption)
 
         assert len(waves) == 1
         wave = waves[0]
@@ -987,7 +973,7 @@ class TestInletWavesNLT1Physics:
         When concentration steps from 0 to positive, we create a characteristic
         with the new concentration that propagates at v(C>0).
         """
-        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=5.0, theta=10.0, sorption=freundlich_n_lt_1, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=5.0, theta=10.0, sorption=freundlich_n_lt_1)
 
         assert len(waves) == 1, "Expected one wave"
         assert isinstance(waves[0], CharacteristicWave), "Should create characteristic for C=0 to C>0 with n<1"
@@ -999,7 +985,7 @@ class TestInletWavesNLT1Physics:
         Physics: When clean water (C=0) enters behind contaminated water (C>0),
         we create a characteristic with C=0 that propagates at v(0) = flow/1.
         """
-        waves = create_inlet_waves_at_theta(c_prev=5.0, c_new=0.0, theta=10.0, sorption=freundlich_n_lt_1, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=5.0, c_new=0.0, theta=10.0, sorption=freundlich_n_lt_1)
 
         assert len(waves) == 1, "Expected one wave"
         assert isinstance(waves[0], CharacteristicWave), "Should create characteristic for C>0 to C=0 with n<1"
@@ -1013,9 +999,7 @@ class TestInletWavesNLT1Physics:
         - C: 10→5 means slow→fast = compression = shock
         """
         # Step up: 5→10 (fast to slow for n<1) = expansion
-        waves_up = create_inlet_waves_at_theta(
-            c_prev=5.0, c_new=10.0, theta=10.0, sorption=freundlich_n_lt_1, v_inlet=0.0
-        )
+        waves_up = create_inlet_waves_at_theta(c_prev=5.0, c_new=10.0, theta=10.0, sorption=freundlich_n_lt_1)
 
         # Verify velocities
         vel_5 = characteristic_speed(5.0, freundlich_n_lt_1)
@@ -1028,9 +1012,7 @@ class TestInletWavesNLT1Physics:
             assert isinstance(waves_up[0], RarefactionWave), "Expected rarefaction for fast→slow step"
 
         # Step down: 10→5 (slow to fast for n<1) = compression
-        waves_down = create_inlet_waves_at_theta(
-            c_prev=10.0, c_new=5.0, theta=10.0, sorption=freundlich_n_lt_1, v_inlet=0.0
-        )
+        waves_down = create_inlet_waves_at_theta(c_prev=10.0, c_new=5.0, theta=10.0, sorption=freundlich_n_lt_1)
 
         # Step down should create shock (new water faster than old)
         if len(waves_down) == 1:
@@ -1298,7 +1280,6 @@ class TestInletWaveCreationEdgeCases:
             c_new=1.0,  # Low C - slow for n>1
             theta=10.0,
             sorption=freundlich_sorption,
-            v_inlet=0.0,
         )
 
         # This is an expansion (fast old water, slow new water) → rarefaction
@@ -1314,7 +1295,7 @@ class TestInletWaveCreationEdgeCases:
         # With constant retardation, all velocities are the same
         const_r = ConstantRetardation(retardation_factor=2.0)
 
-        waves = create_inlet_waves_at_theta(c_prev=5.0, c_new=10.0, theta=10.0, sorption=const_r, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=5.0, c_new=10.0, theta=10.0, sorption=const_r)
 
         # With constant R, velocities are same → characteristic
         assert len(waves) == 1

--- a/tests/src/test_front_tracking_math.py
+++ b/tests/src/test_front_tracking_math.py
@@ -104,6 +104,26 @@ class TestFreundlichSorption:
         sorption_fav = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3, c_min=1e-12)
         assert sorption_fav.retardation(0.0) > 1.0
 
+    def test_retardation_single_path_no_invalid_power_warning_on_negative_c(self):
+        """Non-positive ``c`` (n<1, c_min=0) clamps to zero -> R=1 with no fractional-power warning.
+
+        Regression for the collapse to a single ``np.maximum``-clamped path: the earlier
+        ``np.where`` special branch eagerly evaluated ``c**(1/n - 1)`` on the raw (negative)
+        array, raising ``(-c)`` to a fractional power and emitting a spurious
+        ``invalid value encountered in power`` RuntimeWarning before discarding the result.
+        Here ``1/n - 1 = 0.4285...`` is non-integer, so the raw-power path would warn.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=0.7, bulk_density=1500.0, porosity=0.3, c_min=0.0)
+        c = np.array([-5.0, -1e-9, 0.0, 2.0])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any RuntimeWarning becomes a failure
+            r = sorption.retardation(c)
+        # All non-positive concentrations clamp to R = 1 exactly; the positive one matches the isotherm.
+        exponent = 1.0 / 0.7 - 1.0
+        coefficient = (1500.0 / 0.3) * 0.01 / 0.7
+        expected = np.array([1.0, 1.0, 1.0, 1.0 + coefficient * 2.0**exponent])
+        np.testing.assert_array_equal(r, expected)
+
     def test_retardation_positive_concentration_n_greater_1(self):
         """Test R(C) > 1 for C > 0 when n > 1."""
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
@@ -735,7 +755,7 @@ _STARINGREEKS_VG = [
 
 @pytest.mark.parametrize(("theta_r", "theta_s", "k_s", "lam"), _STARINGREEKS_BC)
 class TestBrooksCoreyConductivity:
-    """Brooks-Corey closed-form unsaturated-conductivity sorption (BC = Mualem variant)."""
+    """Brooks-Corey closed-form unsaturated-conductivity sorption (BC = Burdine variant, a = 3 + 2/λ)."""
 
     def test_constructor_derives_a_and_delta_theta(self, theta_r, theta_s, k_s, lam):
         """``a = 3 + 2/λ`` and ``Δθ = θ_s − θ_r`` set in ``__post_init__``."""

--- a/tests/src/test_front_tracking_output.py
+++ b/tests/src/test_front_tracking_output.py
@@ -20,6 +20,7 @@ from gwtransport.fronttracking.output import (
     compute_cumulative_inlet_mass,
     compute_cumulative_outlet_mass,
     compute_domain_mass,
+    compute_total_outlet_mass,
     concentration_at_point,
     identify_outlet_segments,
     integrate_rarefaction_exact,
@@ -815,3 +816,182 @@ class TestDecayingShockWaveDomainMassConservation:
             compute_domain_mass(theta=float(t), v_outlet=v_outlet, waves=waves, sorption=sorption) for t in thetas
         ])
         np.testing.assert_allclose(m_dom, m_in, rtol=1e-12)
+
+
+def _godunov_fv_domain_mass(cin, theta_edges, v_outlet, sorption, theta_query, n_cells=1500):
+    """Independent upwind (Godunov) FV oracle for the n=2 Freundlich domain mass in [0, v_outlet].
+
+    Marches C_total in (V, θ) with an upwind flux, inverting the closed-form n=2 total→dissolved
+    map each step. Stores only the current column (never the space-time history), so it stays well
+    under memory limits. Returns (domain_mass, c_outlet) at ``theta_query``.
+    """
+    a = sorption.bulk_density * sorption.k_f / sorption.porosity  # C_total = c + a*sqrt(c) (n=2)
+
+    def c_from_ct(u):
+        # Invert C_total = c + a*sqrt(c): x = sqrt(c) solves x² + a·x − C_total = 0.
+        u = np.maximum(u, 0.0)
+        x = 0.5 * (-a + np.sqrt(a * a + 4.0 * u))
+        return x * x
+
+    te = np.asarray(theta_edges, dtype=float)
+    cin = np.asarray(cin, dtype=float)
+    dv = v_outlet * 1.25 / n_cells
+    dtheta = 0.4 * dv
+    out_idx = int(v_outlet / dv)
+    c = np.zeros(n_cells)
+    ct = sorption.total_concentration(c)
+    theta = 0.0
+    while theta < theta_query:
+        k = min(max(int(np.searchsorted(te, theta, side="right")) - 1, 0), len(cin) - 1)
+        c_in = cin[k] if theta < te[-1] else 0.0
+        c_left = np.empty(n_cells)
+        c_left[0] = c_in
+        c_left[1:] = c[:-1]
+        ct -= (dtheta / dv) * (c - c_left)
+        c = c_from_ct(ct)
+        theta += dtheta
+    return float(np.sum(ct[:out_idx]) * dv), float(c[out_idx])
+
+
+class TestSinglePulseDomainMass:
+    """``compute_domain_mass`` matches an independent Godunov FV oracle on a single pulse.
+
+    A single pulse produces exactly one fan-bearing wave, so the single-owner
+    ``compute_domain_mass`` reader is exact (up to Riemann discretisation) and equals the FV
+    resident mass. Multi-pulse / oscillating inputs form OVERLAPPING non-interacting fans that
+    the reader cannot compose exactly; that unresolved interaction is now refused at the public
+    boundary (:func:`gwtransport.advection.infiltration_to_extraction_nonlinear_sorption` raises
+    ``NotImplementedError`` via :func:`gwtransport.fronttracking.solver.find_unresolved_interaction`),
+    and its exact resolution is deferred to a solver-level follow-up — so the former multi-peak /
+    fan-truncation / oscillating conservation cases (which pinned a since-reverted output-side
+    mitigation) are covered by the raise, not by an internal-``compute_domain_mass`` assertion.
+    """
+
+    def test_fv_oracle_matches_single_pulse(self):
+        """The Godunov FV oracle agrees with ``compute_domain_mass`` on a single pulse (~0.5%)."""
+        cin = np.array([0.0, 10.0, 10.0, 0.0, 0.0, 0.0])
+        v_outlet = 40.0
+        sorption = FreundlichSorption(k_f=0.05, n=2.0, bulk_density=1600.0, porosity=0.35)
+        tedges = pd.date_range("2020-01-01", periods=len(cin) + 1, freq="D")
+        tr = FrontTracker(
+            cin=cin, flow=np.full(len(cin), 100.0), tedges=tedges, aquifer_pore_volume=v_outlet, sorption=sorption
+        )
+        tr.run()
+        theta_q = 500.0  # before breakthrough: all injected mass resident
+        m_dom = compute_domain_mass(theta=theta_q, v_outlet=v_outlet, waves=tr.state.waves, sorption=sorption)
+        fv_dom, fv_cout = _godunov_fv_domain_mass(cin, tr.state.theta_edges, v_outlet, sorption, theta_q)
+        assert fv_cout < 1e-6  # single pulse has not broken through — resident mass only
+        assert abs(m_dom - fv_dom) < 0.01 * fv_dom
+
+
+class TestConservationFormClampScale:
+    """Regression: the FP-noise clamp/warning scales with the m_in−m_dom cancellation (review O2).
+
+    The old band ``1e-12·max(cout)`` keyed off the OUTPUT concentration, which collapses to ~0
+    before breakthrough — far too tight, so ~1e-11 cancellation dust on a fully in-range Freundlich
+    input tripped a UserWarning carrying a factually false "edges exceed inlet range" message.
+    """
+
+    def test_in_range_freundlich_multipeak_emits_no_warning(self, recwarn):
+        """The report's in-range multi-peak Freundlich case emits no UserWarning."""
+        cin = np.array([0.0, 10.0, 10.0, 0.0, 0.0, 0.0, 5.0, 5.0, 0.0])
+        v_outlet = 40.0
+        sorption = FreundlichSorption(k_f=0.05, n=2.0, bulk_density=1600.0, porosity=0.35)
+        tedges = pd.date_range("2020-01-01", periods=len(cin) + 1, freq="D")
+        tr = FrontTracker(
+            cin=cin, flow=np.full(len(cin), 100.0), tedges=tedges, aquifer_pore_volume=v_outlet, sorption=sorption
+        )
+        tr.run()
+        theta_edges_out = np.linspace(1.0, 899.0, 80)  # every edge inside [0, 900]
+        compute_bin_averaged_concentration_exact(
+            theta_edges_out, v_outlet, tr.state.waves, sorption, cin=cin, theta_edges_inlet=tr.state.theta_edges
+        )
+        assert len(recwarn.list) == 0, "in-range conservation-form input must not warn"
+
+    def test_out_of_window_warning_names_the_true_cause(self):
+        """Output edges past the inlet window still warn, and the message says 'exceeding' the window.
+
+        A genuine out-of-window residual needs the wave list to keep growing m_dom while m_in
+        saturates — use a sustained boundary (single ShockWave, c_left=10) whose inlet record ends
+        before the output range.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        shock = ShockWave(theta_start=0.0, v_start=0.0, c_left=10.0, c_right=0.0, sorption=sorption, is_active=True)
+        waves = [shock]
+        v_outlet = 300.0
+        theta_cross = v_outlet / shock.speed
+        theta_edges_out = np.linspace(7.0, theta_cross * 2.0 + 7.0, 50)
+        theta_edges_inlet = np.array([0.0, theta_cross * 0.5])  # ends before the output range
+        cin = np.array([10.0])
+        with pytest.warns(UserWarning, match="exceeding theta_edges_inlet"):
+            compute_bin_averaged_concentration_exact(
+                theta_edges_out, v_outlet, waves, sorption, cin=cin, theta_edges_inlet=theta_edges_inlet
+            )
+
+
+class TestTotalOutletMassSemantics:
+    """``compute_total_outlet_mass`` honest c_∞ semantics (review O3).
+
+    Baseline paired the FINITE record integral ``m_in_total`` with the infinite-time steady-state
+    fill ``C_T(c_∞)·v_outlet``, returning a NEGATIVE total whenever ``m_in_total < C_T(c_∞)·v_outlet``
+    (demonstrated −3405.7). A pulse (``c_∞=0``) keeps ``m_in_total``; a sustained ``c_∞>0`` boundary
+    injects forever so the total outlet mass is unbounded → ``+inf``.
+    """
+
+    def test_pulse_returns_injected_mass(self):
+        """``cin[-1] == 0`` returns the finite injected mass ``Σ cin·Δθ``."""
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        cin = np.array([0.0, 4.0, 4.0, 0.0])
+        theta_edges = np.array([0.0, 100.0, 200.0, 300.0, 400.0])
+        m_out = compute_total_outlet_mass(v_outlet=500.0, sorption=sorption, cin=cin, theta_edges=theta_edges)
+        assert m_out == float(np.sum(cin * np.diff(theta_edges)))  # = 800.0, exact
+
+    def test_sustained_ambient_returns_inf_not_negative(self):
+        """``cin[-1] > 0`` with the −3405.7 layout returns +inf, never a negative mass."""
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        cin = np.array([0.0, 4.0, 4.0])  # c_∞ = 4 sustained
+        theta_edges = np.array([0.0, 100.0, 200.0, 300.0])
+        v_outlet = 5000.0  # large enough that C_T(c_∞)·v_outlet > m_in_total (baseline went negative)
+        m_in_total = float(np.sum(cin * np.diff(theta_edges)))
+        assert float(sorption.total_concentration(4.0)) * v_outlet > m_in_total  # the baseline-negative regime
+        m_out = compute_total_outlet_mass(v_outlet=v_outlet, sorption=sorption, cin=cin, theta_edges=theta_edges)
+        assert m_out == np.inf
+
+
+class TestConservationFormInletMassOutOfRange:
+    """Cumsum m_in at output edges == per-edge reference, incl. below/above the inlet window (O4).
+
+    The O(N+M) cumsum+searchsorted evaluation of the cumulative inlet integral must match the
+    per-edge ``compute_cumulative_inlet_mass`` reference to FP precision even when output edges fall
+    below ``theta_edges_inlet[0]`` (mass 0) or above ``theta_edges_inlet[-1]`` (saturated total).
+    """
+
+    def test_conservation_form_out_of_range_edges_match_reference(self):
+        """End-to-end conservation form with out-of-range edges equals the m_in−m_dom reference."""
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        shock = ShockWave(theta_start=0.0, v_start=0.0, c_left=10.0, c_right=0.0, sorption=sorption, is_active=True)
+        waves = [shock]
+        v_outlet = 300.0
+        # Inlet record starts mid-window (te_in[0] = 50) and ends at 350; output edges straddle both.
+        theta_edges_inlet = np.array([50.0, 150.0, 250.0, 350.0])
+        cin = np.array([10.0, 10.0, 10.0])
+        theta_edges_out = np.array([10.0, 40.0, 90.0, 200.0, 300.0, 380.0, 500.0])
+
+        c_avg = compute_bin_averaged_concentration_exact(
+            theta_edges_out, v_outlet, waves, sorption, cin=cin, theta_edges_inlet=theta_edges_inlet
+        )
+
+        # Independent reference: per-edge compute_cumulative_inlet_mass (the O(N·M) path the cumsum
+        # replaces), minus domain mass, clamped exactly as the conservation branch does.
+        m_in_ref = np.array([
+            compute_cumulative_inlet_mass(theta=float(e), cin=cin, theta_edges=theta_edges_inlet)
+            for e in theta_edges_out
+        ])
+        m_dom_ref = np.array([
+            compute_domain_mass(theta=float(e), v_outlet=v_outlet, waves=waves, sorption=sorption)
+            for e in theta_edges_out
+        ])
+        m_out_ref = np.where(theta_edges_out <= 0.0, 0.0, m_in_ref - m_dom_ref)
+        ref = np.maximum(np.diff(m_out_ref) / np.diff(theta_edges_out), 0.0)
+
+        np.testing.assert_allclose(c_avg, ref, rtol=1e-12, atol=1e-12)

--- a/tests/src/test_front_tracking_phase8.py
+++ b/tests/src/test_front_tracking_phase8.py
@@ -7,9 +7,11 @@ All tests have correct physics expectations for Freundlich n>1.
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from gwtransport.advection import infiltration_to_extraction_nonlinear_sorption
 from gwtransport.fronttracking.math import FreundlichSorption
+from gwtransport.fronttracking.solver import FrontTracker
 from gwtransport.fronttracking.waves import RarefactionWave, ShockWave
 from gwtransport.utils import compute_time_edges
 
@@ -132,31 +134,40 @@ class TestEntropyAndPhysics:
     """Test physical correctness."""
 
     def test_all_shocks_satisfy_entropy(self):
-        """All shocks must satisfy Lax entropy condition."""
+        """Every shock the solver builds satisfies the Lax entropy condition.
+
+        The multi-level input (0.1→10→5→15→8) makes a later, faster shock
+        overtake an earlier wave, so the public API refuses it (interim
+        wave-interaction guard). Entropy is a solver-level property of each
+        individual shock, so it is verified directly on the wave list that
+        ``FrontTracker`` builds.
+        """
         dates = pd.date_range(start="2020-01-01", periods=20, freq="D")
         tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
-
-        # Multiple concentration changes
         cin = np.array([0.1] * 4 + [10.0] * 4 + [5.0] * 4 + [15.0] * 4 + [8.0] * 4)
         flow = np.full(len(dates), 100.0)
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
 
-        cout_dates = pd.date_range(start=dates[0], periods=30, freq="D")
-        cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=len(cout_dates))
+        # Interim contract: the public API refuses this interacting multi-front input.
+        with pytest.raises(NotImplementedError):
+            infiltration_to_extraction_nonlinear_sorption(
+                cin=cin,
+                flow=flow,
+                tedges=tedges,
+                cout_tedges=tedges,
+                aquifer_pore_volumes=np.array([300.0]),
+                freundlich_k=0.01,
+                freundlich_n=2.0,
+                bulk_density=1500.0,
+                porosity=0.3,
+            )
 
-        _cout, structure = infiltration_to_extraction_nonlinear_sorption(
-            cin=cin,
-            flow=flow,
-            tedges=tedges,
-            cout_tedges=cout_tedges,
-            aquifer_pore_volumes=np.array([300.0]),
-            freundlich_k=0.01,
-            freundlich_n=2.0,
-            bulk_density=1500.0,
-            porosity=0.3,
-        )
-
-        # All shocks must satisfy entropy
-        shocks = [w for w in structure[0]["waves"] if isinstance(w, ShockWave)]
+        # Solver invariant (still valid on the unresolved wave list): every shock
+        # the tracker builds individually satisfies the Lax entropy condition.
+        tracker = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=300.0, sorption=sorption)
+        tracker.run()
+        shocks = [w for w in tracker.state.waves if isinstance(w, ShockWave)]
+        assert shocks, "expected the multi-change input to create shocks"
         for shock in shocks:
             assert shock.satisfies_entropy(), "Shock violates entropy condition"
 
@@ -461,41 +472,39 @@ class TestComplexInteractions:
         assert 2.0 - 1e-9 <= np.max(valid_cout) <= 12.0, f"Peak should be in [2, 12], got {np.max(valid_cout)}"
 
     def test_rapid_sequential_changes_event_ordering(self):
-        """Rapid concentration changes: stress test for event queue and wave creation."""
+        """Rapid concentration changes: stress test for the event queue and wave creation.
+
+        The rapid sequence (0→10→5→15→2→8) interacts (faster later shocks
+        overtake earlier waves), so the public API refuses it (interim guard).
+        Wave creation and θ-ordering of events are solver invariants, verified
+        directly on the ``FrontTracker`` state.
+        """
         dates = pd.date_range(start="2020-01-01", periods=30, freq="D")
         tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
-
-        # Rapid sequential changes: 0→10→5→15→2→8
         cin = np.array([0.0] * 5 + [10.0] * 5 + [5.0] * 5 + [15.0] * 5 + [2.0] * 5 + [8.0] * 5)
         flow = np.full(len(dates), 100.0)
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
 
-        cout_dates = pd.date_range(start=dates[0], periods=50, freq="D")
-        cout_tedges = compute_time_edges(tedges=None, tstart=None, tend=cout_dates, number_of_bins=len(cout_dates))
+        # Interim contract: the public API refuses this interacting multi-front input.
+        with pytest.raises(NotImplementedError):
+            infiltration_to_extraction_nonlinear_sorption(
+                cin=cin,
+                flow=flow,
+                tedges=tedges,
+                cout_tedges=tedges,
+                aquifer_pore_volumes=np.array([300.0]),
+                freundlich_k=0.01,
+                freundlich_n=2.0,
+                bulk_density=1500.0,
+                porosity=0.3,
+            )
 
-        cout, structure = infiltration_to_extraction_nonlinear_sorption(
-            cin=cin,
-            flow=flow,
-            tedges=tedges,
-            cout_tedges=cout_tedges,
-            aquifer_pore_volumes=np.array([300.0]),
-            freundlich_k=0.01,
-            freundlich_n=2.0,  # n>1: n>1
-            bulk_density=1500.0,
-            porosity=0.3,
+        # Solver invariants: rapid changes create multiple waves and the event
+        # queue stays chronologically ordered in θ.
+        tracker = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=300.0, sorption=sorption)
+        tracker.run()
+        assert len(tracker.state.waves) >= 5, (
+            f"Should create multiple waves from rapid changes, got {len(tracker.state.waves)}"
         )
-
-        # Should create multiple waves
-        total_waves = structure[0]["n_shocks"] + structure[0]["n_rarefactions"] + structure[0]["n_characteristics"]
-        assert total_waves >= 5, f"Should create multiple waves from rapid changes, got {total_waves}"
-
-        # Events are ordered by θ (which is monotone in t for non-negative flow).
-        event_thetas = [event["theta"] for event in structure[0]["events"]]
+        event_thetas = [event["theta"] for event in tracker.state.events]
         assert event_thetas == sorted(event_thetas), "Events should be chronologically ordered in θ"
-
-        # Output should not have NaN values after first arrival (translate θ→t).
-        tracker_state = structure[0]["tracker_state"]
-        t_first = tracker_state.t_at_theta(structure[0]["theta_first_arrival"])
-        cout_tedges_days = ((cout_tedges - cout_tedges[0]) / pd.Timedelta(days=1)).values
-        mask_after_spinup = cout_tedges_days[:-1] >= t_first
-        cout_after_spinup = cout[mask_after_spinup]
-        assert not np.any(np.isnan(cout_after_spinup)), "Output should not have NaN after spin-up"

--- a/tests/src/test_front_tracking_solver.py
+++ b/tests/src/test_front_tracking_solver.py
@@ -1174,3 +1174,92 @@ class TestEndToEndConservation:
 
         total = m_out + m_dom_end
         np.testing.assert_allclose(total, mass_in, rtol=5e-3)
+
+
+class TestNoSpuriousOutletCrossings:
+    """Regression for c_min-floored spurious outlet crossings (review minor / H2).
+
+    A c≈0 rarefaction tail (or characteristic) has its speed floored by the ``c_min`` dry-soil
+    retardation (``R(1e-12)≈2.5e6`` for n>1), which schedules a physically meaningless outlet
+    crossing at θ~1e8 that pollutes ``state.events`` and leaves ``theta_current`` at ~1e8.
+    """
+
+    @pytest.mark.parametrize(
+        ("cin", "v_outlet"),
+        [
+            ([0.0, 5.0, 10.0, 10.0, 5.0, 0.0], 400.0),
+            ([0.0, 10.0, 10.0, 0.0, 0.0, 0.0, 5.0, 5.0, 0.0], 40.0),
+        ],
+    )
+    def test_no_events_beyond_physical_horizon(self, cin, v_outlet):
+        cin = np.asarray(cin)
+        sorption = FreundlichSorption(k_f=0.001, n=2.0, bulk_density=1600.0, porosity=0.35)
+        n_bins = len(cin)
+        tedges = pd.date_range("2020-01-01", periods=n_bins + 1, freq="D")
+        flow = np.full(n_bins, 100.0)
+        tr = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=v_outlet, sorption=sorption)
+        tr.run()
+        # The physical θ-range is bounded by the last inlet edge plus a modest transit; the
+        # pinned artifacts land ~1e5–1e6× beyond it. A 100× horizon cleanly separates them.
+        horizon = 100.0 * float(tr.state.theta_edges[-1])
+        event_thetas = [e["theta"] for e in tr.state.events]
+        assert max(event_thetas) < horizon, f"spurious event at θ={max(event_thetas):.3g} (horizon {horizon:.3g})"
+        assert tr.state.theta_current < horizon
+
+
+class TestMultiPeakSingleOwnerInvariant:
+    """Every point in [0, V_outlet] is claimed by at most one active fan region (review C3 / H3).
+
+    A later inlet shock injected inside an existing fan's span must not leave two active
+    waves claiming the same near-inlet interval. After the waves.py growing-decay fixes the
+    intruding shock is resolved into a single-owner ``DecayingShockWave`` via the
+    shock↔rarefaction collision, so this spatial invariant holds; this test guards against a
+    regression that reintroduces a double claim.
+
+    This invariant is necessary but NOT sufficient for correctness: it says nothing about the
+    outlet-mass over-count a right-decaying DSW causes after its shock face leaves the domain, nor
+    about later pulses whose fans DO come to overlap. Those genuinely-interacting multi-front inputs
+    are refused at the public boundary — :func:`gwtransport.advection.infiltration_to_extraction_nonlinear_sorption`
+    raises ``NotImplementedError`` via :func:`gwtransport.fronttracking.solver.find_unresolved_interaction`
+    (exercised by ``TestUnresolvedMultiFrontInteractionRaises`` in ``test_front_tracking_api``); exact
+    multi-front interaction is deferred to a solver-level follow-up. The two parameterisations here use
+    weak retardation (``k_f = 0.001``) so the fans stay single-owner and the run completes.
+    """
+
+    @pytest.mark.parametrize(
+        ("cin", "v_outlet"),
+        [
+            ([0.0, 10.0, 10.0, 0.0, 0.0, 0.0, 5.0, 5.0, 0.0], 40.0),
+            ([0.0, 10.0, 10.0, 0.0, 0.0, 0.0, 15.0, 15.0, 0.0], 40.0),
+        ],
+    )
+    def test_no_two_active_fans_claim_same_point(self, cin, v_outlet):
+        cin = np.asarray(cin)
+        sorption = FreundlichSorption(k_f=0.001, n=2.0, bulk_density=1600.0, porosity=0.35)
+        n_bins = len(cin)
+        tedges = pd.date_range("2020-01-01", periods=n_bins + 1, freq="D")
+        flow = np.full(n_bins, 100.0)
+        tr = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=v_outlet, sorption=sorption)
+        tr.run()
+
+        def fan_owners(v, theta):
+            owners = []
+            for i, w in enumerate(tr.state.waves):
+                if not w.was_active_at(theta):
+                    continue
+                if isinstance(w, DecayingShockWave):
+                    v_s = w.position_at_theta(theta)
+                    if v_s is None:
+                        continue
+                    in_fan = (w.decay_side == "left" and v < v_s) or (w.decay_side == "right" and v > v_s)
+                    if in_fan and v != w.v_origin and w.concentration_at_point(v, theta) is not None:
+                        owners.append(i)
+                elif isinstance(w, RarefactionWave) and w.contains_point(v, theta):
+                    owners.append(i)
+            return owners
+
+        theta_hi = 1.6 * float(tr.state.theta_edges[-1])
+        for theta in np.linspace(1.0, theta_hi, 200):
+            for v in np.linspace(1e-3 * v_outlet, v_outlet * (1 - 1e-3), 150):
+                owners = fan_owners(float(v), float(theta))
+                assert len(owners) <= 1, f"waves {owners} both claim v={v:.3f} at θ={theta:.2f}"

--- a/tests/src/test_front_tracking_waves.py
+++ b/tests/src/test_front_tracking_waves.py
@@ -11,14 +11,40 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 
 import numpy as np
 import pytest
+from scipy.integrate import quad
+from scipy.optimize import brentq
 
 from gwtransport.fronttracking.math import (
     ConstantRetardation,
     FreundlichSorption,
     LangmuirSorption,
     VanGenuchtenMualemConductivity,
+    characteristic_speed,
 )
 from gwtransport.fronttracking.waves import CharacteristicWave, DecayingShockWave, RarefactionWave, ShockWave
+
+
+def _invariant_theta_local_of_c(sorption, c_decay_initial, c_fixed, theta_local_collision, c_target):
+    """Independent reference for the numerical DSW decay invariant.
+
+    Integrates the decay-agnostic invariant
+    ``θ_local(c) = θ_local_coll · exp(∫_{c0}^{c} R'/[(1 − R·S)·R] dc)`` with the
+    symmetric secant speed ``S = (c − c_fixed)/(C_T(c) − C_T(c_fixed))`` via
+    adaptive ``scipy.integrate.quad`` — a method-independent check on the
+    module's composite-quadrature cache (which integrates the same integrand).
+    """
+    ct_fixed = float(sorption.total_concentration(c_fixed))
+
+    def integrand(c):
+        h = max(1e-9, 1e-7 * abs(c))
+        rp = (float(sorption.retardation(c + h)) - float(sorption.retardation(c - h))) / (2.0 * h)
+        r = float(sorption.retardation(c))
+        ct = float(sorption.total_concentration(c))
+        s = (c - c_fixed) / (ct - ct_fixed)
+        return rp / ((1.0 - r * s) * r)
+
+    val, _ = quad(integrand, c_decay_initial, c_target, limit=400)
+    return theta_local_collision * np.exp(val)
 
 
 class TestCharacteristicWave:
@@ -820,3 +846,167 @@ class TestSaturatedVanGenuchtenWaveSpeeds:
         )
         assert wave.head_speed() == np.inf
         assert np.isfinite(wave.tail_speed())
+
+
+def _fan_consistent_dsw(sorption, *, decay_side, c0, c_fixed, c_fan_tail, theta_origin, theta_local_collision):
+    """Build a fan-continuity-consistent DSW (``v_start = v_origin + θ_local/R(c0)``)."""
+    theta_start = theta_origin + theta_local_collision
+    v_origin = 0.0
+    v_start = v_origin + theta_local_collision / float(sorption.retardation(c0))
+    return DecayingShockWave(
+        theta_start=theta_start,
+        v_start=v_start,
+        c_decay_initial=c0,
+        c_fixed=c_fixed,
+        c_fan_tail=c_fan_tail,
+        decay_side=decay_side,
+        v_origin=v_origin,
+        theta_origin=theta_origin,
+        sorption=sorption,
+    )
+
+
+class TestDecayingShockWaveNumericalInversion:
+    """Fan-exhaustion and outlet-crossing on the numerical (non-closed-form) decay path.
+
+    These pin the orientation-agnostic inversion of the monotone
+    ``c_decay(θ_local)`` map and the outlet-crossing bracket seed. Each numerical
+    result is checked against an independent adaptive-``quad`` evaluation of the
+    same invariant integral.
+    """
+
+    def test_growing_decay_fan_exhaustion_finite(self):
+        """Growing decay (``c_decay_initial < c_fan_tail``) exhausts at a finite θ, not θ_start.
+
+        Favorable-Freundlich tail collision ([12,6,3,40]-class geometry): the
+        decaying side grows 3 → 6 and reaches ``c_fan_tail`` at a finite
+        ``θ_local`` given by the un-clamped invariant. The orientation-blind
+        early return previously reported immediate exhaustion at ``θ_start``.
+        """
+        sorption = FreundlichSorption(k_f=0.02, n=2.0, bulk_density=1500.0, porosity=0.3)
+        c0, c_fixed, c_fan_tail = 3.0, 40.0, 6.0
+        theta_origin, tlc = 400.0, 363.0
+        wave = _fan_consistent_dsw(
+            sorption,
+            decay_side="right",
+            c0=c0,
+            c_fixed=c_fixed,
+            c_fan_tail=c_fan_tail,
+            theta_origin=theta_origin,
+            theta_local_collision=tlc,
+        )
+        # Numerical path (Freundlich n=2 mirror c_decay_initial < c_fixed): no closed form.
+        assert np.isnan(wave.K)
+        assert wave.c_decay_initial < wave.c_fan_tail  # growing orientation
+
+        theta_ref = theta_origin + _invariant_theta_local_of_c(sorption, c0, c_fixed, tlc, c_fan_tail)
+        theta_exhaust = wave.theta_at_fan_exhaustion()
+        assert theta_exhaust is not None
+        assert theta_exhaust > wave.theta_start  # not the θ_start early return
+        np.testing.assert_allclose(theta_exhaust, theta_ref, rtol=1e-8)
+        # Physical meaning: c_decay has reached c_fan_tail at exhaustion.
+        c_at_exhaust = wave.c_decay_at_theta(theta_exhaust)
+        np.testing.assert_allclose(c_at_exhaust, c_fan_tail, rtol=1e-8)
+
+    def test_numerical_shrinking_fan_exhaustion_finite(self):
+        """Numerical shrinking decay (Langmuir c_fixed>0) exhausts at a finite θ, not None.
+
+        The clamped forward profile saturates AT ``c_fan_tail`` and never crosses
+        it, so the previous forward-map bracket reported no exhaustion; the
+        un-clamped invariant gives a finite θ.
+        """
+        sorption = LangmuirSorption(s_max=0.1, k_l=5.0, bulk_density=1500.0, porosity=0.3)
+        c0, c_fixed, c_fan_tail = 10.0, 1.0, 4.0
+        theta_origin, tlc = 0.0, 500.0
+        wave = _fan_consistent_dsw(
+            sorption,
+            decay_side="left",
+            c0=c0,
+            c_fixed=c_fixed,
+            c_fan_tail=c_fan_tail,
+            theta_origin=theta_origin,
+            theta_local_collision=tlc,
+        )
+        assert np.isnan(wave.K)  # numerical path
+
+        theta_ref = theta_origin + _invariant_theta_local_of_c(sorption, c0, c_fixed, tlc, c_fan_tail)
+        theta_exhaust = wave.theta_at_fan_exhaustion()
+        assert theta_exhaust is not None
+        np.testing.assert_allclose(theta_exhaust, theta_ref, rtol=1e-8)
+        c_at_exhaust = wave.c_decay_at_theta(theta_exhaust)
+        np.testing.assert_allclose(c_at_exhaust, c_fan_tail, rtol=1e-8)
+
+    def test_numerical_outlet_crossing_roundtrip_sub_unit_theta_local(self):
+        """Outlet crossing recovers θ even when the crossing lies within θ_local < 1 of the apex.
+
+        Roundtrip ``position_at_theta → outlet_crossing_theta`` must be an
+        identity on the numerical path. The bracket seed was floored at the
+        dimensional constant 1.0 m³, so crossings closer than 1.0 to the apex
+        returned None.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=3.0, bulk_density=1500.0, porosity=0.3)
+        c0, c_fixed, c_fan_tail = 8.0, 2.0, 2.5
+        theta_origin, tlc = 0.0, 0.3  # tiny θ_local so crossings sit below 1.0 m³
+        wave = _fan_consistent_dsw(
+            sorption,
+            decay_side="left",
+            c0=c0,
+            c_fixed=c_fixed,
+            c_fan_tail=c_fan_tail,
+            theta_origin=theta_origin,
+            theta_local_collision=tlc,
+        )
+        assert np.isnan(wave.K)  # numerical path
+
+        for theta_local in (0.35, 0.6, 0.99):
+            theta = theta_origin + theta_local
+            v = wave.position_at_theta(theta)
+            assert v is not None
+            recovered = wave.outlet_crossing_theta(v_outlet=v)
+            assert recovered is not None
+            np.testing.assert_allclose(recovered, theta, rtol=1e-8)
+
+    def test_numerical_c_decay_matches_independent_quad(self):
+        """Cached numerical ``c_decay(θ_local)`` agrees with the direct invariant quad to 1e-9.
+
+        Anchors the per-wave cached decay profile (built by composite quadrature)
+        against an adaptive ``quad`` inversion of the same invariant.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=1.5, bulk_density=1500.0, porosity=0.3)
+        c0, c_fixed, c_fan_tail = 8.0, 1.0, 2.0
+        theta_origin, tlc = 0.0, 500.0
+        wave = _fan_consistent_dsw(
+            sorption,
+            decay_side="left",
+            c0=c0,
+            c_fixed=c_fixed,
+            c_fan_tail=c_fan_tail,
+            theta_origin=theta_origin,
+            theta_local_collision=tlc,
+        )
+
+        def c_direct(theta_local):
+            # Invert θ_local(c) = target via the independent quad reference.
+            def f(c):
+                return _invariant_theta_local_of_c(sorption, c0, c_fixed, tlc, c) - theta_local
+
+            return brentq(f, c_fan_tail + 1e-12, c0 - 1e-12, xtol=1e-15)
+
+        for theta_local in np.linspace(tlc * 1.01, tlc * 6.0, 25):
+            cached = wave.c_decay_at_theta(theta_origin + theta_local)  # theta_origin=0 -> θ = θ_local
+            np.testing.assert_allclose(cached, c_direct(theta_local), rtol=1e-9)
+
+
+class TestWaveSpeedCaching:
+    """Cached wave celerities (``__post_init__``) are bit-identical to direct evaluation."""
+
+    def test_characteristic_speed_cached_bit_identical(self):
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        wave = CharacteristicWave(theta_start=0.0, v_start=0.0, concentration=5.0, sorption=sorption)
+        assert wave.speed() == characteristic_speed(5.0, sorption)
+
+    def test_rarefaction_head_tail_speed_cached_bit_identical(self):
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        wave = RarefactionWave(theta_start=0.0, v_start=0.0, c_head=10.0, c_tail=2.0, sorption=sorption)
+        assert wave.head_speed() == characteristic_speed(10.0, sorption)
+        assert wave.tail_speed() == characteristic_speed(2.0, sorption)

--- a/tests/src/test_front_tracking_zero_concentration.py
+++ b/tests/src/test_front_tracking_zero_concentration.py
@@ -28,7 +28,7 @@ class TestInletWaveCreationZeroConcentration:
         """Test C=0 → C=10 creates rarefaction for n>1 Freundlich with c_min>0."""
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3, c_min=1e-12)
 
-        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=10.0, theta=5.0, sorption=sorption, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=10.0, theta=5.0, sorption=sorption)
 
         # For n>1, velocity increases with concentration
         # So 10 > 0 means faster concentration catching slower, creating compression (shock)
@@ -43,7 +43,7 @@ class TestInletWaveCreationZeroConcentration:
         """Test C=0 → C=10 creates characteristic for n<1 Freundlich with c_min=0."""
         sorption = FreundlichSorption(k_f=0.01, n=0.5, bulk_density=1500.0, porosity=0.3, c_min=0.0)
 
-        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=10.0, theta=5.0, sorption=sorption, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=10.0, theta=5.0, sorption=sorption)
 
         # For n<1 with c_min=0, R(0)=1 is special case
         # Stepping from 0 to nonzero creates characteristic
@@ -55,7 +55,7 @@ class TestInletWaveCreationZeroConcentration:
         """Test C=0 → C=10 creates characteristic for constant retardation."""
         sorption = ConstantRetardation(retardation_factor=2.0)
 
-        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=10.0, theta=5.0, sorption=sorption, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=0.0, c_new=10.0, theta=5.0, sorption=sorption)
 
         assert len(waves) == 1
         assert isinstance(waves[0], CharacteristicWave)
@@ -65,7 +65,7 @@ class TestInletWaveCreationZeroConcentration:
         """Test C=10 → C=0 creates rarefaction for n>1."""
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3, c_min=1e-12)
 
-        waves = create_inlet_waves_at_theta(c_prev=10.0, c_new=0.0, theta=15.0, sorption=sorption, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=10.0, c_new=0.0, theta=15.0, sorption=sorption)
 
         # For n>1, concentration decrease creates rarefaction (expansion)
         assert len(waves) == 1
@@ -78,7 +78,7 @@ class TestInletWaveCreationZeroConcentration:
         """Test C=2 → C=10 creates shock for n>1 (compression)."""
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
 
-        waves = create_inlet_waves_at_theta(c_prev=2.0, c_new=10.0, theta=5.0, sorption=sorption, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=2.0, c_new=10.0, theta=5.0, sorption=sorption)
 
         assert len(waves) == 1
         assert isinstance(waves[0], ShockWave)
@@ -90,7 +90,7 @@ class TestInletWaveCreationZeroConcentration:
         """Test C=10 → C=2 creates rarefaction for n>1 (expansion)."""
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
 
-        waves = create_inlet_waves_at_theta(c_prev=10.0, c_new=2.0, theta=5.0, sorption=sorption, v_inlet=0.0)
+        waves = create_inlet_waves_at_theta(c_prev=10.0, c_new=2.0, theta=5.0, sorption=sorption)
 
         assert len(waves) == 1
         assert isinstance(waves[0], RarefactionWave)

--- a/tests/src/test_fronttracking_plot.py
+++ b/tests/src/test_fronttracking_plot.py
@@ -23,6 +23,7 @@ from gwtransport.fronttracking.plot import (
     plot_wave_interactions,
 )
 from gwtransport.fronttracking.solver import FrontTracker
+from gwtransport.fronttracking.validation import verify_physics
 from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
 
 plt.switch_backend("Agg")
@@ -168,6 +169,80 @@ def _structure_from_tracker(tracker):
         "waves": tracker.state.waves,
         "events": tracker.state.events,
     }
+
+
+class TestVerifyPhysicsSpinupMaskTimeOrigin:
+    """verify_physics check 5 must build its spin-up mask on the *shared* time origin.
+
+    The mask maps ``cout_tedges`` to θ via ``tracker_state.theta_at_t``, which expects
+    days measured from ``tracker_state.tedges[0]`` (the input origin). If the output grid
+    is offset from the input origin and the mask is built with each grid's own first edge
+    as reference, the after-spin-up window is shifted earlier and NaNs that fall after the
+    true first arrival are silently excluded.
+    """
+
+    def test_nan_after_spinup_detected_in_offset_output_window(self, freundlich_favorable):
+        # Small step so the mass-balance check integrates a single shock cheaply.
+        tedges = pd.date_range("2020-01-01", periods=9, freq="10D")
+        cin = np.array([0.0] + [10.0] * 7)
+        flow = np.full(8, 100.0)
+        tracker = FrontTracker(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            aquifer_pore_volume=50.0,
+            sorption=freundlich_favorable,
+        )
+        tracker.run(max_iterations=500)
+        state = tracker.state
+
+        theta_first = tracker.theta_first_arrival
+        t_first = state.t_at_theta(theta_first)
+        assert np.isfinite(t_first)
+
+        # Output grid entirely AFTER first arrival but OFFSET from the input origin.
+        offset_days = t_first + 20.0
+        cout_tedges = pd.date_range(state.tedges[0] + pd.Timedelta(days=offset_days), periods=4, freq="5D")
+        cout = np.full(len(cout_tedges) - 1, 10.0)
+        cout[0] = np.nan  # NaN in the first (genuinely after-spin-up) output bin.
+
+        structure = {
+            "waves": state.waves,
+            "theta_first_arrival": theta_first,
+            "events": state.events,
+            "tracker_state": state,
+        }
+        results = verify_physics(structure, cout, cout_tedges, cin, verbose=False)
+        check5 = next(c for c in results["checks"] if c["name"] == "No NaN after spin-up")
+        assert not check5["passed"], "NaN after spin-up in an offset output window must be detected"
+
+
+class TestSummaryOverlayTimeOrigin:
+    """The bin-averaged outlet overlay must share the exact curve's time origin (tedges[0])."""
+
+    def test_bin_averaged_overlay_starts_at_shared_origin(self, tracker_step):
+        state = tracker_step.state
+        structure = _structure_from_tracker(tracker_step)
+
+        # Output grid offset 100 days past the input origin.
+        offset_days = 100.0
+        cout_tedges = pd.date_range(state.tedges[0] + pd.Timedelta(days=offset_days), periods=6, freq="10D")
+        cout = np.full(len(cout_tedges) - 1, 5.0)
+
+        fig, axes = plot_front_tracking_summary(
+            structure,
+            state.tedges,
+            state.cin,
+            cout_tedges,
+            cout,
+            show_exact=False,
+        )
+        binned = [ln for ln in axes["outlet"].get_lines() if ln.get_label() == "Bin-averaged outlet"]
+        assert binned, "bin-averaged overlay line not found"
+        xmin = float(np.asarray(binned[0].get_xdata(), dtype=float).min())
+        # Left edge sits at the offset when measured from the shared origin, not at 0.
+        np.testing.assert_allclose(xmin, offset_days, atol=1e-9)
+        plt.close(fig)
 
 
 class TestPlotSummaryAndComparisonSmoke:

--- a/tests/src/test_gamma.py
+++ b/tests/src/test_gamma.py
@@ -413,6 +413,21 @@ def test_bins_quantile_edges_too_few():
         gamma_bins(alpha=5.0, beta=2.0, quantile_edges=np.array([0.0, 1.0]))
 
 
+def test_bins_empty_quantile_edges_raises():
+    """Regression (G1): an empty quantile_edges must raise ValueError, not leak IndexError.
+
+    Before the fix the empty array passed the (vacuously true) strictly-increasing check
+    and then indexed ``quantile_edges[0]`` on a size-0 array, leaking an IndexError instead
+    of the documented ValueError family.
+    """
+    with pytest.raises(ValueError):
+        gamma_bins(alpha=2.0, beta=3.0, quantile_edges=np.array([]))
+
+    # A single edge cannot define even one bin either.
+    with pytest.raises(ValueError):
+        gamma_bins(alpha=2.0, beta=3.0, quantile_edges=np.array([0.0]))
+
+
 def test_bins_loc_zero_matches_legacy():
     """With loc=0, bins() reproduces the two-parameter result bit-for-bit."""
     r_default = gamma_bins(alpha=5.0, beta=2.0, n_bins=20)

--- a/tests/src/test_gamma_residence_time.py
+++ b/tests/src/test_gamma_residence_time.py
@@ -307,6 +307,92 @@ def test_spinup_invalid_raises():
         gamma(flow=flow, tedges=tedges, cout_tedges=tedges, mean=300.0, std=80.0, spinup=-0.1)
 
 
+def _degenerate_covered_oracle(flow, tedges, b, mean_val, std_val, loc, r, direction):
+    """Independent covered-sub-mass oracle for a zero-throughflow (Q=0) output bin ``b``.
+
+    Over a zero-flow bin the cumulative volume ``v`` is fixed while output time advances, so the
+    bin-average residence time is the pointwise ``tau(v, V_p) = sign*(T(v + sign*r*V_p) - t_mid)``
+    (``T`` the volume->time map) averaged against the gamma density. Under a strict spin-up policy a
+    ``V_p`` whose parcel leaves the record (e2i: ``v - r V_p < 0``; i2e: ``v + r V_p > v_end``) is
+    excluded, so the mean is renormalized over the covered sub-range ``[support_lo, vp_hi]`` by
+    adaptive quadrature. Returns the covered-mass conditional mean and the covered mass fraction.
+    """
+    td = tedges_to_days(tedges)
+    flow_cum = cumulative_flow_volume(flow, np.diff(td), strictly_monotone=True)
+    v_end = flow_cum[-1]
+    alpha = (mean_val - loc) ** 2 / std_val**2
+    beta = std_val**2 / (mean_val - loc)
+    support_lo = loc + gamma_dist.ppf(1e-13, alpha, scale=beta)
+    support_hi = loc + gamma_dist.ppf(1 - 1e-13, alpha, scale=beta)
+    sign = -1.0 if direction == "extraction_to_infiltration" else 1.0
+    v = flow_cum[b]
+    t_mid = 0.5 * (td[b] + td[b + 1])
+    vp_hi = min((v if sign < 0 else v_end - v) / r, support_hi)
+
+    def pdf(vp):
+        return gamma_dist.pdf(vp - loc, alpha, scale=beta)
+
+    def tau_pdf(vp):
+        return sign * (np.interp(v + sign * r * vp, flow_cum, td) - t_mid) * pdf(vp)
+
+    pts = sorted({p for p in (sign * (flow_cum - v) / r) if support_lo < p < vp_hi})
+    num = quad(tau_pdf, support_lo, vp_hi, points=pts or None, limit=200)[0]
+    den = quad(pdf, support_lo, vp_hi, points=pts or None, limit=200)[0]
+    full_mass = gamma_dist.cdf(support_hi - loc, alpha, scale=beta) - gamma_dist.cdf(
+        support_lo - loc, alpha, scale=beta
+    )
+    return num / den, den / full_mass
+
+
+@pytest.mark.parametrize(
+    ("direction", "zero_bin"), [("extraction_to_infiltration", 2), ("infiltration_to_extraction", 9)]
+)
+def test_degenerate_bin_respects_spinup(direction, zero_bin):
+    """A zero-throughflow output bin must honour the spin-up policy (regression for M4).
+
+    The Q=0 degenerate branch previously clamped out-of-record look-back/forward parcels
+    (``np.interp``) and ignored ``spinup`` entirely, so ``None``/``0.0``/float all returned the
+    full-support *clamped* mean. The strict policies must instead renormalize over the covered
+    sub-mass (matching an independent quadrature oracle), and a float threshold must ``NaN`` an
+    under-covered bin. The default warm-start ``spinup='constant'`` is unchanged.
+    """
+    n = 12
+    flow = np.full(n, 100.0)
+    flow[zero_bin] = 0.0
+    tedges = pd.date_range("2023-01-01", periods=n + 1, freq="D")
+    mean_val, std_val, loc, r = 500.0, 150.0, 0.0, 1.0
+    kw = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "mean": mean_val,
+        "std": std_val,
+        "loc": loc,
+        "direction": direction,
+        "retardation_factor": r,
+    }
+    g_const = gamma(**kw, spinup="constant")
+    g_none = gamma(**kw, spinup=None)
+    g_zero = gamma(**kw, spinup=0.0)
+
+    oracle, cov_frac = _degenerate_covered_oracle(flow, tedges, zero_bin, mean_val, std_val, loc, r, direction)
+    # The chosen mean puts most of the APVD beyond the reachable look-back/forward volume: strong
+    # under-coverage, so the clamped (old, buggy) and covered-mass (correct) values differ materially.
+    assert cov_frac < 0.05
+    # Strict None renormalizes over the covered sub-mass -> matches the independent quad oracle.
+    np.testing.assert_allclose(g_none[zero_bin], oracle, rtol=1e-10, atol=0)
+    # ...and it is a genuine correction, distinct from the warm-started default.
+    assert not np.isclose(g_none[zero_bin], g_const[zero_bin], rtol=1e-6, atol=1e-6)
+    # spinup=0.0 is the exact None alias (bit-identical).
+    assert g_zero[zero_bin] == g_none[zero_bin]
+    # A float threshold above the covered fraction NaNs the under-covered bin...
+    assert np.isnan(gamma(**kw, spinup=0.6)[zero_bin])
+    # ...while a threshold below it still emits the covered-mass mean.
+    np.testing.assert_allclose(gamma(**kw, spinup=cov_frac / 2)[zero_bin], oracle, rtol=1e-10, atol=0)
+    # The default warm-start stays finite (never NaN) at the zero-flow bin.
+    assert np.isfinite(g_const[zero_bin])
+
+
 @pytest.mark.parametrize("direction", DIRECTIONS)
 def test_spinup_zero_vs_constant_differ_in_spinup_agree_deep(direction):
     """spinup=0.0 and spinup="constant" differ in early spin-up bins but agree in deep informed bins.
@@ -375,6 +461,53 @@ def test_float_spinup_threshold_gates_emission(direction):
     both = ~nan_low & ~nan_high
     assert both.any()
     np.testing.assert_allclose(low[both], high[both], atol=0, rtol=1e-12)
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_spinup_one_emits_every_fully_covered_bin(direction):
+    """spinup=1.0 must emit a finite value at EVERY fully-covered bin (regression for the exact gate).
+
+    The float-``spinup`` covered-fraction gate compared ``den >= threshold * reference`` exactly. For
+    a fully-covered bin the covered sub-mass ``den`` equals its reference only up to summation-
+    reassociation ulps, so the strictest threshold ``1.0`` -- newly reachable after widening the
+    contract to ``[0, 1]`` -- spuriously ``NaN``-ed a large fraction of fully-covered bins. A bin is
+    fully covered exactly where the strict ``spinup=None`` mean is finite and coincides with the
+    warm-started default (nothing is extrapolated there), so ``spinup=1.0`` must emit at all of them
+    and, since the gate only masks emission and never the value, must equal ``spinup=None`` bit-for-bit
+    there. A deep zero-throughflow (Q=0) bin places one of those fully-covered bins in the degenerate
+    branch, exercising the same exact gate on the pointwise path.
+    """
+    n = 90
+    flow = np.full(n, 100.0)
+    # A deep zero-throughflow bin: extraction looks back (deep = late, large cumulative volume);
+    # infiltration looks forward (deep = early). Either way the full gamma support is reachable, so
+    # the bin is fully covered and lands in the degenerate branch's covered-fraction gate.
+    zero_bin = n - 15 if direction == "extraction_to_infiltration" else 14
+    flow[zero_bin] = 0.0
+    tedges = pd.date_range("2023-01-01", periods=n + 1, freq="D")
+    kw = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": tedges,
+        "mean": 500.0,
+        "std": 150.0,
+        "loc": 0.0,
+        "direction": direction,
+        "retardation_factor": 1.0,
+    }
+    g_none = gamma(**kw, spinup=None)
+    g_const = gamma(**kw, spinup="constant")
+    g_one = gamma(**kw, spinup=1.0)
+
+    # Fully covered = strict None is finite and matches the warm-start (no extrapolation used there).
+    fully_covered = np.isfinite(g_none) & np.isclose(g_none, g_const, rtol=1e-9, atol=1e-9)
+    assert fully_covered.sum() > n // 2, "scenario must have many fully-covered bins"
+    assert fully_covered[zero_bin], "the deep zero-flow bin must be fully covered (degenerate-gate coverage)"
+
+    # No fully-covered bin may be spuriously NaN under the strictest threshold...
+    assert np.all(np.isfinite(g_one[fully_covered])), "spinup=1.0 spuriously NaN-ed a fully-covered bin"
+    # ...and where it emits, the gate only masks: the value is the strict covered-sub-mass mean exactly.
+    np.testing.assert_array_equal(g_one[fully_covered], g_none[fully_covered])
 
 
 @pytest.mark.parametrize("direction", DIRECTIONS)

--- a/tests/src/test_logremoval.py
+++ b/tests/src/test_logremoval.py
@@ -657,26 +657,26 @@ def test_gamma_find_flow_for_target_mean_loc_zero_matches_closed_form():
 
 
 def test_gamma_pdf_negative_loc_raises():
-    """gamma_pdf must reject negative rt_loc."""
-    with pytest.raises(ValueError, match="rt_loc must be non-negative"):
+    """gamma_pdf must reject negative rt_loc (via gamma.parse_parameters)."""
+    with pytest.raises(ValueError, match="loc must be non-negative"):
         gamma_pdf(r=np.array([1.0]), rt_alpha=3.0, rt_beta=10.0, rt_loc=-1.0, log10_decay_rate=0.2)
 
 
 def test_gamma_cdf_negative_loc_raises():
-    """gamma_cdf must reject negative rt_loc."""
-    with pytest.raises(ValueError, match="rt_loc must be non-negative"):
+    """gamma_cdf must reject negative rt_loc (via gamma.parse_parameters)."""
+    with pytest.raises(ValueError, match="loc must be non-negative"):
         gamma_cdf(r=np.array([1.0]), rt_alpha=3.0, rt_beta=10.0, rt_loc=-1.0, log10_decay_rate=0.2)
 
 
 def test_gamma_mean_negative_loc_raises():
-    """gamma_mean must reject negative rt_loc."""
-    with pytest.raises(ValueError, match="rt_loc must be non-negative"):
+    """gamma_mean must reject negative rt_loc (via gamma.parse_parameters)."""
+    with pytest.raises(ValueError, match="loc must be non-negative"):
         gamma_mean(rt_alpha=3.0, rt_beta=10.0, rt_loc=-1.0, log10_decay_rate=0.2)
 
 
 def test_gamma_find_flow_for_target_mean_negative_loc_raises():
-    """gamma_find_flow_for_target_mean must reject negative apv_loc."""
-    with pytest.raises(ValueError, match="apv_loc must be non-negative"):
+    """gamma_find_flow_for_target_mean must reject negative apv_loc (via gamma.parse_parameters)."""
+    with pytest.raises(ValueError, match="loc must be non-negative"):
         gamma_find_flow_for_target_mean(
             target_mean=1.0,
             apv_alpha=3.0,
@@ -737,6 +737,90 @@ def test_gamma_find_flow_for_target_mean_invalid_alpha_beta_raises(apv_alpha, ap
             apv_loc=5.0,
             log10_decay_rate=0.1,
         )
+
+
+# ---------------------------------------------------------------------------
+# L1: dual (mean, std, loc) / (alpha, beta, loc) parameterization for the four
+# gamma functions, routed through gamma.parse_parameters, and rejection of
+# physically invalid (e.g. negative alpha) parameters.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rt_alpha", "rt_beta", "rt_loc", "log10_decay_rate"),
+    [
+        (4.0, 3.0, 0.0, 0.2),
+        (2.5, 10.0, 1.5, 0.05),
+        (7.0, 0.8, 5.0, 0.3),
+    ],
+)
+def test_gamma_functions_mean_std_matches_alpha_beta(rt_alpha, rt_beta, rt_loc, log10_decay_rate):
+    """(mean, std, loc) input reproduces the (alpha, beta, loc) result to machine precision.
+
+    Regression (L1): before the fix the gamma functions accepted only (alpha, beta, loc),
+    breaking the package-wide dual-parameterization convention; passing rt_mean/rt_std
+    raised a TypeError.
+    """
+    rt_mean = rt_alpha * rt_beta + rt_loc
+    rt_std = np.sqrt(rt_alpha) * rt_beta
+    r = np.array([0.1, 1.0, 2.5, 5.0])
+
+    pdf_ab = gamma_pdf(r=r, rt_alpha=rt_alpha, rt_beta=rt_beta, rt_loc=rt_loc, log10_decay_rate=log10_decay_rate)
+    pdf_ms = gamma_pdf(r=r, rt_mean=rt_mean, rt_std=rt_std, rt_loc=rt_loc, log10_decay_rate=log10_decay_rate)
+    assert_allclose(pdf_ms, pdf_ab, rtol=1e-14, atol=0.0)
+
+    cdf_ab = gamma_cdf(r=r, rt_alpha=rt_alpha, rt_beta=rt_beta, rt_loc=rt_loc, log10_decay_rate=log10_decay_rate)
+    cdf_ms = gamma_cdf(r=r, rt_mean=rt_mean, rt_std=rt_std, rt_loc=rt_loc, log10_decay_rate=log10_decay_rate)
+    assert_allclose(cdf_ms, cdf_ab, rtol=1e-14, atol=0.0)
+
+    mean_ab = gamma_mean(rt_alpha=rt_alpha, rt_beta=rt_beta, rt_loc=rt_loc, log10_decay_rate=log10_decay_rate)
+    mean_ms = gamma_mean(rt_mean=rt_mean, rt_std=rt_std, rt_loc=rt_loc, log10_decay_rate=log10_decay_rate)
+    assert_allclose(mean_ms, mean_ab, rtol=1e-14, atol=0.0)
+
+
+@pytest.mark.parametrize(
+    ("apv_alpha", "apv_beta", "apv_loc", "log10_decay_rate", "target_mean"),
+    [
+        (3.0, 100.0, 0.0, 0.2, 2.0),
+        (2.5, 250.0, 50.0, 0.1, 1.5),
+    ],
+)
+def test_gamma_find_flow_mean_std_matches_alpha_beta(apv_alpha, apv_beta, apv_loc, log10_decay_rate, target_mean):
+    """gamma_find_flow_for_target_mean accepts (mean, std, loc) equivalently to (alpha, beta, loc)."""
+    apv_mean = apv_alpha * apv_beta + apv_loc
+    apv_std = np.sqrt(apv_alpha) * apv_beta
+
+    flow_ab = gamma_find_flow_for_target_mean(
+        target_mean=target_mean,
+        apv_alpha=apv_alpha,
+        apv_beta=apv_beta,
+        apv_loc=apv_loc,
+        log10_decay_rate=log10_decay_rate,
+    )
+    flow_ms = gamma_find_flow_for_target_mean(
+        target_mean=target_mean,
+        apv_mean=apv_mean,
+        apv_std=apv_std,
+        apv_loc=apv_loc,
+        log10_decay_rate=log10_decay_rate,
+    )
+    assert_allclose(flow_ms, flow_ab, rtol=1e-14, atol=0.0)
+
+
+def test_gamma_functions_reject_negative_alpha():
+    """Regression (L1): negative rt_alpha/apv_alpha must raise, not return an invalid value.
+
+    Before the fix ``gamma_mean(rt_alpha=-2, ...)`` silently returned a physically
+    meaningless number because no positivity validation was performed.
+    """
+    with pytest.raises(ValueError, match="Alpha and beta must be positive"):
+        gamma_mean(rt_alpha=-2.0, rt_beta=3.0, log10_decay_rate=0.2)
+    with pytest.raises(ValueError, match="Alpha and beta must be positive"):
+        gamma_pdf(r=np.array([1.0]), rt_alpha=-2.0, rt_beta=3.0, log10_decay_rate=0.2)
+    with pytest.raises(ValueError, match="Alpha and beta must be positive"):
+        gamma_cdf(r=np.array([1.0]), rt_alpha=-2.0, rt_beta=3.0, log10_decay_rate=0.2)
+    with pytest.raises(ValueError, match="Alpha and beta must be positive"):
+        gamma_find_flow_for_target_mean(target_mean=1.0, apv_alpha=-2.0, apv_beta=3.0, log10_decay_rate=0.2)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/src/test_percolation.py
+++ b/tests/src/test_percolation.py
@@ -823,6 +823,28 @@ class TestValidatorBranches:
         with pytest.raises(ValueError, match=match):
             root_zone_to_water_table_kinematic_wave(**kwargs)
 
+    @pytest.mark.parametrize(
+        ("override", "match"),
+        [
+            # NaN / +inf must be rejected, not passed silently: a comparison-only guard
+            # (`arr <= 0` / `k_s <= 0`) evaluates False for both and yields all-NaN output.
+            ({"cumulative_pore_volumes_outlet": np.array([np.nan])}, r"non-empty with all entries positive"),
+            ({"cumulative_pore_volumes_outlet": np.array([np.inf])}, r"non-empty with all entries positive"),
+            ({"cumulative_pore_volumes_outlet": np.array([0.1, np.nan])}, r"non-empty with all entries positive"),
+            ({"k_s": np.nan}, r"k_s must be positive"),
+            ({"k_s": np.inf}, r"k_s must be positive"),
+        ],
+    )
+    def test_c7_nonfinite_cpv_and_ks_raise(self, override, match):
+        """C7: non-finite ``cumulative_pore_volumes_outlet`` / ``k_s`` raise instead of silent all-NaN.
+
+        NaN and +inf both slip past a bare ``<= 0`` comparison (each yields ``False``),
+        so the guard must additionally require finiteness. Regression for PERC-P1.
+        """
+        kwargs = {**self._valid_kwargs(), **override}
+        with pytest.raises(ValueError, match=match):
+            root_zone_to_water_table_kinematic_wave(**kwargs)
+
 
 # =============================================================================
 # Section D — vG characteristic-speed monotonicity (property test)
@@ -903,23 +925,25 @@ class TestMissingCoverage:
     def test_m2_dry_days_handled(self):
         """M2: dry intervals (q=0) interspersed with positive q → no NaN/inf, physical bounds hold.
 
-        Constructs a wet-then-dry-then-wet sequence on a short column so the
-        signal exits *inside* the inlet θ-window (PERC-M2 regime). Asserts the
-        physical bounds ``0 ≤ q_wt ≤ q_root.max()`` (a flux at the water table can
-        neither go negative nor exceed the largest root-zone leakage), not merely
-        the absence of NaN/inf. The clamp-to-zero ``UserWarning`` is exercised
-        separately by ``test_m2b_no_clamp_warning_inside_inlet_window``.
+        Constructs a wet-then-dry-then-wet sequence on a short column. The full-zero
+        dry gap is a *single-front* run (one wetting front, no unresolved wave
+        interaction); its breakthrough lands just past the inlet θ-window, so the
+        in-window conservation residual is pure pre-breakthrough FP-cancellation dust.
+        That dust now falls inside the ``compute_bin_averaged_concentration_exact``
+        FP-cancellation band and is clamped SILENTLY — the previous run emitted a
+        ``clamp threshold`` ``UserWarning`` only because the old band was keyed off the
+        (≈0, pre-breakthrough) output concentration and was orders of magnitude too
+        tight. Run under ``simplefilter("error")`` so any warning — a spurious clamp
+        diagnostic OR a false multi-front-interaction flag — fails the test, then assert
+        the physical envelope ``0 ≤ q_wt ≤ q_root.max()`` (a flux at the water table can
+        neither go negative nor exceed the largest root-zone leakage).
         """
         tedges = _make_tedges(60)
         q_root = np.full(60, 0.001)
         q_root[20:30] = 0.0  # dry period (full zero — the genuine dry-days case)
         v_out = np.array([O05["theta_s"] * 0.3])
-        # The full-zero dry gap pushes the drying tail past the inlet window,
-        # tripping the benign out-of-window clamp warning (the subject of M2b,
-        # which uses an in-window forcing). Match it explicitly via pytest.warns
-        # rather than blanket-silencing, so any unrelated new warning still
-        # surfaces as an error here.
-        with pytest.warns(UserWarning, match="clamp threshold"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any UserWarning (clamp / interaction) becomes an exception
             q_wt, _ = root_zone_to_water_table_kinematic_wave(
                 q_root_zone=q_root,
                 tedges=tedges,

--- a/tests/src/test_radial_asr.py
+++ b/tests/src/test_radial_asr.py
@@ -117,13 +117,38 @@ class TestDeHoog:
         np.testing.assert_allclose(batched, analytic, atol=1e-5)
 
     def test_nonpositive_t_returns_zero(self):
-        # de Hoog is defined only for t > 0; the t<=0 guard returns exactly 0 there (keeping the internal
-        # scaling finite) while still inverting the positive entries. Unreachable from the reuse engine
-        # (every phase has tau > 0), but the primitive must stay safe.
+        # de Hoog is defined only for t > 0; the final t>0 mask returns exactly 0 there (the big_t clamp keeps
+        # the internal scaling finite) while still inverting the positive entries -- one general path, no
+        # early return. Unreachable from the reuse engine (every phase has tau > 0), but the primitive must
+        # stay safe.
         t = np.array([-1.0, 0.0, 2.0])
         got = dehoog_inverse(f_hat=lambda s: 1.0 / (s + 1.0), t=t, n_terms=32, scaling=4.0)
         np.testing.assert_array_equal(got[:2], 0.0)
         np.testing.assert_allclose(got[2], np.exp(-2.0), atol=1e-5)
+
+    def test_underflow_columns_invert_to_zero_overflow_surfaces(self):
+        # RA2 (guard): a batch column whose transform decays to the double-precision underflow floor (exact
+        # or denormal zeros at the high-frequency nodes -- the far-field rest / Airy / Riccati propagator
+        # entries) drives the quotient-difference recurrence into 0/0 and x/0. Its physical inverse is ~0, so
+        # it must invert to exactly 0, NOT NaN -- a NaN there propagated through P @ field and silently
+        # collapsed the whole cout to background. A column whose transform OVERFLOWED (Inf/NaN already present)
+        # is a genuine breakdown and must still surface as NaN so a real failure cannot read as a physical
+        # zero. (Before the guard only *identically*-zero columns were parked; a partial-underflow column
+        # returned NaN.)
+        m = 24
+
+        def f_hat(s):
+            base = 1.0 / (s + 1.0)  # a well-resolved transform -> exp(-t)
+            underflow = base.copy()
+            underflow[3:] = 0.0  # decayed to the floor at the high-frequency nodes -> QD 0/0
+            overflow = base.copy()
+            overflow[5] = np.inf  # a genuinely broken (overflowed) transform
+            return np.stack([base, underflow, overflow], axis=1)
+
+        out = dehoog_inverse(f_hat=f_hat, t=np.array([1.0]), n_terms=m)
+        np.testing.assert_allclose(out[0, 0], np.exp(-1.0), atol=1e-6)  # normal column unaffected
+        assert out[0, 1] == 0.0  # underflowed column -> physical zero (was NaN before the guard)
+        assert not np.isfinite(out[0, 2])  # overflowed column -> NaN surfaces (never masked to 0)
 
 
 # --- Airy kernel + KB Sec. 6 moments ------------------------------------------------------------
@@ -366,6 +391,25 @@ class TestGammaWrapper:
         recovered = np.sum(cout[flow < 0] * (-flow[flow < 0]))
         np.testing.assert_allclose(recovered, np.sum(cin[flow > 0] * flow[flow > 0]), rtol=1e-2)
 
+    def test_velocity_cv_zero_is_homogeneous_screen(self):
+        # velocity_cv = 0 is a homogeneous screen -- a single streamtube at the mean velocity (pore height
+        # screen_height), matching the docstring. It must run (a degenerate std-0 gamma is not a valid
+        # distribution) and reproduce the plain engine at pore_heights = screen_height, bit-for-bit.
+        tedges, flow, geom = _scenario()
+        cin = np.where(flow > 0, 1.0, 0.0)
+        common = {
+            "flow": flow,
+            "tedges": tedges,
+            "cout_tedges": tedges,
+            "porosity": geom["porosity"],
+            "well_radius": geom["well_radius"],
+            "longitudinal_dispersivity": geom["longitudinal_dispersivity"],
+            "n_quad": 120,
+        }
+        gam = gamma_infiltration_to_extraction(cin=cin, screen_height=10.0, velocity_cv=0.0, n_bins=8, **common)
+        homogeneous = infiltration_to_extraction(cin=cin, pore_heights=10.0, **common)
+        np.testing.assert_array_equal(gam, homogeneous)
+
     @pytest.mark.slow
     def test_gamma_multi_cycle_round_trip(self):
         # Both gamma (screen-velocity ensemble) wrappers on a MULTI-CYCLE schedule, so they route through the
@@ -418,6 +462,17 @@ class TestValidation:
                 cout_tedges=tedges,
                 **{**geom, "longitudinal_dispersivity": 0.0},
             )
+
+    def test_reverse_nan_cout_on_extraction_raises(self):
+        # A single NaN measurement on an extraction bin would poison the whole least-squares reverse into
+        # an all-NaN cin; the inverse must raise (like the advection / diffusion inverses), not silently
+        # return NaN. Structural NaN on injection / rest bins (ignored by the inverse) stays allowed.
+        tedges, flow, geom = _scenario()
+        cin = np.where(flow > 0, 1.0, 0.0)
+        cout = infiltration_to_extraction(cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, n_quad=80)
+        cout[np.flatnonzero(flow < 0)[3]] = np.nan  # poison one extraction measurement
+        with pytest.raises(ValueError, match="cout contains NaN"):
+            extraction_to_infiltration(cout=cout, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, n_quad=80)
 
 
 class TestGeneralEngine:
@@ -480,6 +535,39 @@ class TestGeneralEngine:
         assert 0.9 < recovered <= 1.0 + 1e-3  # near-full recovery, up to the buffer + finite-volume floor
 
     @pytest.mark.slow
+    def test_high_peclet_multi_cycle_recovery_monotone(self):
+        # RA1: a large-plume multi-cycle push-pull whose grid reaches Peclet r_max/alpha_L > 700, where the
+        # reuse engine's Airy interior Green's function overflowed to Inf, the propagator went all-NaN, and the
+        # blanket nan_to_num silently mapped it to exactly 0 (recovery collapsed to 0). With the overflow-safe
+        # fold the recovery stays finite and PHYSICAL: sharpening the front (decreasing alpha_L) recovers a
+        # monotone-non-decreasing fraction of the injected mass -- the collapse produced a non-monotone drop to
+        # 0 at alpha_L = 0.22.
+        c_geo_heights = 30.0  # pore height; c_geo = pi * b * porosity
+        flow = np.array([5000.0] * 60 + [-10000.0] * 15 + [5000.0] * 30 + [-10000.0] * 30)
+        cin = np.array([100.0] * 60 + [0.0] * 15 + [50.0] * 30 + [0.0] * 30)
+        dt = np.ones(len(flow))
+        tedges = pd.date_range("2020-01-01", periods=len(flow) + 1, freq="D")
+        geom = {"pore_heights": c_geo_heights, "porosity": 0.3, "well_radius": 0.5}
+        injected = np.sum((cin * flow * dt)[flow > 0])
+        recovered = []
+        for alpha_l in (0.50, 0.30, 0.22, 0.18):
+            cout = infiltration_to_extraction(
+                cin=cin,
+                flow=flow,
+                tedges=tedges,
+                cout_tedges=tedges,
+                longitudinal_dispersivity=alpha_l,
+                **geom,
+                n_quad=120,
+            )
+            ext = flow < 0
+            assert not np.any(np.isnan(cout[ext]))  # the overflow no longer produces NaN -> silent-zero
+            recovered.append(np.sum((cout * (-flow) * dt)[ext]) / injected)
+        recovered = np.array(recovered)
+        assert np.all(recovered > 0.9)  # no collapse (baseline dropped to ~0 at alpha_L <= 0.22)
+        assert np.all(np.diff(recovered) > -1e-9)  # monotone non-decreasing as the front sharpens
+
+    @pytest.mark.slow
     def test_dm_positive_forward_conserves(self):
         # Single inject->extract cycle (no rest) with D_m>0 routes to the closed-form echo operator; this
         # checks that path conserves mass under molecular diffusion. The multi-cycle reuse-engine D_m>0 path
@@ -509,8 +597,9 @@ class TestGeneralEngine:
         # D_m>0 forward AND reverse through the reuse engine's Riccati branch on a multi-cycle schedule. The
         # public single-cycle D_m>0 path routes to the echo operator, so only a multi-cycle schedule drives
         # the Riccati propagator matrices (forward) and the dense-column ensemble reverse. @slow: the per-node
-        # Riccati ODE dominates and the reverse rebuilds it per injection column, so the schedule and n_quad
-        # are kept minimal (two single-injection cycles -> a 2-column dense reverse).
+        # Riccati ODE dominates; the reverse builds the propagator matrices once and applies them to the whole
+        # unit-pulse batch, so the schedule and n_quad are kept minimal (two single-injection cycles -> a
+        # 2-column dense reverse).
         flow = np.array([100.0] * 1 + [-100.0] * 2 + [100.0] * 1 + [-100.0] * 2)
         tedges = pd.date_range("2024-01-01", periods=len(flow) + 1, freq="D")
         cin = np.where(flow > 0, 1.0, 0.0)

--- a/tests/src/test_radial_asr_gridfree.py
+++ b/tests/src/test_radial_asr_gridfree.py
@@ -404,6 +404,27 @@ class TestGridfreeEngine:
         # the manual mean of the same production engine (cout_deviation) to machine precision.
         np.testing.assert_allclose(ens[ext], manual, rtol=1e-12)
 
+    @pytest.mark.parametrize("alpha_l", [8.0, 3.0])
+    def test_echo_v_window_conserves_mass_at_low_peclet(self, alpha_l):
+        # The resident-profile V' quadrature window must be Peclet-aware. At low Peclet (large alpha_L,
+        # r_front/alpha_L << 1) the profile spreads over many breakthrough widths; a flat 4 S_inj/R margin
+        # truncates that tail and loses mass. Isolate the window from any finite-extraction loss with ONE
+        # injection bin and ONE huge extraction bin (every parcel arrives, so G1(T_end; V') -> 1): then
+        # recovered = W[0, 0] * T_end = int f(V') dV' = S_inj/R exactly, and any deficit is pure window
+        # truncation. Before the Peclet-aware window this lost ~1.5e-2 at alpha_L = 8 / ~3e-4 at alpha_L = 3.
+        c_geo, r_w, s_inj, t_end = 25.0, 0.5, 5000.0, 5.0e7
+        w = single_cycle_echo_matrix(
+            inj_volume_edges=np.array([0.0, s_inj]),
+            ext_volume_edges=np.array([0.0, t_end]),
+            c_geo=c_geo,
+            r_w=r_w,
+            alpha_l=alpha_l,
+            inj_flow_scale=100.0,
+            ext_flow_scale=100.0,
+            n_quad=240,
+        )
+        np.testing.assert_allclose(w[0, 0] * t_end, s_inj, rtol=1e-4)
+
 
 @contextlib.contextmanager
 def _tight_dehoog():
@@ -483,8 +504,15 @@ class TestReuseEngine:
     @pytest.mark.parametrize("direction", ["injection", "extraction"])
     def test_airy_matrix_is_per_reversal_operator(self, direction):
         # THE correctness identity (D_m=0): each cached-matrix column equals the per-reversal _propagate of a
-        # unit source at that node -- the same single de Hoog inversion of the same Airy kernel. Bit-exact,
-        # Peclet-independent (the matrix IS the operator; end-to-end gaps are only the de Hoog nonlinearity).
+        # unit source at that node -- the same single de Hoog inversion of the same Airy kernel. The reuse
+        # matrix folds the Sturm-Liouville source weight e^{-gauge r'/alpha_L} into assemble_airy_resolvent's
+        # log-exponents (overflow-safe at any Peclet -- the divergent injection branch and the extraction
+        # weight would otherwise blow up past r/alpha_L ~ 700 and meet as Inf * 0 = NaN), while _propagate
+        # applies it as a separate post-multiply. The two therefore differ only by exp(a + b) vs exp(a) e^b
+        # reorder noise (~1e-14 in the transform, amplified by the de Hoog condition to ~1e-8 in the column) --
+        # the same benign effect the Riccati sibling below tolerates. Measured worst |Δcol| = 7e-8 across the
+        # three probed columns/directions, so atol=5e-7 keeps ~7× headroom over the real reorder noise while a
+        # sign / structural error is O(|col|) ~ 1e-2..1e-1, five orders of magnitude above the tolerance.
         flow, dt = np.array([100.0] * 4 + [-100.0] * 4), np.ones(8)
         r_nodes, _, dr = _field_grid(flow, dt, CG, 0.5, 0.5, 0.0, 60)
         tau, flow_scale = 400.0, 100.0  # flushed-volume tau = phase_volume
@@ -497,9 +525,35 @@ class TestReuseEngine:
             e = np.zeros(60)
             e[j] = 1.0
             col = _propagate(e, r_nodes, sl, direction, tau, r_w=0.5, alpha_l=0.5, flow_scale=flow_scale, c_geo=CG)
-            # Bit-identical: the matrix column and _propagate of a unit source feed the SAME Ghat*sl input
-            # (the one-hot contraction adds only zeros, exact in IEEE) through the SAME de Hoog code.
-            np.testing.assert_array_equal(pmat[:, j], col)
+            np.testing.assert_allclose(pmat[:, j], col, rtol=1e-6, atol=5e-7)
+
+    @pytest.mark.parametrize("direction", ["injection", "extraction"])
+    def test_airy_matrix_finite_at_high_peclet(self, direction):
+        # At Peclet r_max/alpha_L > ~700 the growing-Airy injection branch (assemble's e^{+g r_sum}) and the
+        # extraction Sturm-Liouville weight e^{+r'/alpha_L} each overflow double precision; only folding the
+        # weight into the assembly's log-exponents keeps their bounded product finite. Before the fold the
+        # propagator was all-NaN, which the ensemble's nan_to_num silently mapped to a physical zero (cout=0).
+        alpha_l, r_w, c_geo = 0.18, 0.5, np.pi * 30.0 * 0.3
+        flow = np.array([5000.0] * 60 + [-10000.0] * 15 + [5000.0] * 30 + [-10000.0] * 30)
+        dt = np.ones(len(flow))
+        r_nodes, _, dr = _field_grid(flow, dt, c_geo, r_w, alpha_l, 0.0, 120)
+        assert r_nodes.max() / alpha_l > 700.0  # the regime that overflowed before the fold
+        signed = flow[flow > 0] if direction == "injection" else -flow[flow < 0]
+        tau, flow_scale = float(np.sum(signed)), float(np.mean(signed))
+        pmat = _airy_propagator_matrix(
+            direction,
+            tau,
+            r_nodes,
+            dr,
+            r_w=r_w,
+            alpha_l=alpha_l,
+            c_geo=c_geo,
+            flow_scale=flow_scale,
+            n_terms=44,
+            tol=1e-9,
+        )
+        assert np.all(np.isfinite(pmat))
+        assert np.max(np.abs(pmat)) < 1.0  # the bounded physical field hand-off (|P| ~ O(1), not amplifying)
 
     @pytest.mark.slow
     @pytest.mark.parametrize(("direction", "r_fac"), [("injection", 1.0), ("extraction", 1.0), ("extraction", 2.0)])
@@ -745,6 +799,53 @@ class TestRestDiffusion:
             for r, rp in ((1.2, 4.0), (4.0, 1.2), (2.0, 30.0)):
                 got = rest_resolvent(s=np.array([s]), r=r, r_prime=rp, r_w=r_w, d_m=d_m)[0, 0]
                 assert abs(got - complex(ref(s, r, rp))) / abs(complex(ref(s, r, rp))) < 1e-12
+
+    def test_rest_resolvent_high_frequency_no_overflow(self):
+        # At a high Laplace frequency Re(kappa r_w) exceeds ~354, where splitting the outer term's bounded
+        # combined exponent into exp(|Re z_w| + z_w) * exp(-z_lt - z_gt) overflows the first factor to Inf and
+        # forms Inf * 0 = NaN, defeating the scaled Bessels. The single-combined-exponent form stays finite and
+        # matches mpmath (arbitrary precision, which represents the huge I_1). r ~ r_w keeps the true (tiny)
+        # value above the double-precision underflow floor so the match is a real relative comparison.
+        d_m, r_w = 0.5, 0.5
+
+        def ref(s, r, rp):
+            s = mp.mpc(s)
+            k = mp.sqrt(s / d_m)
+            rl, rg = (r, rp) if r <= rp else (rp, r)
+            u0 = mp.besselk(1, k * r_w) * mp.besseli(0, k * rl) + mp.besseli(1, k * r_w) * mp.besselk(0, k * rl)
+            return u0 * mp.besselk(0, k * rg) / mp.besselk(1, k * r_w)
+
+        s = 720.0**2 * d_m  # Re(kappa r_w) = 360 > 354 -> the split outer factor overflows to Inf
+        for r, rp in ((0.6, 0.6), (0.55, 0.7)):
+            got = rest_resolvent(s=np.array([s + 0j]), r=r, r_prime=rp, r_w=r_w, d_m=d_m)[0, 0]
+            expected = complex(ref(s, r, rp))
+            assert np.isfinite(got)
+            assert abs(got - expected) / abs(expected) < 1e-10
+
+    def test_rest_propagator_conserves_mass_across_regimes(self):
+        # RA2: the rest (Q=0) propagator must be finite AND must never AMPLIFY resident mass -- the diffusion
+        # invariant dv^T P <= dv per source column (amplification is a maximum-principle violation that drives
+        # cout above cin end-to-end). Two regimes are exercised on the same grid:
+        #   sub-grid (small D_m): the diffusion length sqrt(D_m tau) drops below the grid spacing, so the
+        #     Bessel resolvent's near-delta Green's function is unresolved. The quadratured matrix AMPLIFIED
+        #     mass here (dv^T P reached ~2.4x -> cout > cin, recovered mass > injected) and, before the de Hoog
+        #     underflow guard, its far-field cells were NaN and collapsed cout to background. The
+        #     resolution-limit guard returns the identity (diffusion has not crossed a cell), so mass is
+        #     EXACTLY conserved and the rest reduces to the D_m=0 echo (the correct small-D_m limit).
+        #   resolved (larger D_m): the de Hoog matrix is used; it conserves interior mass and only loses a
+        #     little to the far field at the outer boundary -- never amplifies.
+        r_w, alpha_l, c_geo = 0.5, 0.5, np.pi * 10.0 * 0.35
+        flow = np.array([5.0] * 40 + [0.0] + [-5.0] * 40)
+        dt = np.ones(len(flow))
+        for d_m, sub_grid in ((1e-3, True), (0.05, False)):
+            r_nodes, _, dr = _field_grid(flow, dt, c_geo, r_w, alpha_l, d_m, 120)
+            dv = 2.0 * c_geo * r_nodes * dr  # radial mass measure: mass = dv @ field
+            pmat = _rest_propagator_matrix(1.0, r_nodes, dr, r_w=r_w, d_m_eff=d_m, n_terms=44, tol=1e-9)
+            assert np.all(np.isfinite(pmat))
+            col_mass = dv @ pmat  # resident mass produced per unit source; must never exceed the source mass
+            assert np.max(col_mass / dv) <= 1.0 + 1e-6  # no amplification (pre-fix reached ~2.4x at small D_m)
+            if sub_grid:  # sub-grid rest is the identity to grid accuracy -> mass EXACTLY conserved
+                np.testing.assert_allclose(col_mass, dv, rtol=1e-12)
 
     @pytest.mark.slow
     def test_seasonal_rest_matches_fv_oracle(self):

--- a/tests/src/test_recharge.py
+++ b/tests/src/test_recharge.py
@@ -235,6 +235,41 @@ class TestUnbounded:
             vol += np.sum(w)
         np.testing.assert_allclose(wide[0], mass / vol, atol=2e-8)
 
+    def test_large_single_bin_uspan_kernel_not_truncated(self):
+        """A single bin flushing >60 pore volumes must not drop earlier kernel bins.
+
+        depth=0.1, dt=1, R=1 make u increment by recharge/0.1 per bin. With
+        recharge=[0.5, 6.5, 0.5, 0.5] the second bin flushes u-span 65 (u goes
+        5 -> 70). Spin-up is constant at cin_recharge[0]=10, so C is exactly 10
+        at u=5 (the bin-0 exit). Over bin 1 (recharge concentration 2, a
+        65-pore-volume flush) the recharge-weighted (= u-averaged) exit
+        concentration is (2*65 + (10 - 2)*(1 - e^-65)) / 65 = 138/65 to within
+        e^-65. Keying the kernel-truncation cutoff to the bin's largest u (u2t)
+        instead of its smallest (u1t) drops the still-significant bin-0
+        contribution here, biasing the average to ~1.97 (regression RC1).
+        """
+        depth = 0.1
+        tedges = to_tedges(np.arange(5.0))
+        cin_recharge = np.array([10.0, 2.0, 3.0, 4.0])
+        recharge = np.array([0.5, 6.5, 0.5, 0.5])
+        cout = recharge_to_extraction(
+            cin_recharge=cin_recharge,
+            recharge=recharge,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_depth=depth,
+        )
+        np.testing.assert_allclose(cout[1], 138.0 / 65.0, atol=1e-9)
+
+        # Independent anchor: fine recharge-weighted quadrature of the pointwise
+        # oracle (full, untruncated kernel sum) over the same output bin.
+        n = len(recharge)
+        ts = np.linspace(1.0, 2.0, 20001)
+        mid = 0.5 * (ts[:-1] + ts[1:])
+        c_mid = pointwise_oracle(mid, tedges, np.zeros(n), recharge, cin_recharge, cin_recharge, depth, np.inf)
+        w = recharge[np.clip(np.searchsorted(np.arange(5.0), mid, side="right") - 1, 0, n - 1)] * np.diff(ts)
+        np.testing.assert_allclose(cout[1], np.sum(c_mid * w) / np.sum(w), atol=1e-9)
+
     def test_outside_record_nan(self):
         tedges = to_tedges(np.arange(6.0))
         cout = recharge_to_extraction(
@@ -702,6 +737,11 @@ class TestValidation:
     def test_scalar_ranges(self):
         bad = dict(self.ok)
         bad["aquifer_pore_depth"] = 0.0
+        with pytest.raises(ValueError, match="positive"):
+            recharge_to_extraction(**bad)
+        # NaN slipped past the ``<= 0`` guard and silently produced garbage; must raise.
+        bad = dict(self.ok)
+        bad["aquifer_pore_depth"] = np.nan
         with pytest.raises(ValueError, match="positive"):
             recharge_to_extraction(**bad)
         with pytest.raises(ValueError, match="retardation_factor"):

--- a/tests/src/test_residence_time.py
+++ b/tests/src/test_residence_time.py
@@ -186,16 +186,16 @@ def test_invalid_spinup_raises():
     flow, tedges = _constant_flow()
     with pytest.raises(ValueError, match="spinup"):
         mean(flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=300.0, spinup="bad")
-    # The unified contract is {'constant'} | None | float in [0, 1): out-of-range floats raise.
+    # The unified contract is {'constant'} | None | float in [0, 1]: only floats outside [0, 1] raise.
     with pytest.raises(ValueError, match="spinup"):
-        mean(flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=300.0, spinup=1.0)
+        mean(flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=300.0, spinup=1.5)
     with pytest.raises(ValueError, match="spinup"):
         mean(flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=300.0, spinup=-0.1)
 
 
-@pytest.mark.parametrize("spinup", ["constant", None, 0.0, 0.5])
+@pytest.mark.parametrize("spinup", ["constant", None, 0.0, 0.5, 1.0])
 def test_residence_time_accepts_unified_spinup_set(spinup):
-    """mean accepts each member of the shared {'constant', None, float in [0, 1)} set."""
+    """mean accepts each member of the shared {'constant', None, float in [0, 1]} set."""
     flow, tedges = _constant_flow(n=40, q=100.0)
     apv = np.array([200.0, 400.0, 600.0, 800.0])
     got = mean(flow=flow, tedges=tedges, cout_tedges=tedges, aquifer_pore_volumes=apv, spinup=spinup)
@@ -229,6 +229,30 @@ def test_residence_time_float_threshold_gates_covered_fraction():
     assert nan_high.sum() > nan_zero.sum()  # and strictly NaNs more in the staggered spin-up
     both_finite = ~nan_zero & ~nan_high
     np.testing.assert_array_equal(got_zero[both_finite], got_two_thirds[both_finite])
+
+
+def test_spinup_one_is_strictest_gate():
+    """spinup=1.0 is accepted and requires full coverage (regression for the [0, 1) -> [0, 1] widening).
+
+    Previously ``spinup=1.0`` raised (the residence-time contract was ``[0, 1)`` while advection uses
+    ``[0, 1]``). It must now be the strictest threshold: a bin is emitted only where every streamtube
+    has broken through, and there the renormalized mean equals the warm-started default.
+    """
+    flow, tedges = _constant_flow(n=40, q=100.0)
+    apv = np.array([200.0, 1500.0, 2800.0])  # staggered break-through: an early partial-coverage region
+    common = {"flow": flow, "tedges": tedges, "cout_tedges": tedges, "aquifer_pore_volumes": apv}
+    got_one = mean(**common, spinup=1.0)  # must not raise
+    got_const = mean(**common, spinup="constant")
+    # 1.0 emits iff every streamtube is valid under the strict per-pore-volume map.
+    all_valid = np.isfinite(full(**common, spinup=None)).all(axis=0)
+    # a genuine partial-coverage case: some fully-covered bins, some not
+    assert all_valid.any()
+    assert not all_valid.all()
+    np.testing.assert_array_equal(np.isfinite(got_one), all_valid)
+    # Where emitted it is the full-coverage mean, bit-identical to the warm-started default there.
+    np.testing.assert_array_equal(got_one[all_valid], got_const[all_valid])
+    # gamma also accepts the widened endpoint without raising.
+    assert gamma(flow=flow, tedges=tedges, cout_tedges=tedges, mean=1500.0, std=400.0, spinup=1.0).shape == (40,)
 
 
 @pytest.mark.parametrize("direction", DIRECTIONS)

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -7,21 +7,22 @@ import numpy as np
 import pandas as pd
 import pytest
 import requests.exceptions
+from _oracles import partial_isin  # ty: ignore[unresolved-import]  # tests/src on path via conftest
 from scipy.linalg import null_space
 
 from gwtransport._time import dt_to_days, tedges_to_days
 from gwtransport.examples import generate_example_data, generate_example_deposition_timeseries
 from gwtransport.utils import (
     _make_strictly_monotone,
-    combine_bin_series,
     compute_reverse_target,
     compute_time_edges,
     cumulative_flow_volume,
     get_soil_temperature,
     linear_average,
     linear_interpolate,
-    partial_isin,
     simplify_bins,
+    solve_inverse_transport,
+    solve_inverse_transport_banded,
     solve_tikhonov,
     solve_underdetermined_system,
     step_plot_coords,
@@ -511,365 +512,6 @@ def test_invalid_inputs():
     bin_edges_out = np.array([25, 15, 5])  # Descending order
     with pytest.raises(ValueError, match="bin_edges_out must be non-decreasing"):
         partial_isin(bin_edges_in=bin_edges_in, bin_edges_out=bin_edges_out)
-
-
-def test_combine_bin_series_basic():
-    """Test basic functionality of combine_bin_series."""
-    # Simple case: non-overlapping bins
-    a = np.array([1.0, 2.0])
-    a_edges = np.array([0.0, 1.0, 2.0])
-    b = np.array([3.0, 4.0])
-    b_edges = np.array([1.0, 1.5, 2.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [0, 1, 1.5, 2]
-    expected_edges = np.array([0.0, 1.0, 1.5, 2.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # Expected values for c: [1, 2, 2] (a[0] broadcasts to first bin, a[1] broadcasts to bins 2&3)
-    # Expected values for d: [0, 3, 4] (b[0] broadcasts to second bin, b[1] broadcasts to third bin)
-    expected_c = np.array([1.0, 2.0, 2.0])
-    expected_d = np.array([0.0, 3.0, 4.0])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_identical_edges():
-    """Test combine_bin_series when both series have identical edges."""
-    a = np.array([1.0, 2.0, 3.0])
-    a_edges = np.array([0.0, 1.0, 2.0, 3.0])
-    b = np.array([4.0, 5.0, 6.0])
-    b_edges = np.array([0.0, 1.0, 2.0, 3.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Edges should remain the same
-    expected_edges = np.array([0.0, 1.0, 2.0, 3.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # Values should be preserved
-    np.testing.assert_array_equal(c, a)
-    np.testing.assert_array_equal(d, b)
-
-
-def test_combine_bin_series_overlapping_bins():
-    """Test combine_bin_series with overlapping bin structures."""
-    a = np.array([10.0, 20.0])
-    a_edges = np.array([0.0, 5.0, 10.0])
-    b = np.array([30.0, 40.0])
-    b_edges = np.array([2.0, 7.0, 12.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [0, 2, 5, 7, 10, 12]
-    expected_edges = np.array([0.0, 2.0, 5.0, 7.0, 10.0, 12.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # Test that the values are broadcasted/repeated correctly
-    # a[0]=10 covers [0,5]: broadcasts to bins [0,2] and [2,5]
-    # a[1]=20 covers [5,10]: broadcasts to bins [5,7] and [7,10]
-    # b[0]=30 covers [2,7]: broadcasts to bins [2,5] and [5,7]
-    # b[1]=40 covers [7,12]: broadcasts to bins [7,10] and [10,12]
-    expected_c = np.array([10.0, 10.0, 20.0, 20.0, 0.0])
-    expected_d = np.array([0.0, 30.0, 30.0, 40.0, 40.0])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_single_bins():
-    """Test combine_bin_series with single bins."""
-    a = np.array([5.0])
-    a_edges = np.array([0.0, 2.0])
-    b = np.array([10.0])
-    b_edges = np.array([1.0, 3.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [0, 1, 2, 3]
-    expected_edges = np.array([0.0, 1.0, 2.0, 3.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # a=5 covers [0,2]: broadcasts to [0,1] and [1,2]
-    # b=10 covers [1,3]: broadcasts to [1,2] and [2,3]
-    expected_c = np.array([5.0, 5.0, 0.0])
-    expected_d = np.array([0.0, 10.0, 10.0])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_nested_bins():
-    """Test combine_bin_series where one series is nested within another."""
-    a = np.array([100.0])
-    a_edges = np.array([0.0, 10.0])
-    b = np.array([20.0, 30.0])
-    b_edges = np.array([2.0, 5.0, 8.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [0, 2, 5, 8, 10]
-    expected_edges = np.array([0.0, 2.0, 5.0, 8.0, 10.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # a=100 covers [0,10]: broadcasts to all combined bins within its range
-    # b[0]=20 covers [2,5] and b[1]=30 covers [5,8]
-    expected_c = np.array([100.0, 100.0, 100.0, 100.0])
-    expected_d = np.array([0.0, 20.0, 30.0, 0.0])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_non_overlapping():
-    """Test combine_bin_series with completely non-overlapping bins."""
-    a = np.array([1.0, 2.0])
-    a_edges = np.array([0.0, 1.0, 2.0])
-    b = np.array([3.0, 4.0])
-    b_edges = np.array([3.0, 4.0, 5.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [0, 1, 2, 3, 4, 5]
-    expected_edges = np.array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # a maps to first two bins, b maps to last two bins
-    expected_c = np.array([1.0, 2.0, 0.0, 0.0, 0.0])
-    expected_d = np.array([0.0, 0.0, 0.0, 3.0, 4.0])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_zero_values():
-    """Test combine_bin_series with zero values."""
-    a = np.array([0.0, 5.0])
-    a_edges = np.array([0.0, 1.0, 2.0])
-    b = np.array([3.0, 0.0])
-    b_edges = np.array([0.5, 1.5, 2.5])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [0, 0.5, 1, 1.5, 2, 2.5]
-    expected_edges = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 2.5])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # Check that zero values are preserved and broadcasted correctly
-    expected_c = np.array([0.0, 0.0, 5.0, 5.0, 0.0])
-    expected_d = np.array([0.0, 3.0, 3.0, 0.0, 0.0])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_floating_point():
-    """Test combine_bin_series with floating point precision."""
-    a = np.array([1.1, 2.2])
-    a_edges = np.array([0.1, 1.1, 2.1])
-    b = np.array([3.3, 4.4])
-    b_edges = np.array([0.6, 1.6, 2.6])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [0.1, 0.6, 1.1, 1.6, 2.1, 2.6]
-    expected_edges = np.array([0.1, 0.6, 1.1, 1.6, 2.1, 2.6])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # Test with appropriate precision and broadcasting
-    expected_c = np.array([1.1, 1.1, 2.2, 2.2, 0.0])
-    expected_d = np.array([0.0, 3.3, 3.3, 4.4, 4.4])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_input_validation():
-    """Test input validation for combine_bin_series."""
-    # Test mismatched array lengths
-    a = np.array([1.0, 2.0])
-    a_edges = np.array([0.0, 1.0])  # Should have 3 elements for 2 bins
-    b = np.array([3.0])
-    b_edges = np.array([1.0, 2.0])
-
-    with pytest.raises(ValueError, match="a_edges must have len\\(a\\) \\+ 1 elements"):
-        combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Test mismatched b array lengths
-    a = np.array([1.0])
-    a_edges = np.array([0.0, 1.0])
-    b = np.array([3.0, 4.0])
-    b_edges = np.array([1.0, 2.0])  # Should have 3 elements for 2 bins
-
-    with pytest.raises(ValueError, match="b_edges must have len\\(b\\) \\+ 1 elements"):
-        combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-
-def test_combine_bin_series_list_inputs():
-    """Test combine_bin_series with list inputs."""
-    a = [1.0, 2.0]
-    a_edges = [0.0, 1.0, 2.0]
-    b = [3.0, 4.0]
-    b_edges = [1.5, 2.5, 3.5]
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Should work with list inputs and return numpy arrays
-    assert isinstance(c, np.ndarray)
-    assert isinstance(c_edges, np.ndarray)
-    assert isinstance(d, np.ndarray)
-    assert isinstance(d_edges, np.ndarray)
-
-    # Expected combined edges: [0, 1, 1.5, 2, 2.5, 3.5]
-    expected_edges = np.array([0.0, 1.0, 1.5, 2.0, 2.5, 3.5])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-
-def test_combine_bin_series_negative_values():
-    """Test combine_bin_series with negative values."""
-    a = np.array([-5.0, -2.0])
-    a_edges = np.array([-10.0, -3.0, 0.0])
-    b = np.array([1.0, 4.0])
-    b_edges = np.array([-1.0, 2.0, 5.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [-10, -3, -1, 0, 2, 5]
-    expected_edges = np.array([-10.0, -3.0, -1.0, 0.0, 2.0, 5.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # Test correct mapping with negative values and broadcasting
-    expected_c = np.array([-5.0, -2.0, -2.0, 0.0, 0.0])
-    expected_d = np.array([0.0, 0.0, 1.0, 1.0, 4.0])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_empty_arrays():
-    """Test combine_bin_series with minimal valid inputs."""
-    a = np.array([42.0])
-    a_edges = np.array([0.0, 1.0])
-    b = np.array([24.0])
-    b_edges = np.array([0.5, 1.5])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-
-    # Expected combined edges: [0, 0.5, 1, 1.5]
-    expected_edges = np.array([0.0, 0.5, 1.0, 1.5])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    expected_c = np.array([42.0, 42.0, 0.0])
-    expected_d = np.array([0.0, 24.0, 24.0])
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_extrapolation_nearest():
-    """Test combine_bin_series with nearest extrapolation."""
-    a = np.array([1.0, 2.0])
-    a_edges = np.array([1.0, 2.0, 3.0])
-    b = np.array([10.0, 20.0])
-    b_edges = np.array([2.0, 3.0, 4.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation="nearest")
-
-    # Expected combined edges: [1, 2, 3, 4]
-    expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # With nearest extrapolation:
-    # c extends to all bins using nearest values
-    # d extends to all bins using nearest values
-    expected_c = np.array([1.0, 2.0, 2.0])  # nearest for [3,4] is a[1]=2.0
-    expected_d = np.array([10.0, 10.0, 20.0])  # nearest for [1,2] is b[0]=10.0
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_extrapolation_nan():
-    """Test combine_bin_series with nan extrapolation."""
-    a = np.array([1.0, 2.0])
-    a_edges = np.array([1.0, 2.0, 3.0])
-    b = np.array([10.0, 20.0])
-    b_edges = np.array([2.0, 3.0, 4.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=np.nan)
-
-    # Expected combined edges: [1, 2, 3, 4]
-    expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # With nan extrapolation:
-    # Out-of-range bins get nan values
-    expected_c = np.array([1.0, 2.0, np.nan])  # [3,4] is out of range for a
-    expected_d = np.array([np.nan, 10.0, 20.0])  # [1,2] is out of range for b
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_extrapolation_custom_value():
-    """Test combine_bin_series with custom extrapolation value."""
-    a = np.array([1.0, 2.0])
-    a_edges = np.array([1.0, 2.0, 3.0])
-    b = np.array([10.0, 20.0])
-    b_edges = np.array([2.0, 3.0, 4.0])
-
-    c, c_edges, d, d_edges = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=-999.0)
-
-    # Expected combined edges: [1, 2, 3, 4]
-    expected_edges = np.array([1.0, 2.0, 3.0, 4.0])
-    np.testing.assert_array_equal(c_edges, expected_edges)
-    np.testing.assert_array_equal(d_edges, expected_edges)
-
-    # With custom extrapolation value:
-    # Out-of-range bins get the custom value
-    expected_c = np.array([1.0, 2.0, -999.0])  # [3,4] is out of range for a
-    expected_d = np.array([-999.0, 10.0, 20.0])  # [1,2] is out of range for b
-    np.testing.assert_array_equal(c, expected_c)
-    np.testing.assert_array_equal(d, expected_d)
-
-
-def test_combine_bin_series_extrapolation_default_behavior():
-    """Test that default extrapolation preserves backwards compatibility."""
-    a = np.array([1.0, 2.0])
-    a_edges = np.array([1.0, 2.0, 3.0])
-    b = np.array([10.0, 20.0])
-    b_edges = np.array([2.0, 3.0, 4.0])
-
-    # Default behavior should be equivalent to extrapolation=0.0
-    c1, c_edges1, d1, d_edges1 = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges)
-    c2, c_edges2, d2, d_edges2 = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=0.0)
-
-    np.testing.assert_array_equal(c1, c2)
-    np.testing.assert_array_equal(d1, d2)
-    np.testing.assert_array_equal(c_edges1, c_edges2)
-    np.testing.assert_array_equal(d_edges1, d_edges2)
-
-
-def test_combine_bin_series_extrapolation_no_out_of_range():
-    """Test extrapolation when there are no out-of-range bins."""
-    a = np.array([1.0, 2.0])
-    a_edges = np.array([0.0, 1.0, 2.0])
-    b = np.array([3.0, 4.0])
-    b_edges = np.array([0.0, 1.0, 2.0])
-
-    # When series have identical ranges, extrapolation method shouldn't matter
-    c1, _, d1, _ = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation="nearest")
-    c2, _, d2, _ = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=np.nan)
-    c3, _, d3, _ = combine_bin_series(a=a, a_edges=a_edges, b=b, b_edges=b_edges, extrapolation=0.0)
-
-    np.testing.assert_array_equal(c1, c2)
-    np.testing.assert_array_equal(c1, c3)
-    np.testing.assert_array_equal(d1, d2)
-    np.testing.assert_array_equal(d1, d3)
 
 
 def test_get_soil_temperature_basic():
@@ -1592,7 +1234,7 @@ def test_compute_time_edges_explicit_tedges_roundtrip():
 def test_compute_time_edges_explicit_tedges_wrong_length():
     """tedges with the wrong length (not number_of_bins + 1) is rejected."""
     tedges = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"])
-    with pytest.raises(ValueError, match="tedges must have one more element than flow"):
+    with pytest.raises(ValueError, match="tedges must have one more element than number_of_bins"):
         compute_time_edges(tedges=tedges, tstart=None, tend=None, number_of_bins=5)
 
 
@@ -1607,7 +1249,7 @@ def test_compute_time_edges_tstart_extrapolates_final_edge():
 def test_compute_time_edges_tstart_wrong_length():
     """tstart length must equal number_of_bins."""
     tstart = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-03"])
-    with pytest.raises(ValueError, match="tstart must have the same number of elements as flow"):
+    with pytest.raises(ValueError, match="tstart must have the same number of elements as number_of_bins"):
         compute_time_edges(tedges=None, tstart=tstart, tend=None, number_of_bins=2)
 
 
@@ -1622,7 +1264,7 @@ def test_compute_time_edges_tend_extrapolates_initial_edge():
 def test_compute_time_edges_tend_wrong_length():
     """tend length must equal number_of_bins."""
     tend = pd.DatetimeIndex(["2020-01-02", "2020-01-03"])
-    with pytest.raises(ValueError, match="tend must have the same number of elements as flow"):
+    with pytest.raises(ValueError, match="tend must have the same number of elements as number_of_bins"):
         compute_time_edges(tedges=None, tstart=None, tend=tend, number_of_bins=3)
 
 
@@ -1846,3 +1488,209 @@ def test_simplify_bins_empty_with_flow_returns_empty_flow_array():
     assert new_flow is not None
     assert new_flow.dtype == np.float64
     assert len(new_flow) == 0
+
+
+# ---------------------------------------------------------------------------
+# U1: linear_average 2-D NaN contract is method-independent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("method", ["outer", "raise", "nan"])
+def test_linear_average_2d_nan_propagates_for_all_methods(method):
+    """The documented 2-D per-row NaN contract must hold for every extrapolate_method.
+
+    Regression: the per-row NaN-propagation block was nested under the ``'nan'`` branch, so
+    ``'outer'``/``'raise'`` zeroed the NaN trapezoids and returned a silently wrong finite
+    average (1.0) for a row containing an interior NaN. A row whose bin touches a NaN segment
+    must be NaN regardless of the extrapolation method; a clean row is unaffected.
+    """
+    x_data = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    y_data = np.array([[2.0, 2.0, 2.0, 2.0, 2.0], [2.0, 2.0, np.nan, 2.0, 2.0]])
+    x_edges = np.array([0.0, 4.0])
+    result = linear_average(x_data=x_data, y_data=y_data, x_edges=x_edges, extrapolate_method=method)
+    np.testing.assert_array_equal(result[0], [2.0])  # clean row: unaffected
+    assert np.isnan(result[1, 0])  # NaN-touching row: NaN, not the buggy 1.0
+
+
+# ---------------------------------------------------------------------------
+# U2: time_bin_overlap accepts pandas Timestamp / datetime64 bin_tedges
+# ---------------------------------------------------------------------------
+
+
+def test_time_bin_overlap_timestamp_bin_tedges():
+    """Timestamp tedges and Timestamp (start, end) tuples must work like the numeric case.
+
+    Regression: object arrays of Timestamps drove ``np.maximum(0, Timedelta)`` and raised
+    ``TypeError``. Ten-day bins mirror the numeric ``test_time_bin_overlap_basic`` case, so the
+    expected fractions are identical.
+    """
+    tedges = pd.DatetimeIndex(["2020-01-01", "2020-01-11", "2020-01-21", "2020-01-31"])
+    bin_tedges = [
+        (pd.Timestamp("2020-01-06"), pd.Timestamp("2020-01-16")),
+        (pd.Timestamp("2020-01-26"), pd.Timestamp("2020-02-05")),
+    ]
+    result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
+    np.testing.assert_allclose(result, [[0.5, 0.5, 0.0], [0.0, 0.0, 0.5]])
+
+
+def test_time_bin_overlap_timestamp_matches_datetime64_and_numeric():
+    """Timestamp, datetime64, and numeric inputs give bit-identical overlap fractions."""
+    numeric = time_bin_overlap(tedges=np.array([0, 10, 20, 30]), bin_tedges=[(5, 15), (25, 35)])
+    tedges_dt = pd.DatetimeIndex(["2020-01-01", "2020-01-11", "2020-01-21", "2020-01-31"])
+    bins_ts = [
+        (pd.Timestamp("2020-01-06"), pd.Timestamp("2020-01-16")),
+        (pd.Timestamp("2020-01-26"), pd.Timestamp("2020-02-05")),
+    ]
+    bins_dt64 = [(np.datetime64(a), np.datetime64(b)) for a, b in bins_ts]
+    np.testing.assert_array_equal(time_bin_overlap(tedges=tedges_dt, bin_tedges=bins_ts), numeric)
+    np.testing.assert_array_equal(time_bin_overlap(tedges=np.asarray(tedges_dt), bin_tedges=bins_dt64), numeric)
+
+
+# ---------------------------------------------------------------------------
+# U3: simplify_bins uses an iterative stack (no RecursionError) with identical splits
+# ---------------------------------------------------------------------------
+
+
+def _simplify_bins_recursive_reference(*, edges, values, flow=None, tol=0.0):
+    """Reference implementation using the original recursive _splits (pre-U3).
+
+    Reproduces the exact merged-bin outputs so the iterative-stack rewrite can be pinned
+    bit-for-bit on inputs shallow enough not to overflow the interpreter stack.
+    """
+    edges = np.asarray(edges) if not isinstance(edges, pd.DatetimeIndex) else edges
+    values = np.asarray(values, dtype=float)
+    widths = np.asarray(np.diff(edges), dtype=float)
+    weights = widths * np.asarray(flow, dtype=float) if flow is not None else widths
+
+    def _splits(lo, hi):
+        if np.ptp(values[lo:hi]) <= tol:
+            return []
+        i = lo + int(np.argmax(np.abs(np.diff(values[lo:hi])))) + 1
+        return [*_splits(lo, i), i, *_splits(i, hi)]
+
+    s = np.array([0, *_splits(0, len(values))])
+    idx = np.append(s, len(values))
+    new_edges = edges[idx]
+    new_widths = np.add.reduceat(widths, s)
+    weight_sums = np.add.reduceat(weights, s)
+    new_values = np.add.reduceat(weights * values, s) / weight_sums
+    new_flow = weight_sums / new_widths if flow is not None else None
+    return new_edges, new_values, new_flow
+
+
+def test_simplify_bins_no_recursion_error_on_smooth_monotone():
+    """A smooth monotone breakthrough (logistic, n=2500) must not overflow the stack.
+
+    Regression: the recursive splitter peeled one element per level on monotone data whose
+    largest |diff| sits at a segment edge, raising RecursionError. The iterative stack removes
+    the depth limit; the result is a valid, non-trivial simplification.
+    """
+    n = 2500
+    values = 1.0 / (1.0 + np.exp(-np.linspace(-6.0, 6.0, n)))
+    edges = np.arange(n + 1, dtype=float)
+    new_edges, new_values, _ = simplify_bins(edges=edges, values=values, tol=0.0)
+    # tol=0 merges only runs of identical values; the strictly increasing logistic has none,
+    # so no bins merge and the series is returned intact.
+    assert len(new_values) == n
+    np.testing.assert_array_equal(new_edges, edges)
+
+
+def test_simplify_bins_iterative_matches_recursive_reference():
+    """The iterative stack reproduces the recursive splitter's merged bins bit-for-bit.
+
+    Uses a non-monotone series with a non-trivial merge structure and volume weighting so the
+    split indices, merged values, and merged flow are all exercised on a case shallow enough
+    for the recursive reference to run.
+    """
+    edges = np.array([0.0, 1.0, 3.0, 6.0, 6.5, 8.0, 11.0, 12.0])
+    values = np.array([1.0, 1.0, 1.0, 5.0, 5.2, 2.0, 2.0])
+    flow = np.array([2.0, 4.0, 1.0, 3.0, 0.5, 2.5, 1.5])
+    for tol in (0.0, 0.5):
+        e_new, v_new, f_new = simplify_bins(edges=edges, values=values, flow=flow, tol=tol)
+        e_ref, v_ref, f_ref = _simplify_bins_recursive_reference(edges=edges, values=values, flow=flow, tol=tol)
+        np.testing.assert_array_equal(e_new, e_ref)
+        np.testing.assert_array_equal(v_new, v_ref)
+        np.testing.assert_array_equal(f_new, f_ref)
+
+
+# ---------------------------------------------------------------------------
+# U4: banded WᵀW assembly (dense BLAS build) equivalence
+# ---------------------------------------------------------------------------
+
+
+def test_solve_inverse_transport_banded_wtw_assembly_matches_add_at_reference():
+    """The dense-BLAS WᵀW build equals the per-diagonal np.add.at scatter (atol 1e-12).
+
+    Forming WᵀW with a matmul reorders the summation relative to np.add.at, so the two agree
+    to ~1e-13 rather than bit-for-bit; pin the equivalence at atol 1e-12.
+    """
+    rng = np.random.default_rng(0)
+    n_obs, full_band, n_output = 60, 9, 45
+    band_vals = rng.random((n_obs, full_band))
+    col_start = rng.integers(0, n_output - full_band, size=n_obs).astype(np.intp)
+    cols = col_start[:, None] + np.arange(full_band)[None, :]
+    in_range = cols < n_output
+    cols_clipped = np.clip(cols, 0, n_output - 1)
+
+    # Reference: original per-diagonal add.at assembly of the lower banded WᵀW.
+    ab_ref = np.zeros((full_band, n_output))
+    for d in range(full_band):
+        prod = band_vals[:, d:] * band_vals[:, : full_band - d]
+        c = cols_clipped[:, : full_band - d]
+        m = in_range[:, : full_band - d] & in_range[:, d:]
+        np.add.at(ab_ref[d], c[m], prod[m])
+
+    # New path: dense W build, one BLAS matmul, sub-diagonal extraction.
+    w_dense = np.zeros((n_obs, n_output))
+    obs_idx = np.broadcast_to(np.arange(n_obs)[:, None], cols.shape)
+    w_dense[obs_idx[in_range], cols_clipped[in_range]] = band_vals[in_range]
+    gram = w_dense.T @ w_dense
+    ab_new = np.zeros((full_band, n_output))
+    for d in range(full_band):
+        ab_new[d, : n_output - d] = np.diagonal(gram, offset=-d)
+
+    np.testing.assert_allclose(ab_new, ab_ref, atol=1e-12)
+
+
+def test_solve_inverse_transport_banded_matches_dense_solver():
+    """The banded solver reproduces the dense solve_inverse_transport on a random band.
+
+    End-to-end guard that the dense-BLAS assembly leaves the recovered signal unchanged: the
+    banded Cholesky + semi-normal refinement matches the dense least-squares solution to ~1e-10
+    on the shared active columns (and the NaN pattern is identical).
+    """
+    rng = np.random.default_rng(3)
+    n_obs, full_band, n_output = 80, 11, 60
+    band_vals = rng.random((n_obs, full_band))
+    band_vals /= band_vals.sum(axis=1, keepdims=True)  # precondition: valid rows sum to 1
+    col_start = rng.integers(0, n_output - full_band, size=n_obs).astype(np.intp)
+    observed = rng.random(n_obs)
+    lam = 1e-3
+
+    cols = col_start[:, None] + np.arange(full_band)[None, :]
+    in_range = cols < n_output
+    cols_clipped = np.clip(cols, 0, n_output - 1)
+    obs_idx = np.broadcast_to(np.arange(n_obs)[:, None], cols.shape)
+    w_dense = np.zeros((n_obs, n_output))
+    w_dense[obs_idx[in_range], cols_clipped[in_range]] = band_vals[in_range]
+
+    x_banded = solve_inverse_transport_banded(
+        band_vals=band_vals, col_start=col_start, observed=observed, n_output=n_output, regularization_strength=lam
+    )
+    x_dense = solve_inverse_transport(
+        w_forward=w_dense, observed=observed, n_output=n_output, regularization_strength=lam
+    )
+    np.testing.assert_array_equal(np.isnan(x_banded), np.isnan(x_dense))
+    active = ~np.isnan(x_banded)
+    np.testing.assert_allclose(x_banded[active], x_dense[active], atol=1e-9)
+
+
+def test_solve_inverse_transport_banded_rejects_nonpositive_lambda():
+    """λ <= 0 cannot make the banded Cholesky positive definite, so it is rejected."""
+    band_vals = np.ones((3, 2))
+    col_start = np.array([0, 1, 2], dtype=np.intp)
+    observed = np.ones(3)
+    with pytest.raises(ValueError, match="regularization_strength must be > 0"):
+        solve_inverse_transport_banded(
+            band_vals=band_vals, col_start=col_start, observed=observed, n_output=4, regularization_strength=0.0
+        )

--- a/tests/src/test_validation.py
+++ b/tests/src/test_validation.py
@@ -14,6 +14,7 @@ from gwtransport._validation import (
     _validate_non_negative_array,
     _validate_positive_array,
     _validate_positive_scalar,
+    _validate_retardation_factor,
     _validate_scalar_or_matching_length,
     _validate_tedges_parity,
 )
@@ -92,6 +93,13 @@ def test_non_negative_array_rejects_override_message():
         )
 
 
+@pytest.mark.parametrize("bad", [np.inf, np.nan])
+def test_non_negative_array_rejects_non_finite(bad):
+    """NaN and +inf pass every ``< 0`` comparison; the atom must still reject them."""
+    with pytest.raises(ValueError, match="molecular_diffusivity must be non-negative"):
+        _validate_non_negative_array(np.array([0.0, bad]), name="molecular_diffusivity")
+
+
 # ---------------------------------------------------------------------------
 # _validate_positive_array
 # ---------------------------------------------------------------------------
@@ -112,6 +120,13 @@ def test_positive_array_rejects_negative():
         _validate_positive_array(np.array([1.0, -0.5]), name="streamline_length")
 
 
+@pytest.mark.parametrize("bad", [np.inf, np.nan])
+def test_positive_array_rejects_non_finite(bad):
+    """NaN and +inf pass every ``<= 0`` comparison; the atom must still reject them."""
+    with pytest.raises(ValueError, match="aquifer_pore_volumes must be positive"):
+        _validate_positive_array(np.array([1.0, bad]), name="aquifer_pore_volumes")
+
+
 # ---------------------------------------------------------------------------
 # _validate_positive_scalar
 # ---------------------------------------------------------------------------
@@ -130,6 +145,13 @@ def test_positive_scalar_rejects_override_message():
     """Module wrappers preserve historical capitalized phrasings via ``message=``."""
     with pytest.raises(ValueError, match=r"Thickness must be positive, got -1\.0"):
         _validate_positive_scalar(-1.0, name="thickness", message="Thickness must be positive, got -1.0")
+
+
+@pytest.mark.parametrize("bad", [np.inf, np.nan])
+def test_positive_scalar_rejects_non_finite(bad):
+    """NaN and +inf are neither ``<= 0``; the atom must still reject them."""
+    with pytest.raises(ValueError, match="thickness must be positive"):
+        _validate_positive_scalar(bad, name="thickness")
 
 
 # ---------------------------------------------------------------------------
@@ -153,3 +175,21 @@ def test_scalar_or_matching_length_rejects_wrong_length():
         _validate_scalar_or_matching_length(
             arr, name="molecular_diffusivity", expected_len=3, ref_name="aquifer_pore_volumes"
         )
+
+
+# ---------------------------------------------------------------------------
+# _validate_retardation_factor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("good", [1.0, 1.5, 100.0, np.inf])
+def test_retardation_factor_silent_on_ge_one(good):
+    """Any value ``>= 1`` (including +inf) is physical and must pass silently."""
+    _validate_retardation_factor(good)
+
+
+@pytest.mark.parametrize("bad", [0.0, 0.5, 0.999, np.nan])
+def test_retardation_factor_rejects_below_one_and_nan(bad):
+    """Values ``< 1`` and NaN both fail ``>= 1``; the atom must reject them."""
+    with pytest.raises(ValueError, match=r"retardation_factor must be >= 1\.0"):
+        _validate_retardation_factor(bad)


### PR DESCRIPTION
## Summary

Resolves the confirmed findings of the 2026-07-05 full-library review (`REVIEW_2026-07-05.md`): all correctness bugs plus the vetted leanness/performance improvements and nits, across every module. Each fix was written test-first (regression test confirmed failing on the pre-fix baseline), gated by a physics-math review, and the criticals were re-verified by an **independent FV/analytic oracle** (Godunov/Rusanov solvers validated to 0.02% against analytic Riemann shock speeds), not by trusting the added tests.

### Correctness fixes (critical/major)

- **deposition**: extracted concentration no longer scales with the retardation factor R — steady-state areal mass balance `Q·cout = dep·A_plan` is now R-independent (was off by exactly ×R for R>1). Verified mass-conserving to 1e-15 and forward/reverse adjoint-consistent. (The completeness-critic's "reverse inconsistency at R=2" was shown to be a false positive — the square integer-`RT/dt` deconvolution nullspace, not an operator bug.)
- **radial_asr**: (1) multi-cycle no longer silently returns `cout=0` at high Peclet (log-space Airy resolvent removes the overflow→NaN→`nan_to_num`→0 chain; recovered fraction is now monotone as dispersion drops); (2) the rest phase (Q=0, D_m>0) no longer collapses to background (de Hoog quotient-difference underflow guarded; rest propagator finite).
- **diffusion**: adaptive quadrature restores the documented machine-precision flux-weighted column-mass conservation for sharp fronts under variable flow (fixed 16-point Gauss–Legendre gave up to ~13% mass error at near-zero dispersivity; now ~1e-11), while leaving resolved regimes unchanged.
- **diffusion_fast_fast**: the molecular time-Gaussian no longer smears zero-through-flow (pump-off) bins into valid neighbours (was 13–38% error near gaps); constants are preserved exactly across gaps.
- **advection** (nonlinear sorption): no longer crashes on interior zero-flow bins or on `cout_tedges` starting before `tedges[0]`; graceful NaN/0 boundary convention matching the linear path.
- **residence_time**: the zero-throughflow (degenerate) `gamma()` branch now honors the spin-up policy; negative/NaN flow refusal documented.
- **fronttracking** (growing-decay DSW): `theta_at_fan_exhaustion` handles the growing-decay orientation and the numerical-path exhaustion/outlet-crossing inversions (removed a hidden dimensional `1.0 m³` bracket floor).
- **utils**: `simplify_bins` no longer hits `RecursionError` on smooth monotone breakthrough curves (iterative split); several NaN/validation-contract fixes.
- Plus the minor/nit correctness and doc-truth fixes across gamma, logremoval, percolation, recharge, examples, and cross-module API/boundary consistency (see the review report for the full list).

### Front-tracking multi-front interaction — deferred with an honest guard

The review's two front-tracking criticals (multi-peak and the plateau-at-larger-V) share one root cause: the solver does not resolve wave–wave **interactions** (a faster shock overtaking another shock, rarefaction, or decaying-shock fan), so the public `cout` is the linear superposition of the isolated single-front responses — wrong for a nonlinear operator. A robust fix is solver-level and is tracked in #294. As an honest interim (no silently-wrong output), interacting multi-front inputs now **raise `NotImplementedError`**; single-front / non-interacting / well-separated-early-breakthrough inputs are unaffected and verified against the FV oracle (outlet mass within ~0.1%). Detection is dual: geometric fan overlap plus a cumulative-outlet-mass monotonicity check (mass exits, never re-enters).

### Performance / leanness (all verified equivalent)

Measured, equivalence-checked improvements: diffusion_fast ~3× (union-band + shared-edge erf); the inverse-solve `WtW` assembly ~24× via BLAS; radial reverse propagator reuse and the rest-propagator Bessel precompute (~22×); recharge exp-halving and errstate hoist; residence_time degenerate-branch guard; plus the vetted nits (dead-code removal, redundant-op binding, one-path collapses). `combine_bin_series` (dead) removed; other deletions are listed in the commits.

## Test plan

```bash
env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src -n auto      # unit tests
env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q ruff format . && ruff check .  # lint
uv tool run -q ty check .                                                        # types
```

- Full `tests/src` green (unit + radial + drift), including new regression tests for every fix.
- Independent FV/analytic oracle re-verification of all criticals (deposition R-independence 1e-15; diffusion sharp-front mass 1e-11; diffusion_fast_fast gap 1e-15; radial monotone recovery + rest echo; advection boundaries; front-tracking interaction gate matrix).
- `ty` clean; `ruff` clean.

Also included from the review's §7 follow-up investigations: the package-wide NaN/inf-blind validator hardening (a coherent extension of the confirmed percolation validation bug), and the utils leanness cleanup (dead `combine_bin_series` removed, the `partial_isin` test oracle relocated to `tests/src/_oracles.py`).

Not included (deferred): the solver-level front-tracking wave-interaction fix (#294).

## Contributor License Agreement

- [x] I have read the CLA and I agree to its terms for this and all future contributions I make to gwtransport.
