### PR TITLE
fix(residence_time): clip degenerate-branch first moment; NaN on all-zero flow (#308, #313, #314)

### DIFF
--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -402,8 +402,9 @@ def full(
     # Sign convention: sign = -1 for extraction_to_infiltration, +1 for infiltration_to_extraction;
     # the look-back/forward parcel sits at volume V + shift and tau(V) = sign * (T(V + shift) - T(V)) is
     # piecewise-linear in V (T is the volume -> time map). Its flow-weighted bin average is a closed-
-    # form difference of the antiderivative phi(x) = int_0^x T(w) dw, so no per-streamtube integration
-    # grid is built (memory/time O(n_pore_volumes * n_bins), not O(n_pore_volumes^2 * n_flow)).
+    # form difference of an antiderivative phi with phi' = T (any additive constant cancels in the
+    # difference below; over the extrapolated map T is the extended map), so no per-streamtube
+    # integration grid is built (memory/time O(n_pore_volumes * n_bins), not O(n_pore_volumes^2 * n_flow)).
     sign = -1.0 if direction == "extraction_to_infiltration" else 1.0
     shift = sign * retardation_factor * aquifer_pore_volumes  # (n_pv,)
 
@@ -569,10 +570,10 @@ def mean(
     n_streamtubes = rt.shape[0]
     valid_count = np.isfinite(rt).sum(axis=0)
     with np.errstate(invalid="ignore"):
-        mean = np.nansum(rt, axis=0) / valid_count
+        bin_mean = np.nansum(rt, axis=0) / valid_count
     if threshold > 0.0:
-        mean = np.where(valid_count >= threshold * n_streamtubes, mean, np.nan)
-    return mean
+        bin_mean = np.where(valid_count >= threshold * n_streamtubes, bin_mean, np.nan)
+    return bin_mean
 
 
 def gamma(
@@ -679,10 +680,17 @@ def gamma(
     Notes
     -----
     With the default ``spinup='constant'`` the spin-up is warm-started exactly as in
-    :func:`mean` (constant-boundary-flow extrapolation), so the two agree everywhere. With
+    :func:`mean` (constant-boundary-flow extrapolation) -- the same warm-start policy applies across
+    the whole distribution (``mean`` discretizes it, ``gamma`` integrates it in closed form). With
     ``spinup=0.0`` the spin-up is instead handled by exact covered-sub-mass renormalization: each
     output bin integrates over only the pore-volume sub-range with sufficient flow history. See the
     module docstring (``Spin-up period``) for the full rule.
+
+    The closed form uses regularized incomplete-gamma CDFs. For an extremely narrow APVD
+    (``alpha = (mean / std) ** 2`` above ~1e7, i.e. ``std / mean`` below ~3e-4) SciPy's incomplete
+    gamma loses precision in its far tail and the result degrades to ~1e-5 relative; such a
+    distribution is effectively a single pore volume, so :func:`mean` with one bin is the exact
+    alternative there.
 
     Examples
     --------
@@ -904,7 +912,11 @@ def gamma(
         # whose look-back/forward parcel leaves the record (e2i: v - r*V_p < 0, i2e: v + r*V_p >
         # v_end) is in spin-up, so integrate only the covered sub-range [support_lo, vp_hi] and let the
         # covered sub-mass renormalize the mean (den_pt below), keeping the parcel inside the raw phi map.
-        if extrapolate:
+        # Warm-start the full support only when the phi map was actually extended -- i.e. there is a
+        # positive boundary flow to extrapolate from (matching full's `strict`). With all-zero flow the
+        # map stays the raw record (see _phi_setup), so an out-of-record parcel is in spin-up (-> NaN);
+        # the raw `extrapolate` flag alone would instead clamp it to a finite pointwise value (RT-P2).
+        if extrapolate and bool(np.any(flow > 0.0)):
             vp_hi = np.full(v.shape, support_hi)
         else:
             vp_hi = np.clip((v if sign < 0 else v_end - v) / r, support_lo, support_hi)
@@ -925,7 +937,16 @@ def gamma(
         cdf_pt = edges_pt - loc
         m0_pt = np.diff(gamma_dist.cdf(cdf_pt, alpha, scale=beta), axis=1)
         m1_pt = alpha * beta * np.diff(gamma_dist.cdf(cdf_pt, alpha + 1, scale=beta), axis=1) + loc * m0_pt
-        num_pt = (tau_mid * m0_pt + slope * (m1_pt - mid_pt * m0_pt)).sum(axis=1)
+        # Clip the piece-centred first moment mu1 = int (V_p - mid) f to its exact geometric bound
+        # |mu1| <= half * m0, mirroring the main loop's mu1 clip above. On a piece whose V_p sweep
+        # crosses another zero-flow plateau, the raw (m1 - mid m0) subtracts large near-equal terms and
+        # catastrophically cancels; the large piecewise slope (~ r / ulp-bump) then amplifies the noise
+        # into a spurious residence-time contribution. Only mu1 is needed here: tau is piecewise-linear
+        # in V_p (no quadratic mu2 term).
+        b0_pt = np.maximum(m0_pt, 0.0)
+        half_pt = 0.5 * (hi_pt - lo_pt)
+        mu1_pt = np.clip(m1_pt - mid_pt * m0_pt, -half_pt * b0_pt, half_pt * b0_pt)
+        num_pt = (tau_mid * m0_pt + slope * mu1_pt).sum(axis=1)
         den_pt = m0_pt.sum(axis=1)  # covered sub-mass over [support_lo, vp_hi]
         covered_pt = den_pt > 0
         if spinup_threshold > 0.0:

--- a/tests/src/test_residence_time.py
+++ b/tests/src/test_residence_time.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from gwtransport.gamma import bins as gamma_bins
 from gwtransport.residence_time import (
     fraction_explained_full,
     fraction_explained_gamma,
@@ -355,6 +356,87 @@ def test_gamma_zero_flow_output_bins_match_full_oracle():
         # Narrow gamma (std=0.1) ~ single pore volume at the mean, so it tracks the full oracle.
         valid = np.isfinite(got) & np.isfinite(ref)
         np.testing.assert_allclose(got[valid], ref[valid], atol=0.05)
+
+
+def test_gamma_zero_flow_multi_shutdown_wide_apvd_matches_discretized_mean():
+    """RT-P1 (issue #308): gamma()'s zero-throughflow branch must clip the piece-centred first moment.
+
+    The existing single-gap / narrow-gamma / atol=0.05 regression above cannot catch this: the missing
+    clip is a no-op unless a zero-flow plateau's V_p-image lands near the gamma density peak (needs a
+    *wide* APVD) and the cancellation compounds across *several separated* shutdowns. Without the clip
+    the degenerate branch used the centred first moment ``m1 - mid*m0`` raw; on a piece whose V_p sweep
+    crosses another shutdown's near-vertical flow_cum plateau, the ~r/ulp-bump slope amplifies the
+    ~mid*eps cancellation noise into a spurious ~1e-3 residence-time contribution.
+
+    Oracle: ``mean`` over a fine equal-probability discretization of the *same* gamma (an independent
+    code path). Its discretization floor is ~1.7e-5 here (measured on the non-zero-flow bins, which use
+    the already-correct main loop); the pre-fix defect is ~9e-4, so rtol=1e-4 catches it with a 9x
+    margin while clearing the oracle floor with a 6x margin. Baseline-verified: fails at ~9e-4 without
+    the clip.
+    """
+    n = 120
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    shutdowns = [15, 40, 70, 100]  # >= 2 *separated* zero-flow bins (not one contiguous gap)
+    flow[shutdowns] = 0.0
+    mean_v, std_v, loc_v = 700.0, 400.0, 0.0  # wide APVD: std comparable to mean
+    ref_bins = gamma_bins(mean=mean_v, std=std_v, loc=loc_v, n_bins=4000)
+    for direction in DIRECTIONS:
+        got = gamma(
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            mean=mean_v,
+            std=std_v,
+            loc=loc_v,
+            direction=direction,
+            spinup="constant",
+        )
+        ref = mean(
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=ref_bins["expected_values"],
+            direction=direction,
+            spinup="constant",
+        )
+        valid = np.isfinite(got) & np.isfinite(ref)
+        # Fixture sanity: the shutdown bins must be among the emitted (finite) bins, else the test is vacuous.
+        assert valid[shutdowns].all(), f"{direction}: shutdown bins are not finite; fixture no longer exercises RT-P1"
+        np.testing.assert_allclose(got[valid], ref[valid], rtol=1e-4, atol=0.0)
+
+
+@pytest.mark.parametrize("direction", DIRECTIONS)
+def test_gamma_all_zero_flow_is_all_nan(direction):
+    """RT-P2 (issue #313): gamma(spinup='constant') with all-zero flow must be all-NaN, like full/mean.
+
+    With no positive boundary flow the cumulative-volume->time map cannot be extrapolated, so every
+    look-back leaves the record and is in spin-up. ``full`` returns NaN; before the fix ``gamma``'s
+    degenerate branch keyed its warm-start on the raw ``extrapolate`` flag and clamped the out-of-record
+    parcel to a finite pointwise value (``+-t_mid``, e.g. [0.5, 1.5, 2.5, ...]) instead. Baseline-verified.
+    """
+    n = 10
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.zeros(n)
+    got = gamma(
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        mean=300.0,
+        std=50.0,
+        direction=direction,
+        spinup="constant",
+    )
+    ref = full(
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        aquifer_pore_volumes=np.array([300.0]),
+        direction=direction,
+        spinup="constant",
+    )[0]
+    assert np.all(np.isnan(ref)), "oracle sanity: full() must be all-NaN for all-zero flow"
+    assert np.all(np.isnan(got)), f"{direction}: all-zero-flow gamma() must be all-NaN, got {got}"
 
 
 @pytest.mark.parametrize("func_name", list(_RESIDENCE_FUNCS))


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in `residence_time.gamma()`'s zero-throughflow (Q=0 output-bin) degenerate branch, found in the 2026-07-12 review.

- **RT-P1 (#308, major)** — the degenerate branch computed the piece-centred first moment `m1 - mid*m0` **raw**, omitting the catastrophic-cancellation clip that the main loop applies (`np.clip(m1 - mid*m0, -half*b0, half*b0)`). On a piece whose `V_p` sweep crosses *another* zero-flow bin's near-vertical `flow_cum` plateau, the piecewise slope `~ r/ulp-bump ~ 8e10 day/m³` amplifies the `~mid·eps` cancellation noise into a spurious residence-time contribution. Result: `gamma()` was silently wrong by **~0.1–0.4 %** at zero-flow output bins whenever the record has **≥2 separated** shutdowns and the APVD is **wide** — under the default `spinup='constant'`. The existing regression test misses it (single contiguous gap + narrow `std=0.1` gamma + `atol=0.05`). Fix mirrors the main-loop `mu1` clip (only `mu1` is needed — `tau` is piecewise-linear here, no `mu2` term).

- **RT-P2 (#313, minor)** — the same branch keyed its warm-start on the raw `extrapolate` flag, so all-zero flow returned finite garbage (`±t_mid`, e.g. `[0.5, 1.5, 2.5, …]`) instead of NaN. With no positive boundary flow the `phi` map cannot be extended (see `_phi_setup`), so an out-of-record parcel is genuinely in spin-up. Fix gates the warm-start on `any(flow > 0)`, matching `full()`'s `strict` logic — all-zero flow now returns NaN like `full`/`mean`.

Both fixes are surgical (mirroring existing, reviewed patterns) and affect only the zero-flow-bin path; every non-degenerate bin is untouched.

## Test plan

Baseline-first (per repo policy): both new tests **fail on the unmodified baseline and pass with the fix**.

- `test_gamma_zero_flow_multi_shutdown_wide_apvd_matches_discretized_mean` (RT-P1): ≥2 separated shutdowns + wide gamma (mean 700, std 400); oracle = `mean()` over a 4000-bin equal-probability discretization of the same gamma (independent code path). Baseline error ~9e-4 at the shutdown bins; fixed ~1e-5 (the oracle's discretization floor, same as the already-correct non-zero-flow bins). `rtol=1e-4` (9× under the bug, 6× over the floor).
- `test_gamma_all_zero_flow_is_all_nan` (RT-P2): all-zero flow → all-NaN, matching `full()`.

Additional verification (not in the suite):
- **Convergence proof** the fix is the true continuum limit: refining the oracle 4× (n_bins 2000→8000→32000→128000) shrinks the zero-flow-bin gap ~4× each step (3.4×/3.7×/4.5×), i.e. the remaining gap is entirely the oracle's discretization error → the fixed `gamma()` is what the discretized mean converges to.
- Full `tests/src` suite green; `ruff format`/`ruff check` clean; `ty check` passes (the pre-existing `tedges_to_days` items are unrelated and predate this change).

Held for review; not merged.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
