### PR TITLE
feat(fronttracking): resolve multi-front wave interactions (nonlinear sorption) (#294)

### DIFF
--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -1081,6 +1081,31 @@ def _validate_front_tracking_inputs(
     return cin, flow, tedges, cout_tedges, aquifer_pore_volumes, sorption, cout_tedges_days
 
 
+def _theta_at_last_output_edge(
+    cout_tedges_days: npt.NDArray[np.floating],
+    flow_tedges_days: npt.NDArray[np.floating],
+    flow: npt.NDArray[np.floating],
+) -> float:
+    """Cumulative flow θ at the last requested output edge (the interaction-resolution horizon).
+
+    Piecewise-linear ``t → θ`` map (identical to ``FrontTrackerState.theta_at_t``),
+    extrapolating the final-bin flow when the output window extends past the flow record.
+
+    Returns
+    -------
+    float
+        Cumulative flow θ [m³] at ``cout_tedges_days[-1]``.
+    """
+    theta_edges = np.concatenate(([0.0], np.cumsum(flow * np.diff(flow_tedges_days))))
+    t = float(cout_tedges_days[-1])
+    if t <= flow_tedges_days[0]:
+        return float(theta_edges[0])
+    if t >= flow_tedges_days[-1]:
+        return float(theta_edges[-1] + (t - flow_tedges_days[-1]) * float(flow[-1]))
+    i = int(np.searchsorted(flow_tedges_days, t, side="right")) - 1
+    return float(theta_edges[i] + (t - flow_tedges_days[i]) * float(flow[i]))
+
+
 def _flow_weighted_front_tracking_output(
     cout_tedges_days: npt.NDArray[np.floating],
     flow_tedges_days: npt.NDArray[np.floating],
@@ -1290,6 +1315,13 @@ def infiltration_to_extraction_nonlinear_sorption(
         - 'tracker_state': FrontTrackerState - Complete simulation state
         - 'aquifer_pore_volume': float - Pore volume for this simulation
 
+    Raises
+    ------
+    RuntimeError
+        If the front-tracking solver leaves an unresolved wave interaction (the domain-mass
+        field over-counts stored mass). This is an internal-consistency tripwire, not an
+        input limitation — every wave interaction is now composed; a firing indicates a bug.
+
     See Also
     --------
     infiltration_to_extraction : Convolution-based approach for linear retardation
@@ -1350,6 +1382,11 @@ def infiltration_to_extraction_nonlinear_sorption(
     cout_sum = np.zeros(len(cout_tedges) - 1)
     structures = []
 
+    # Resolve wave interactions out to the last requested output edge (extrapolating the
+    # final-bin flow if the output window extends past the flow record), so beyond-outlet
+    # merges that still feed an in-window outlet query are composed.
+    theta_horizon = _theta_at_last_output_edge(cout_tedges_days, flow_tedges_days, flow)
+
     for aquifer_pore_volume in aquifer_pore_volumes:
         tracker = FrontTracker(
             cin=cin,
@@ -1357,28 +1394,25 @@ def infiltration_to_extraction_nonlinear_sorption(
             tedges=tedges,
             aquifer_pore_volume=aquifer_pore_volume,
             sorption=sorption,
+            theta_horizon=theta_horizon,
         )
 
         tracker.run(max_iterations=max_iterations)
 
-        # The front tracker resolves shock↔shock / shock↔rarefaction collisions but not a
-        # later front overtaking an existing decaying-shock fan (or two fans composing). Such
-        # an unresolved interaction makes the public cout a spurious linear superposition of a
-        # nonlinear operator — non-conservative and silently wrong — so refuse it. The detector
-        # combines a geometric fan-overlap scan with a cumulative-outlet-mass monotonicity check
-        # (the latter catches the multi-pulse shock-overtakes-fan class whose fans never share an
-        # in-domain point); see find_unresolved_interaction.
+        # The solver now resolves every wave interaction (shock↔shock, fan-entry, doubly-fed
+        # formation, same-apex annihilation and their compositions), so the wave list is
+        # interaction-consistent and the single-owner reader is exact. This detector is now a
+        # tripwire: a firing means the solver left an unresolved interaction (an internal bug),
+        # not an unsupported input — fail loud rather than return a silently wrong cout.
         interaction = find_unresolved_interaction(tracker.state)
         if interaction is not None:
             msg = (
-                "infiltration_to_extraction_nonlinear_sorption: input produces interacting fronts "
-                f"(a shock overtakes another shock / rarefaction / decaying-shock fan within the "
-                f"transport domain: {interaction}); exact multi-front interaction is not yet "
-                "implemented. Use non-interacting inputs — a single front, or well-separated pulses "
-                "whose fronts break through before they overtake one another — or track "
-                "https://github.com/gwtransport/gwtransport/issues/294 for exact multi-front interaction support."
+                "infiltration_to_extraction_nonlinear_sorption: the front-tracking solver left an "
+                f"unresolved wave interaction ({interaction}). This is an internal inconsistency; "
+                "please report it with the cin/flow/pore-volume inputs at "
+                "https://github.com/gwtransport/gwtransport/issues."
             )
-            raise NotImplementedError(msg)
+            raise RuntimeError(msg)
 
         cout_sum += _flow_weighted_front_tracking_output(
             cout_tedges_days=cout_tedges_days,

--- a/src/gwtransport/fronttracking/events.py
+++ b/src/gwtransport/fronttracking/events.py
@@ -19,7 +19,13 @@ from dataclasses import dataclass
 from enum import Enum
 
 from gwtransport.fronttracking.math import characteristic_position, characteristic_speed
-from gwtransport.fronttracking.waves import CharacteristicWave, DecayingShockWave, RarefactionWave, ShockWave
+from gwtransport.fronttracking.waves import (
+    CharacteristicWave,
+    DecayingShockWave,
+    DoubleFanShockWave,
+    RarefactionWave,
+    ShockWave,
+)
 
 # Numerical tolerance constants
 EPSILON_SPEED = 1e-15  # Tolerance for checking if two speeds are equal (machine precision)
@@ -75,6 +81,11 @@ class EventType(Enum):
     """Rarefaction boundary intersects with another rarefaction boundary."""
     DSW_FAN_EXHAUSTED = "decaying_shock_fan_exhausted"
     """A decaying shock's fan is exhausted (c_decay reached c_fan_tail)."""
+    WAVE_MERGE = "wave_merge"
+    """Two faces overtake (universal merge): any interaction involving a decaying/doubly-fed
+    shock — fan-entry, doubly-fed formation, same-apex annihilation, and their compositions."""
+    DFSW_SIDE_EXHAUSTED = "double_fan_side_exhausted"
+    """A doubly-fed shock's fan side reaches its far bound (degrades to a decaying shock/shock)."""
     OUTLET_CROSSING = "outlet_crossing"
     """Wave crosses outlet boundary."""
 
@@ -106,6 +117,7 @@ class Event:
     waves_involved: list  # List[Wave] - can't type hint due to circular import
     location: float
     boundary_type: str | None = None
+    faces: tuple | None = None  # (Face, Face) for WAVE_MERGE; ('left'|'right',) side for DFSW_SIDE_EXHAUSTED
 
     def __repr__(self):  # noqa: D105
         return (
@@ -343,8 +355,8 @@ def find_outlet_crossing(wave, v_outlet: float, theta_current: float) -> float |
         dtheta = (v_outlet - v_current) / wave.speed
         return theta_eval + dtheta
 
-    if isinstance(wave, DecayingShockWave):
-        # Closed-form inverse V_s(theta) = v_outlet.
+    if isinstance(wave, (DecayingShockWave, DoubleFanShockWave)):
+        # Closed-form / cached-trajectory inverse V_s(theta) = v_outlet.
         theta_cross = wave.outlet_crossing_theta(v_outlet)
         if theta_cross is None:
             return None

--- a/src/gwtransport/fronttracking/handlers.py
+++ b/src/gwtransport/fronttracking/handlers.py
@@ -404,6 +404,7 @@ def create_inlet_waves_at_theta(
                 v_start=0.0,
                 concentration=c_new,
                 sorption=sorption,
+                c_ahead=c_prev,
             )
         ]
 
@@ -439,5 +440,6 @@ def create_inlet_waves_at_theta(
             v_start=0.0,
             concentration=c_new,
             sorption=sorption,
+            c_ahead=c_prev,
         )
     ]

--- a/src/gwtransport/fronttracking/interactions.py
+++ b/src/gwtransport/fronttracking/interactions.py
@@ -1,0 +1,451 @@
+"""Wave–wave interaction resolution for multi-front nonlinear-sorption transport.
+
+The event-driven solver in :mod:`gwtransport.fronttracking.solver` resolves collisions among
+characteristics, shocks and rarefactions with the closed-form helpers in
+:mod:`gwtransport.fronttracking.events`. This module adds the missing interaction classes —
+anything a :class:`~gwtransport.fronttracking.waves.DecayingShockWave` or
+:class:`~gwtransport.fronttracking.waves.DoubleFanShockWave` participates in — via one uniform
+calculus (issue #294):
+
+- **Faces and feeders.** Every wave is a set of *faces* (a shock face, a contact, or a
+  rarefaction/fan boundary line). Each face separates a *left* (upstream) from a *right*
+  (downstream) :class:`~gwtransport.fronttracking.waves.Feeder` — a constant state or a
+  bounded self-similar fan.
+- **Universal merge.** When a rear (upstream, faster) face overtakes a front (downstream)
+  face, they merge into a single successor built from ``(rear.left_feeder, front.right_feeder)``.
+  This one rule generates shock↔shock merges, shocks entering a fan (fan-entry), a rarefaction
+  head catching a decaying shock (doubly-fed formation), same-apex decaying-shock annihilation,
+  and every composition thereof.
+- **Lipschitz-safe detection.** First crossings are found by a per-pair speed-bounded march
+  (``|dg/dθ| ≤ Λ_pair``) so no crossing is skipped, with a grazing-minimum bracket for
+  double-crossings inside one step. The bound is per-pair (not a global ``1``) because the
+  percolation conductivity isotherms have ``R < 1`` regions.
+
+This file is part of gwtransport which is released under AGPL-3.0 license.
+See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+from scipy.optimize import brentq
+
+from gwtransport.fronttracking.math import NonlinearSorption, SorptionModel, characteristic_speed
+from gwtransport.fronttracking.waves import (
+    CharacteristicWave,
+    DecayingShockWave,
+    DoubleFanShockWave,
+    Feeder,
+    RarefactionWave,
+    ShockWave,
+    Wave,
+)
+
+EPSILON_POSITION = 1e-15
+# Largest speed used to size the Lipschitz march when a feeder range touches a saturated
+# state (R = 0, λ = +∞ for van Genuchten-Mualem at S_e = 1). The step floor plus the D6
+# monotonic-outlet-mass tripwire back this rare case; the sorption isotherms never hit it.
+MAX_FINITE_SPEED = 1e6
+MERGE_MATCH_TOL = 1e-9  # feeder-equality tolerance for degenerate (zero-jump) successors
+
+
+@dataclass
+class Face:
+    """One separating surface of a wave, for event detection and the reader sweep.
+
+    A face carries the wave it belongs to, a role tag, its position as a function of θ, the
+    left (upstream) and right (downstream) feeders, whether its trajectory is curved (a
+    fan-fed shock) and an upper bound on its speed (for the Lipschitz march).
+    """
+
+    wave: Wave
+    role: str  # 'shock' | 'contact' | 'head' | 'tail' | 'boundary'
+    left: Feeder
+    right: Feeder
+    is_curved: bool
+    speed_bound: float
+    line: tuple[float, float, float] | None = None
+    """For a ``boundary`` face: ``(v_apex, theta_apex, speed)`` of the linear characteristic."""
+
+    def position(self, theta: float) -> float | None:
+        """Face position at ``theta`` (``None`` outside the wave's active θ-window)."""
+        return _face_position(self, theta)
+
+
+def _max_characteristic_speed(feeder: Feeder, sorption: SorptionModel) -> float:
+    """Upper bound on ``|λ|`` over a feeder's concentration range (monotone in ``c``)."""
+    if feeder.is_const:
+        s = characteristic_speed(feeder.c_a, sorption)
+    else:
+        s = max(characteristic_speed(feeder.c_a, sorption), characteristic_speed(feeder.c_b, sorption))
+    return min(s, MAX_FINITE_SPEED) if np.isfinite(s) else MAX_FINITE_SPEED
+
+
+def _far_bound(feeder: Feeder, sorption: SorptionModel, *, upstream: bool) -> float:
+    """Return the fan boundary concentration on the far (upstream/downstream) side.
+
+    Upstream (the apex/tail side) is the larger-retardation bound; downstream (the head
+    side) is the smaller-retardation bound. Monotonicity-agnostic (works for the n<1 mirror).
+    """
+    r_a = float(sorption.retardation(feeder.c_a))
+    r_b = float(sorption.retardation(feeder.c_b))
+    if upstream:
+        return feeder.c_a if r_a >= r_b else feeder.c_b
+    return feeder.c_a if r_a <= r_b else feeder.c_b
+
+
+def iter_faces(wave: Wave, theta: float, *, include_boundaries: bool = True) -> list[Face]:
+    """Enumerate the faces of ``wave`` at ``theta`` (shock/contact/boundary).
+
+    ``theta`` selects the *historical* boundary state: a free fan boundary line is a face
+    only for ``θ`` before it was consumed by a wave entering the fan (mirroring
+    ``was_active_at``). ``include_boundaries=False`` drops boundary lines entirely.
+    """
+    if isinstance(wave, CharacteristicWave):
+        left = Feeder.constant(wave.concentration)
+        right = Feeder.constant(wave.c_ahead)
+        return [Face(wave, "contact", left, right, is_curved=False, speed_bound=abs(wave.speed()))]
+
+    if isinstance(wave, ShockWave):
+        left = Feeder.constant(wave.c_left)
+        right = Feeder.constant(wave.c_right)
+        return [Face(wave, "shock", left, right, is_curved=False, speed_bound=abs(wave.speed))]
+
+    if isinstance(wave, RarefactionWave):
+        fan = Feeder.fan(wave.v_start, wave.theta_start, wave.c_tail, wave.c_head, wave.sorption)
+        head = Face(
+            wave, "head", fan, Feeder.constant(wave.c_head), is_curved=False, speed_bound=abs(wave.head_speed())
+        )
+        tail = Face(
+            wave, "tail", Feeder.constant(wave.c_tail), fan, is_curved=False, speed_bound=abs(wave.tail_speed())
+        )
+        return [head, tail]
+
+    if isinstance(wave, DecayingShockWave):
+        return _decaying_shock_faces(wave, theta, include_boundaries=include_boundaries)
+
+    if isinstance(wave, DoubleFanShockWave):
+        return _double_fan_faces(wave, theta, include_boundaries=include_boundaries)
+
+    return []
+
+
+def _decaying_shock_faces(wave: DecayingShockWave, theta: float, *, include_boundaries: bool) -> list[Face]:
+    """Shock face (curved) plus the free fan boundary line of a decaying shock at ``theta``."""
+    s = wave.sorption
+    c_lo = min(wave.c_fan_tail, wave.c_decay_initial)
+    c_hi = max(wave.c_fan_tail, wave.c_decay_initial)
+    boundary_free = not wave.fan_boundary_consumed and theta < wave.theta_fan_boundary_consumed
+    fan = Feeder.fan(wave.v_origin, wave.theta_origin, c_lo, c_hi, s, far_boundary_free=boundary_free)
+    fixed = Feeder.constant(wave.c_fixed)
+    speed_bound = max(_max_characteristic_speed(fan, s), _max_characteristic_speed(fixed, s))
+    if wave.decay_side == "left":
+        shock = Face(wave, "shock", fan, fixed, is_curved=True, speed_bound=speed_bound)
+    else:
+        shock = Face(wave, "shock", fixed, fan, is_curved=True, speed_bound=speed_bound)
+    faces = [shock]
+
+    if include_boundaries and boundary_free:
+        tail_c = Feeder.constant(wave.c_fan_tail)
+        line_speed = characteristic_speed(wave.c_fan_tail, s)
+        if np.isfinite(line_speed):
+            # A wave entering through this boundary rides into a fan whose FAR edge is this
+            # shock's own face (owned), so the entrant's successor must not re-expose a
+            # boundary there: the boundary-side fan feeder is far_boundary_free=False.
+            entry_fan = Feeder.fan(wave.v_origin, wave.theta_origin, c_lo, c_hi, s, far_boundary_free=False)
+            if wave.decay_side == "left":
+                # fan is upstream of the shock; its far (upstream) boundary carries c_fan_tail.
+                left, right = tail_c, entry_fan
+            else:
+                left, right = entry_fan, tail_c
+            faces.append(_boundary_line(wave, wave.v_origin, wave.theta_origin, line_speed, left, right))
+    return faces
+
+
+def _double_fan_faces(wave: DoubleFanShockWave, theta: float, *, include_boundaries: bool) -> list[Face]:
+    """Shock face (curved) plus the free left/right fan boundary lines of a doubly-fed shock."""
+    s = wave.sorption
+    left_free = not wave.left_boundary_consumed and theta < wave.theta_left_boundary_consumed
+    right_free = not wave.right_boundary_consumed and theta < wave.theta_right_boundary_consumed
+    left_fan = Feeder.fan(
+        wave.left_feeder.v_apex,
+        wave.left_feeder.theta_apex,
+        wave.left_feeder.c_a,
+        wave.left_feeder.c_b,
+        s,
+        far_boundary_free=left_free,
+    )
+    right_fan = Feeder.fan(
+        wave.right_feeder.v_apex,
+        wave.right_feeder.theta_apex,
+        wave.right_feeder.c_a,
+        wave.right_feeder.c_b,
+        s,
+        far_boundary_free=right_free,
+    )
+    speed_bound = max(_max_characteristic_speed(left_fan, s), _max_characteristic_speed(right_fan, s))
+    faces = [Face(wave, "shock", left_fan, right_fan, is_curved=True, speed_bound=speed_bound)]
+
+    if include_boundaries and left_free:
+        c_far = _far_bound(left_fan, s, upstream=True)
+        line_speed = characteristic_speed(c_far, s)
+        if np.isfinite(line_speed):
+            entry_fan = Feeder.fan(
+                left_fan.v_apex, left_fan.theta_apex, left_fan.c_a, left_fan.c_b, s, far_boundary_free=False
+            )
+            faces.append(
+                _boundary_line(
+                    wave, left_fan.v_apex, left_fan.theta_apex, line_speed, Feeder.constant(c_far), entry_fan
+                )
+            )
+    if include_boundaries and right_free:
+        c_far = _far_bound(right_fan, s, upstream=False)
+        line_speed = characteristic_speed(c_far, s)
+        if np.isfinite(line_speed):
+            entry_fan = Feeder.fan(
+                right_fan.v_apex, right_fan.theta_apex, right_fan.c_a, right_fan.c_b, s, far_boundary_free=False
+            )
+            faces.append(
+                _boundary_line(
+                    wave, right_fan.v_apex, right_fan.theta_apex, line_speed, entry_fan, Feeder.constant(c_far)
+                )
+            )
+    return faces
+
+
+def _boundary_line(wave: Wave, v_apex: float, theta_apex: float, speed: float, left: Feeder, right: Feeder) -> Face:
+    """Build a linear fan boundary characteristic face (``V = v_apex + speed·(θ − θ_apex)``)."""
+    return Face(
+        wave, "boundary", left, right, is_curved=False, speed_bound=abs(speed), line=(v_apex, theta_apex, speed)
+    )
+
+
+def _face_position(face: Face, theta: float) -> float | None:
+    """Position of any face at ``theta`` (dispatch on role/backing wave)."""
+    wave = face.wave
+    if not wave.was_active_at(theta):
+        return None
+    if face.role == "boundary" and face.line is not None:
+        v_apex, theta_apex, speed = face.line
+        return v_apex + speed * (theta - theta_apex)
+    if isinstance(wave, RarefactionWave):
+        return wave.head_position_at_theta(theta) if face.role == "head" else wave.tail_position_at_theta(theta)
+    return wave.position_at_theta(theta)
+
+
+def find_face_crossing(
+    face_a: Face, face_b: Face, theta_current: float, theta_horizon: float
+) -> tuple[float, float] | None:
+    """First θ in ``(θ_start, θ_horizon]`` where two faces coincide, else ``None``.
+
+    ``θ_start = max(θ_current, both faces born)``. The gap ``g(θ) = pos_b − pos_a`` is
+    marched with a per-pair speed bound ``Λ = speed_bound_a + speed_bound_b`` so a step
+    ``Δθ = max(|g|/Λ, floor)`` cannot straddle a sign change unseen; each step also brackets
+    the gap's interior minimum to catch a grazing double-crossing.
+    """
+    wave_a, wave_b = face_a.wave, face_b.wave
+    theta_start = max(theta_current, wave_a.theta_start, wave_b.theta_start)
+    if theta_start >= theta_horizon:
+        return None
+
+    def gap(theta: float) -> float | None:
+        pa = face_a.position(theta)
+        pb = face_b.position(theta)
+        if pa is None or pb is None:
+            return None
+        return pb - pa
+
+    lam = face_a.speed_bound + face_b.speed_bound
+    lam = lam if np.isfinite(lam) and lam > 0 else MAX_FINITE_SPEED
+    floor = 1e-9 * max(abs(theta_start), 1.0)
+
+    theta = theta_start
+    g_prev = gap(theta)
+    if g_prev is None:
+        return None
+    # Born-coincident / already-crossed event: when a wave is created by a near-simultaneous
+    # (triple-) collision, it can be born within FP of — or just past — an adjacent wave it
+    # must immediately merge with. The gap is already ≈0 or slightly negative at the search
+    # start, so the forward march never sees a sign change. Detect it directly: if one wave
+    # was just born (θ_start == search start) and the faces coincide within a small position
+    # tolerance, emit the merge now (at the search start).
+    pa0 = face_a.position(theta_start)
+    born_now = abs(wave_a.theta_start - theta_start) <= floor or abs(wave_b.theta_start - theta_start) <= floor
+    coincidence_tol = 1e-3 * max(abs(pa0) if pa0 is not None else 0.0, 1.0)
+    if abs(g_prev) < EPSILON_POSITION or (born_now and abs(g_prev) < coincidence_tol):
+        return (theta, pa0) if pa0 is not None else None
+
+    while theta < theta_horizon:
+        step = max(abs(g_prev) / lam, floor)
+        theta_next = min(theta + step, theta_horizon)
+        g_next = gap(theta_next)
+        if g_next is None:
+            return None
+        if g_prev * g_next <= 0.0:
+            root = _bracket_zero(gap, theta, theta_next)
+            if root is not None:
+                v = face_a.position(root)
+                return (root, v) if v is not None else None
+        theta, g_prev = theta_next, g_next
+    return None
+
+
+def _bracket_zero(gap, lo: float, hi: float) -> float | None:
+    """Root of ``gap`` in ``[lo, hi]`` (endpoints straddle zero, or one is ~0)."""
+    g_lo = gap(lo)
+    g_hi = gap(hi)
+    if g_lo is None or g_hi is None:
+        return None
+    if abs(g_lo) < EPSILON_POSITION:
+        return lo
+    if abs(g_hi) < EPSILON_POSITION:
+        return hi
+    if g_lo * g_hi > 0.0:
+        return None
+    return float(brentq(gap, lo, hi, xtol=1e-13))
+
+
+def make_wave_from_feeders(left: Feeder, right: Feeder, v: float, theta: float, sorption: SorptionModel) -> Wave | None:
+    """Build the successor wave a merge produces from ``(left, right)`` feeders at ``(v, θ)``.
+
+    ``(const, const)`` → :class:`ShockWave` (or ``None`` for a zero jump);
+    ``(const, fan)``/``(fan, const)`` → :class:`DecayingShockWave`;
+    ``(fan, fan)`` → :class:`DoubleFanShockWave`. Fan feeders whose far boundary is not free
+    (``far_boundary_free=False``) mark the successor's boundary consumed on that side.
+    """
+    if left.is_const and right.is_const:
+        if abs(left.c_a - right.c_a) < MERGE_MATCH_TOL:
+            return None
+        shock = ShockWave(theta_start=theta, v_start=v, c_left=left.c_a, c_right=right.c_a, sorption=sorption)
+        return shock if shock.satisfies_entropy() else None
+
+    if left.is_const or right.is_const:
+        return _make_decaying_shock(left, right, v, theta, sorption)
+
+    return _make_double_fan(left, right, v, theta, sorption)
+
+
+def _make_decaying_shock(left: Feeder, right: Feeder, v: float, theta: float, sorption: SorptionModel) -> Wave | None:
+    """Successor for one const + one fan feeder → a decaying shock (or a plain shock).
+
+    The decaying side evolves from ``c_decay_initial`` (the fan value at the collision)
+    toward ``c_fixed``. The fan only *feeds* that motion while there is a fan edge on the
+    ``c_fixed`` side of ``c_decay_initial``; ``c_fan_tail`` is that edge (the exhaustion
+    target — the decay asymptotes at ``c_fixed`` if it lies before the edge). If no fan edge
+    lies toward ``c_fixed`` (the shock leaves the fan immediately — e.g. a collision exactly
+    at a fan boundary), there is no fan-fed decay and the successor is a plain
+    :class:`ShockWave` ``(c_decay_initial | c_fixed)``.
+    """
+    assert isinstance(sorption, NonlinearSorption)  # noqa: S101
+    if left.is_const:
+        fixed_c = left.c_a
+        fan = right
+        decay_side = "right"
+    else:
+        fixed_c = right.c_a
+        fan = left
+        decay_side = "left"
+    c_decay_initial = fan.value(v, theta)
+    if abs(c_decay_initial - fixed_c) < MERGE_MATCH_TOL:
+        return None
+
+    direction = fixed_c - c_decay_initial
+    edges_toward_fixed = [b for b in (fan.c_a, fan.c_b) if (b - c_decay_initial) * direction > MERGE_MATCH_TOL]
+    if not edges_toward_fixed:
+        # The decay exits the fan at once — no fan-fed side, just a constant-state shock.
+        # decay_side='left' has the decaying (fan) side upstream; 'right' downstream.
+        if decay_side == "left":
+            c_left, c_right = c_decay_initial, fixed_c
+        else:
+            c_left, c_right = fixed_c, c_decay_initial
+        shock = ShockWave(theta_start=theta, v_start=v, c_left=c_left, c_right=c_right, sorption=sorption)
+        return shock if shock.satisfies_entropy() else None
+    # The fan edge farthest along the decay direction is the exhaustion target.
+    c_fan_tail = max(edges_toward_fixed, key=lambda b: (b - c_decay_initial) * direction)
+
+    return DecayingShockWave(
+        theta_start=theta,
+        v_start=v,
+        c_decay_initial=c_decay_initial,
+        c_fixed=fixed_c,
+        c_fan_tail=c_fan_tail,
+        decay_side=decay_side,
+        v_origin=fan.v_apex,
+        theta_origin=fan.theta_apex,
+        sorption=sorption,
+        fan_boundary_consumed=not fan.far_boundary_free,
+    )
+
+
+def _make_double_fan(left: Feeder, right: Feeder, v: float, theta: float, sorption: SorptionModel) -> Wave | None:
+    """Successor for two fan feeders → a doubly-fed shock."""
+    assert isinstance(sorption, NonlinearSorption)  # noqa: S101
+    return DoubleFanShockWave(
+        theta_start=theta,
+        v_start=v,
+        left_feeder=left,
+        right_feeder=right,
+        sorption=sorption,
+        left_boundary_consumed=not left.far_boundary_free,
+        right_boundary_consumed=not right.far_boundary_free,
+    )
+
+
+def resolve_merge(face_a: Face, face_b: Face, theta: float, v: float, sorption: SorptionModel) -> list[Wave]:
+    """Resolve a two-face collision: deactivate/consume parents, return successor waves.
+
+    Determines the rear (upstream) and front (downstream) face just before the crossing,
+    forms the successor from ``(rear.left, front.right)``, and retires the parents: a whole
+    wave is deactivated when its shock/contact/rarefaction face merges (its fan is absorbed
+    into the successor); a bare fan boundary line is *consumed* while its owning wave lives on.
+    """
+    rear, front = _order_rear_front(face_a, face_b, theta)
+    successors = make_wave_from_feeders(rear.left, front.right, v, theta, sorption)
+    new_waves = [successors] if successors is not None else []
+
+    _retire_parent(rear, theta)
+    _retire_parent(front, theta)
+    return new_waves
+
+
+def _order_rear_front(face_a: Face, face_b: Face, theta: float) -> tuple[Face, Face]:
+    """Return ``(rear, front)`` — the upstream (smaller V just before θ) face first."""
+    eps = 1e-7 * max(abs(theta), 1.0)
+    pa = face_a.position(theta - eps)
+    pb = face_b.position(theta - eps)
+    if pa is None or pb is None:
+        pa = face_a.position(theta)
+        pb = face_b.position(theta)
+    if pa is None or pb is None:
+        return face_a, face_b
+    return (face_a, face_b) if pa <= pb else (face_b, face_a)
+
+
+def _retire_parent(face: Face, theta: float) -> None:
+    """Deactivate the wave, or consume just its boundary line if that is the merged face."""
+    wave = face.wave
+    if face.role == "boundary":
+        _consume_boundary(wave, face, theta)
+        return
+    wave.deactivate(theta)
+
+
+def _consume_boundary(wave: Wave, face: Face, theta: float) -> None:
+    """Timestamp the crossed fan boundary as consumed at ``theta``; the wave lives on.
+
+    Retrospective queries at ``θ' < theta`` still see the boundary as free (historical truth),
+    so a later reader query does not retro-erase the boundary before it was actually consumed.
+    """
+    if isinstance(wave, DecayingShockWave):
+        wave.theta_fan_boundary_consumed = theta
+    elif isinstance(wave, DoubleFanShockWave):
+        line = face.line
+        matches_left = (
+            line is not None
+            and abs(line[0] - wave.left_feeder.v_apex) < EPSILON_POSITION
+            and abs(line[1] - wave.left_feeder.theta_apex) < EPSILON_POSITION
+        )
+        if matches_left:
+            wave.theta_left_boundary_consumed = theta
+        else:
+            wave.theta_right_boundary_consumed = theta

--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -28,18 +28,26 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 
 import warnings
 from collections.abc import Sequence
+from itertools import pairwise
 from operator import itemgetter
 
 import numpy as np
 import numpy.typing as npt
 
 from gwtransport.fronttracking.events import find_outlet_crossing
+from gwtransport.fronttracking.interactions import Face, iter_faces
 from gwtransport.fronttracking.math import (
-    ConstantRetardation,
     NonlinearSorption,
     SorptionModel,
 )
-from gwtransport.fronttracking.waves import CharacteristicWave, DecayingShockWave, RarefactionWave, ShockWave, Wave
+from gwtransport.fronttracking.waves import (
+    CharacteristicWave,
+    DecayingShockWave,
+    Feeder,
+    RarefactionWave,
+    ShockWave,
+    Wave,
+)
 
 # Numerical tolerance constants
 EPSILON_VELOCITY = 1e-15  # Tolerance for checking if velocity is effectively zero
@@ -51,6 +59,25 @@ EPSILON_POSITION = 1e-15  # Tolerance for shock-face proximity in position v [m�
 # multi-pulse record (measured max ratio ~460); 65536 clears that with wide margin while staying
 # ~7 orders below any real breakthrough concentration (O(cin)).
 FP_CANCELLATION_CLAMP = 65536.0
+
+
+def _reader_faces(waves: Sequence[Wave], theta: float) -> list[tuple[float, Face]]:
+    """``(position, face)`` for every active wave face at ``theta`` (reader sweep basis).
+
+    Fan boundary lines are included: they mark where a downstream-opening fan ends and its
+    plateau begins (a ``decay_side='right'`` decaying/doubly-fed shock has its fan on the
+    downstream side, so its head boundary must partition the domain — the feeder clamp alone
+    only reaches the apex-side plateau).
+    """
+    out: list[tuple[float, Face]] = []
+    for wave in waves:
+        if not wave.was_active_at(theta):
+            continue
+        for face in iter_faces(wave, theta, include_boundaries=True):
+            pos = face.position(theta)
+            if pos is not None:
+                out.append((pos, face))
+    return out
 
 
 def concentration_at_point(
@@ -84,148 +111,33 @@ def concentration_at_point(
 
     Notes
     -----
-    **Wave priority**: decaying shocks first (closed-form analytical), then
-    rarefaction fans (spatial extent), then most recently crossing shock or
-    rarefaction tail, then characteristics. If no active wave controls the
-    point, returns 0.0 (initial condition).
+    **Nearest-downstream-face sweep.** ``C(v, θ)`` is the *left* (upstream) state of the
+    nearest face strictly downstream of ``v`` among the waves active at ``θ``; if no face
+    is downstream, the *right* state of the outermost face; ``0`` in a virgin domain. A
+    face's feeder is a constant or a bounded self-similar fan (clamped to its extent, so the
+    plateau beyond a fan reads correctly). Because every face crossing fires a solver event,
+    the front list is interaction-consistent and each region has a single owner — no
+    ownership heuristic is needed. This is exact for a single front (one owner everywhere)
+    and for genuinely interacting multi-front inputs alike.
     """
-    # Multi-DSW dispatch: when several active DSW fans contain v, the newest
-    # (largest ``theta_start``) wins — same rule as ``compute_domain_mass``.
-    # Iterating chronologically and short-circuiting picks the older DSW's fan
-    # value, which is wrong for overlap regions. The fan predicate mirrors the
-    # in-fan check used downstream.
-    dsw_in_fan: list[DecayingShockWave] = []
-    for wave in waves:
-        if isinstance(wave, DecayingShockWave) and wave.was_active_at(theta):
-            v_s = wave.position_at_theta(theta)
-            if v_s is None:
-                continue
-            in_fan = (wave.decay_side == "left" and v < v_s) or (wave.decay_side == "right" and v > v_s)
-            if in_fan and v != wave.v_origin:
-                dsw_in_fan.append(wave)
-
-    if dsw_in_fan:
-        newest = max(dsw_in_fan, key=lambda w: w.theta_start)
-        c = newest.concentration_at_point(v, theta)
-        if c is not None:
-            return c
-
-    # Fallback: no DSW fan contains v — handle shock-face (v ≈ V_s) and
-    # fixed-side (v on the c_fixed side) cases. Chronological iteration is
-    # fine here because (a) shock-face is rare and unique by v ≈ V_s, and
-    # (b) all DSWs in a typical multi-pulse share the same c_fixed baseline.
-    for wave in waves:
-        if isinstance(wave, DecayingShockWave) and wave.was_active_at(theta):
-            c = wave.concentration_at_point(v, theta)
-            if c is not None:
-                return c
-
-    # Multi-rarefaction dispatch: same shape as DSWs. RarefactionWave returns
-    # None outside its fan, so collecting non-None candidates is equivalent to
-    # an in-fan check. Newest wins.
-    raref_candidates: list[tuple[float, RarefactionWave]] = []
-    for wave in waves:
-        if isinstance(wave, RarefactionWave) and wave.was_active_at(theta):
-            c = wave.concentration_at_point(v, theta)
-            if c is not None:
-                raref_candidates.append((c, wave))
-
-    if raref_candidates:
-        return max(raref_candidates, key=lambda cw: cw[1].theta_start)[0]
-
-    latest_wave_theta = -np.inf
-    latest_wave_c = None
-    # Stacked-shock geometry: for v right of multiple shocks, c at v is c_right
-    # of the shock CLOSEST to v from the left (largest V_shock with V_shock < v).
-    # ``theta_start`` would mis-rank stacked shocks (youngest = innermost ≠
-    # closest-to-v), so we track V_shock directly.
-    # Obstruction check: a shock's c_R applies at v only when no other active
-    # wave (rarefaction tail/head, DSW V_s, other shock) sits between V_shock
-    # and v. Otherwise c_R is the c in the immediate-right-of-shock zone, not
-    # at v.
-    rightmost_passed_v_shock = -np.inf
-    rightmost_passed_c_right: float | None = None
-
-    def _intervening_wave_between(v_a: float, v_b: float) -> bool:
-        """Return True if any other active wave has a boundary V in (v_a, v_b)."""
-        for other in waves:
-            if not other.was_active_at(theta):
-                continue
-            if isinstance(other, RarefactionWave):
-                v_t = other.tail_position_at_theta(theta)
-                v_h = other.head_position_at_theta(theta)
-                if v_t is not None and v_a < v_t < v_b:
-                    return True
-                if v_h is not None and v_a < v_h < v_b:
-                    return True
-            else:
-                v_o = other.position_at_theta(theta)
-                if v_o is not None and v_a < v_o < v_b:
-                    return True
-        return False
-
-    for wave in waves:
-        if isinstance(wave, ShockWave) and wave.was_active_at(theta):
-            v_shock = wave.position_at_theta(theta)
-            if v_shock is not None:
-                if abs(v - v_shock) < EPSILON_POSITION:
-                    return 0.5 * (wave.c_left + wave.c_right)
-
-                if abs(wave.speed) > EPSILON_VELOCITY:
-                    theta_cross = wave.theta_start + (v - wave.v_start) / wave.speed
-
-                    if theta_cross <= theta:
-                        if theta_cross > latest_wave_theta:
-                            latest_wave_theta = theta_cross
-                            latest_wave_c = wave.c_left
-                    elif v > v_shock > rightmost_passed_v_shock and not _intervening_wave_between(v_shock, v):
-                        rightmost_passed_v_shock = v_shock
-                        rightmost_passed_c_right = wave.c_right
-
-    for wave in waves:
-        if isinstance(wave, RarefactionWave) and wave.was_active_at(theta):
-            v_tail = wave.tail_position_at_theta(theta)
-            if v_tail is not None and v_tail > v + EPSILON_POSITION:
-                tail_speed = wave.tail_speed()
-                if tail_speed > EPSILON_VELOCITY:
-                    theta_pass = wave.theta_start + (v - wave.v_start) / tail_speed
-                    if theta_pass <= theta and theta_pass > latest_wave_theta:
-                        latest_wave_theta = theta_pass
-                        latest_wave_c = wave.c_tail
-
-    # Priority: latest_wave_c is set by the IF-shock branch (theta_cross <=
-    # theta -> c_L of closest-passing shock) or by the rarefaction-tail loop
-    # (rarefaction tail downstream of v passed v at theta_pass -> c_tail).
-    # rightmost_passed_c_right is set by the elif-shock branch (v > V_shock,
-    # shock upstream of v, c_R of closest-from-left shock). The two represent
-    # different geometric truths: latest_wave_c is "most recent event AT v",
-    # rightmost_passed_c_right is "c just past the upstream shock". When a
-    # rarefaction tail is downstream of the shock AND right of v, that
-    # rarefaction's c_tail wins (the tail's passage at v is more recent than
-    # the shock's contribution at v, geometrically). Prefer latest_wave_c.
-    if latest_wave_c is not None:
-        return latest_wave_c
-    if rightmost_passed_c_right is not None:
-        return rightmost_passed_c_right
-
-    latest_c = 0.0
-    latest_theta = -np.inf
-
-    for wave in waves:
-        if isinstance(wave, CharacteristicWave) and wave.was_active_at(theta):
-            v_char_at_theta = wave.position_at_theta(theta)
-
-            if v_char_at_theta is not None and v_char_at_theta >= v - EPSILON_POSITION:
-                speed = wave.speed()
-
-                if speed > EPSILON_VELOCITY:
-                    theta_pass = wave.theta_start + (v - wave.v_start) / speed
-
-                    if theta_pass <= theta and theta_pass > latest_theta:
-                        latest_theta = theta_pass
-                        latest_c = wave.concentration
-
-    return latest_c
+    faces = _reader_faces(waves, theta)
+    # Nearest face at or downstream of v (within FP): its left (upstream) feeder gives the
+    # state just behind it, which is the state at v. A face strictly upstream of v does not
+    # describe v. If nothing is at/downstream, the outermost face's right (downstream) feeder
+    # holds — the state ahead of every front.
+    downstream = [(p, f) for (p, f) in faces if p >= v - EPSILON_POSITION]
+    if downstream:
+        pos, face = min(downstream, key=itemgetter(0))
+        # Exactly on a shock/fan face: return the average of the two sides (the infinitesimally
+        # thin discontinuity convention). A contact (characteristic) carries its value on the
+        # upstream side, so it returns that (the behind value) at its own position.
+        if abs(pos - v) < EPSILON_POSITION and face.role != "contact":
+            return 0.5 * (face.left.value(v, theta) + face.right.value(v, theta))
+        return face.left.value(v, theta)
+    if faces:
+        _p, face = max(faces, key=itemgetter(0))
+        return face.right.value(v, theta)
+    return 0.0
 
 
 def compute_breakthrough_curve(
@@ -859,9 +771,12 @@ def compute_bin_averaged_concentration_exact(
         # fully in-range inputs. Residuals within this band are numerical zero: clamp and stay
         # silent.
         mass_scale = np.maximum(np.abs(m_in_at_edges), np.abs(m_dom_at_edges))
+        # Band = the larger of the FP-cancellation floor and a 1e-6 relative transient floor.
+        # The latter absorbs the benign ``c_min``-floor artifact at a fan-entry (a decaying
+        # side born at ``c ≈ 1e-12`` rather than exactly 0 perturbs the near-apex fan integral
+        # for one θ-sample); a genuine over-count is O(a pulse's mass), far above the band.
         eps_band = (
-            FP_CANCELLATION_CLAMP
-            * np.finfo(float).eps
+            max(FP_CANCELLATION_CLAMP * np.finfo(float).eps, 1e-6)
             * np.maximum(np.maximum(mass_scale[:-1], mass_scale[1:]), 1.0)
             / dtheta_out
         )
@@ -985,178 +900,64 @@ def compute_domain_mass(
         )
         mass >= 0.0
     """
-    # Single θ-pass over the waves. Every quantity below (active flag, wave
-    # position, fan head/tail) depends only on θ, not on the spatial segment, so
-    # evaluate each exactly once here and reuse it in the per-segment loop. Doing
-    # it per segment made ``compute_domain_mass`` re-solve ``position_at_theta``
-    # (a spline/root-find for numerical DecayingShockWaves) O(n_waves) times per
-    # segment — O(n_waves²) transcendental work where O(n_waves) suffices.
-    wave_positions = []
-    # Precomputed fan geometry for the segment dispatch below, kept in wave
-    # iteration order so the newest-wins ``max(..., key=theta_start)`` tie-break
-    # resolves to the same wave as the per-segment rebuild did.
-    dsw_fans: list[tuple[DecayingShockWave, float]] = []  # (wave, v_s = position_at_theta)
-    raref_fans: list[tuple[RarefactionWave, float, float]] = []  # (wave, v_tail, v_head)
+    # Partition [0, v_outlet] at the active faces; each segment has a single owner (the
+    # left feeder of its nearest downstream face). A constant owner integrates as
+    # C_total·Δv; a fan owner integrates in closed form via integrate_fan_spatial_exact,
+    # clamped at the fan's near-apex (larger-retardation) bound. Because the wave list is
+    # interaction-consistent (every face crossing fires a solver event), this single-owner
+    # sweep is exact for single-front and genuinely interacting multi-front layouts alike.
+    faces = _reader_faces(waves, theta)
+    boundaries = {0.0, v_outlet}
+    boundaries.update(p for (p, _f) in faces if 0.0 < p < v_outlet)
+    positions = sorted(boundaries)
 
-    for wave in waves:
-        # Use was_active_at(theta) — not is_active — so historical wave geometries
-        # contribute to retrospective m_dom queries. Without this, a wave deactivated
-        # by a later collision event is skipped here, which propagates as a "cin echo
-        # at the outlet" bug (m_out = m_in − 0 instead of m_in − m_dom_correct).
-        if not wave.was_active_at(theta):
-            continue
-
-        if isinstance(wave, (CharacteristicWave, ShockWave)):
-            v_pos = wave.position_at_theta(theta)
-            if v_pos is not None and 0 <= v_pos <= v_outlet:
-                wave_positions.append(v_pos)
-
-        elif isinstance(wave, RarefactionWave):
-            v_head = wave.head_position_at_theta(theta)
-            v_tail = wave.tail_position_at_theta(theta)
-
-            if v_head is not None and 0 <= v_head <= v_outlet:
-                wave_positions.append(v_head)
-            if v_tail is not None and 0 <= v_tail <= v_outlet:
-                wave_positions.append(v_tail)
-
-            # contains_point() excludes theta == theta_start (strict) even though
-            # was_active_at includes it; mirror that guard so ownership is identical.
-            # v_head/v_tail are non-None here (the wave is active) and stored
-            # unclamped — contains_point compares against the raw fan edges.
-            if theta > wave.theta_start and v_head is not None and v_tail is not None:
-                raref_fans.append((wave, v_tail, v_head))
-
-        elif isinstance(wave, DecayingShockWave):
-            v_pos = wave.position_at_theta(theta)
-            if v_pos is not None and 0 <= v_pos <= v_outlet:
-                wave_positions.append(v_pos)
-            if 0 <= wave.v_origin <= v_outlet:
-                wave_positions.append(wave.v_origin)
-            # Store the shock position unclamped: the fan-membership test below
-            # compares an in-domain v_mid against v_s, which may lie outside
-            # [0, v_outlet] yet still bound the fan covering the domain.
-            if v_pos is not None:
-                dsw_fans.append((wave, v_pos))
-
-    # Add domain boundaries
-    wave_positions.extend([0.0, v_outlet])
-
-    # Sort and remove duplicates; all entries are within [0, v_outlet] by
-    # construction (each append site is guarded by the bounds check).
-    wave_positions = sorted(set(wave_positions))
-
-    # Compute mass in each segment using refined integration
     total_mass = 0.0
-
-    for i in range(len(wave_positions) - 1):
-        v_start = wave_positions[i]
-        v_end = wave_positions[i + 1]
+    for v_start, v_end in pairwise(positions):
         dv = v_end - v_start
-
         if dv < EPSILON_VOLUME:
             continue
-
-        # Check whether the midpoint is inside any fan-bearing wave; the fan
-        # spatial integral is closed-form for both RarefactionWave and
-        # DecayingShockWave (the latter via the parameterised
-        # ``integrate_fan_spatial_exact``).
-        #
-        # Multi-fan dispatch: when multiple DSWs (or rarefactions) nominally
-        # contain v_mid, the newer one (later ``theta_start``) wins —
-        # geometrically equivalent to the exclusion rule
-        # ``v_mid ∈ [V_apex_W₂, V_s_W₁]`` for simulator-produced layouts.
         v_mid = 0.5 * (v_start + v_end)
-        raref_wave: RarefactionWave | None = None
-        decaying_wave: DecayingShockWave | None = None
+        feeder = _owner_feeder(faces, v_mid)
 
-        # Dispatch against the precomputed fan geometry; no per-segment
-        # position_at_theta / was_active_at re-evaluation.
-        dsw_candidates = [
-            (wave, v_s)
-            for (wave, v_s) in dsw_fans
-            # decay_side='left': fan is upstream of V_s (v < V_s);
-            # decay_side='right': fan is downstream of V_s (v > V_s).
-            if ((wave.decay_side == "left" and v_mid < v_s) or (wave.decay_side == "right" and v_mid > v_s))
-            and v_mid != wave.v_origin
-        ]
-        if dsw_candidates:
-            decaying_wave = max(dsw_candidates, key=lambda pair: pair[0].theta_start)[0]
-
-        if decaying_wave is None:
-            raref_candidates = [
-                (wave, v_tail, v_head) for (wave, v_tail, v_head) in raref_fans if v_tail <= v_mid <= v_head
-            ]
-            if raref_candidates:
-                raref_wave = max(raref_candidates, key=lambda pair: pair[0].theta_start)[0]
-
-        if raref_wave is not None:
-            mass_segment = _integrate_rarefaction_spatial_exact(raref_wave, v_start, v_end, theta, sorption)
-        elif decaying_wave is not None:
-            # The decaying fan is bounded at its apex by the parent's tail concentration
-            # ``c_fan_tail`` (the sustained-inlet plateau), NOT the downstream ``c_fixed``.
-            # ``integrate_fan_spatial_exact`` then clamps the abandoned region at ``c_fan_tail``;
-            # passing ``c_fixed`` would integrate the unbounded self-similar fan to the apex and
-            # over-count the tail, breaking domain-mass conservation once a DSW forms.
-            mass_segment = integrate_fan_spatial_exact(
-                decaying_wave.theta_origin,
-                decaying_wave.v_origin,
+        if feeder is None or feeder.is_const:
+            c = feeder.value(v_mid, theta) if feeder is not None else 0.0
+            total_mass += float(sorption.total_concentration(c)) * dv
+        else:
+            total_mass += integrate_fan_spatial_exact(
+                feeder.theta_apex,
+                feeder.v_apex,
                 v_start,
                 v_end,
                 theta,
                 sorption,
-                c_apex=decaying_wave.c_fan_tail,
+                c_apex=_near_apex_bound(feeder, sorption),
             )
-        else:
-            # Constant region: c at midpoint is exact for the segment.
-            c = concentration_at_point(v_mid, theta, waves, sorption)
-            c_total = sorption.total_concentration(c)
-            mass_segment = c_total * dv
-
-        total_mass += mass_segment
 
     return float(total_mass)
 
 
-def _integrate_rarefaction_spatial_exact(
-    raref: RarefactionWave,
-    v_start: float,
-    v_end: float,
-    theta: float,
-    sorption: SorptionModel,
-) -> float:
-    """Exact spatial integral of a rarefaction's total concentration at fixed θ.
+def _owner_feeder(faces: list[tuple[float, Face]], v: float) -> Feeder | None:
+    """Return the feeder controlling the state at ``v``: nearest-downstream face's left, else outermost right."""
+    downstream = [(p, f) for (p, f) in faces if p > v + EPSILON_POSITION]
+    if downstream:
+        _p, face = min(downstream, key=itemgetter(0))
+        return face.left
+    if faces:
+        _p, face = max(faces, key=itemgetter(0))
+        return face.right
+    return None
 
-    Thin wrapper over :func:`integrate_fan_spatial_exact` that pulls the fan
-    apex from ``raref.theta_start, raref.v_start``. For ``ConstantRetardation``
-    the rarefaction degenerates to a single c value (no fan), so we use the
-    wave's ``concentration_at_point`` directly.
 
-    Parameters
-    ----------
-    raref : RarefactionWave
-        Rarefaction wave.
-    v_start, v_end : float
-        Integration range [m³].
-    theta : float
-        Cumulative flow at which to evaluate [m³].
-    sorption : SorptionModel
-        Sorption model.
+def _near_apex_bound(feeder: Feeder, sorption: SorptionModel) -> float:
+    """Return the fan boundary concentration with the larger retardation (the near-apex / plateau side).
 
-    Returns
-    -------
-    float
-        Mass in the segment ``[v_start, v_end]``.
+    This is the ``c_apex`` clamp for ``integrate_fan_spatial_exact``: the value the fan holds
+    at (and beyond) its apex. Monotonicity-agnostic — the low-c bound for R-decreasing
+    isotherms, the high-c bound for the Freundlich ``n<1`` mirror where R increases with c.
     """
-    if isinstance(sorption, ConstantRetardation):
-        v_mid = 0.5 * (v_start + v_end)
-        c = raref.concentration_at_point(v_mid, theta) or 0.0
-        c_total = sorption.total_concentration(c)
-        return c_total * (v_end - v_start)
-
-    return integrate_fan_spatial_exact(
-        raref.theta_start, raref.v_start, v_start, v_end, theta, sorption, c_apex=raref.c_tail
-    )
+    r_a = float(sorption.retardation(feeder.c_a))
+    r_b = float(sorption.retardation(feeder.c_b))
+    return feeder.c_a if r_a >= r_b else feeder.c_b
 
 
 def integrate_fan_spatial_exact(

--- a/src/gwtransport/fronttracking/solver.py
+++ b/src/gwtransport/fronttracking/solver.py
@@ -20,7 +20,6 @@ All calculations are exact analytical with machine precision.
 
 import logging
 from dataclasses import dataclass
-from itertools import pairwise
 from operator import itemgetter
 
 import numpy as np
@@ -48,6 +47,12 @@ from gwtransport.fronttracking.handlers import (
     handle_shock_collision,
     handle_shock_rarefaction_collision,
 )
+from gwtransport.fronttracking.interactions import (
+    find_face_crossing,
+    iter_faces,
+    make_wave_from_feeders,
+    resolve_merge,
+)
 from gwtransport.fronttracking.math import (
     SorptionModel,
     compute_first_front_arrival_theta,
@@ -59,12 +64,17 @@ from gwtransport.fronttracking.output import (
 from gwtransport.fronttracking.waves import (
     CharacteristicWave,
     DecayingShockWave,
+    DoubleFanShockWave,
+    Feeder,
     RarefactionWave,
     ShockWave,
     Wave,
 )
 
 logger = logging.getLogger(__name__)
+
+# Concentration tolerance for matching a doubly-fed side value to a fan edge at exhaustion.
+_SIDE_EXHAUSTION_C_TOL = 1e-9
 
 
 @dataclass
@@ -108,6 +118,7 @@ class FrontTrackerState:
     tedges: pd.DatetimeIndex
     tedges_days: npt.NDArray[np.floating]
     theta_edges: npt.NDArray[np.floating]
+    theta_horizon: float = float("inf")
 
     def t_at_theta(self, theta: float) -> float:
         """Translate cumulative flow θ back to user-facing time t [days].
@@ -227,6 +238,7 @@ class FrontTracker:
         tedges: pd.DatetimeIndex,
         aquifer_pore_volume: float,
         sorption: SorptionModel,
+        theta_horizon: float | None = None,
     ):
         cin = np.asarray(cin, dtype=float)
         flow = np.asarray(flow, dtype=float)
@@ -251,6 +263,13 @@ class FrontTracker:
         bin_volumes = flow * dt_days
         theta_edges = np.concatenate(([0.0], np.cumsum(bin_volumes)))
 
+        # Global interaction resolution runs to a θ-horizon: an unresolved crossing at
+        # θ > horizon cannot affect any reader query at θ ≤ horizon (information propagates
+        # strictly downstream, all speeds ≥ 0). Default = the last inlet edge; the public
+        # API passes the last requested output edge so beyond-outlet merges that still feed
+        # an in-window outlet query are resolved.
+        resolved_horizon = float(theta_edges[-1]) if theta_horizon is None else float(theta_horizon)
+
         self.state = FrontTrackerState(
             waves=[],
             events=[],
@@ -262,6 +281,7 @@ class FrontTracker:
             tedges=tedges,
             tedges_days=tedges_days,
             theta_edges=theta_edges,
+            theta_horizon=resolved_horizon,
         )
 
         self.theta_first_arrival = compute_first_front_arrival_theta(cin, theta_edges, aquifer_pore_volume, sorption)
@@ -310,11 +330,18 @@ class FrontTracker:
 
         def push_collision(theta, event_type, waves, v, boundary):
             nonlocal counter
-            if not (0 <= v <= self.state.v_outlet):
+            # Global resolution (issue #294 D5): collisions are resolved wherever they occur,
+            # up to θ_horizon — not only within [0, v_outlet]. The single-owner reader needs a
+            # globally interaction-consistent front order, since the nearest downstream face
+            # of an in-domain query may lie beyond the outlet (e.g. a rarefaction head that
+            # catches a shock past v_outlet still bounds the in-domain fan). Information
+            # propagates strictly downstream (all speeds ≥ 0), so an event at θ > θ_horizon
+            # cannot affect any reader query at θ ≤ θ_horizon.
+            if v < -collision_tol:
                 return
-            if theta <= theta_current + collision_tol:
+            if theta <= theta_current + collision_tol or theta > self.state.theta_horizon:
                 return
-            candidates.append((theta, counter, event_type, waves, v, boundary))
+            candidates.append((theta, counter, event_type, waves, v, boundary, None))
             counter += 1
 
         chars = [w for w in active_waves if isinstance(w, CharacteristicWave)]
@@ -359,6 +386,56 @@ class FrontTracker:
                 for theta, v, boundary in intersections:
                     push_collision(theta, EventType.RAREF_RAREF_COLLISION, [raref1, raref2], v, boundary)
 
+        # Interaction events (issue #294): every face pair with at least one decaying/doubly-fed
+        # shock. The closed-form loops above cover char/shock/rarefaction pairs; here a face of a
+        # DSW/DFSW (its curved shock face or a free fan boundary line) meets any other wave's face.
+        # Resolution is GLOBAL — allowed beyond v_outlet up to θ_horizon — because the sweep reader
+        # needs a globally interaction-consistent front order for the nearest-downstream lookup.
+        special_types = (DecayingShockWave, DoubleFanShockWave)
+        if any(isinstance(w, special_types) for w in active_waves):
+            all_faces = [face for wave in active_waves for face in iter_faces(wave, theta_current)]
+            theta_horizon = self.state.theta_horizon
+            for i, fa in enumerate(all_faces):
+                for fb in all_faces[i + 1 :]:
+                    if fa.wave is fb.wave:
+                        continue
+                    if not (isinstance(fa.wave, special_types) or isinstance(fb.wave, special_types)):
+                        continue
+                    crossing = find_face_crossing(fa, fb, theta_current, theta_horizon)
+                    if crossing is None:
+                        continue
+                    theta, v = crossing
+                    if v < -collision_tol or theta > self.state.theta_horizon:
+                        continue
+                    # A born-coincident merge is reported at theta == theta_current (a wave
+                    # created this step is already touching/past a neighbour it must merge
+                    # with). Admit it — resolve_merge deactivates both parents, so it cannot
+                    # re-fire — but keep the strict-future filter for every ordinary crossing
+                    # so a just-processed event is not re-emitted one ULP later.
+                    born_coincident = theta <= theta_current + collision_tol and (
+                        abs(fa.wave.theta_start - theta_current) <= collision_tol
+                        or abs(fb.wave.theta_start - theta_current) <= collision_tol
+                    )
+                    if theta <= theta_current + collision_tol and not born_coincident:
+                        continue
+                    candidates.append((theta, counter, EventType.WAVE_MERGE, [fa.wave, fb.wave], v, None, (fa, fb)))
+                    counter += 1
+
+        # Doubly-fed side exhaustion: a DFSW fan side reaching its far bound degrades the wave.
+        for wave in active_waves:
+            if isinstance(wave, DoubleFanShockWave):
+                exhaust = wave.theta_at_side_exhaustion()
+                if exhaust is None:
+                    continue
+                theta_ex, side = exhaust
+                if theta_ex <= theta_current + collision_tol or theta_ex > self.state.theta_horizon:
+                    continue
+                v_ex = wave.position_at_theta(theta_ex)
+                if v_ex is None or v_ex < -collision_tol:
+                    continue
+                candidates.append((theta_ex, counter, EventType.DFSW_SIDE_EXHAUSTED, [wave], v_ex, None, (side,)))
+                counter += 1
+
         # Fan-exhaustion: a DecayingShockWave is valid only while c_decay stays
         # above c_fan_tail. When c_decay reaches c_fan_tail the fan is spent and
         # the wave hands off to a regular ShockWave(c_fan_tail, c_fixed).
@@ -367,10 +444,12 @@ class FrontTracker:
                 theta_exhaust = wave.theta_at_fan_exhaustion()
                 if theta_exhaust is None or theta_exhaust <= theta_current + collision_tol:
                     continue
-                v_exhaust = wave.position_at_theta(theta_exhaust)
-                if v_exhaust is None or not (0 <= v_exhaust <= self.state.v_outlet):
+                if theta_exhaust > self.state.theta_horizon:
                     continue
-                candidates.append((theta_exhaust, counter, EventType.DSW_FAN_EXHAUSTED, [wave], v_exhaust, None))
+                v_exhaust = wave.position_at_theta(theta_exhaust)
+                if v_exhaust is None or v_exhaust < -collision_tol:
+                    continue
+                candidates.append((theta_exhaust, counter, EventType.DSW_FAN_EXHAUSTED, [wave], v_exhaust, None, None))
                 counter += 1
 
         v_outlet = self.state.v_outlet
@@ -396,7 +475,15 @@ class FrontTracker:
                         continue
                     theta_cross = theta_eval + (v_outlet - v_pos) / s
                     if theta_cross > theta_current:
-                        candidates.append((theta_cross, counter, EventType.OUTLET_CROSSING, [wave], v_outlet, None))
+                        candidates.append((
+                            theta_cross,
+                            counter,
+                            EventType.OUTLET_CROSSING,
+                            [wave],
+                            v_outlet,
+                            None,
+                            None,
+                        ))
                         counter += 1
             else:
                 theta_cross = find_outlet_crossing(wave, self.state.v_outlet, theta_current)
@@ -408,13 +495,14 @@ class FrontTracker:
                         [wave],
                         self.state.v_outlet,
                         None,
+                        None,
                     ))
                     counter += 1
 
         if not candidates:
             return None
 
-        theta_event, _, event_type, waves, v, extra = min(candidates, key=itemgetter(slice(2)))
+        theta_event, _, event_type, waves, v, extra, faces = min(candidates, key=itemgetter(slice(2)))
 
         raref_types = {
             EventType.RAREF_CHAR_COLLISION,
@@ -429,6 +517,7 @@ class FrontTracker:
             waves_involved=waves,
             location=v,
             boundary_type=boundary_type,
+            faces=faces,
         )
 
     def handle_event(self, event: Event):
@@ -472,6 +561,17 @@ class FrontTracker:
             # Conservative: rarefaction-rarefaction collision records the event
             # but makes no topology change. Both rarefactions remain active.
             new_waves = []
+
+        elif event.event_type == EventType.WAVE_MERGE:
+            assert event.faces is not None  # noqa: S101  # WAVE_MERGE always carries its two faces
+            face_a, face_b = event.faces
+            new_waves = resolve_merge(face_a, face_b, event.theta, event.location, self.state.sorption)
+
+        elif event.event_type == EventType.DFSW_SIDE_EXHAUSTED:
+            assert event.faces is not None  # noqa: S101  # DFSW_SIDE_EXHAUSTED carries the ('left'|'right',) side
+            new_waves = self._handle_dfsw_side_exhaustion(
+                event.waves_involved[0], event.faces[0], event.theta, event.location
+            )
 
         elif event.event_type == EventType.DSW_FAN_EXHAUSTED:
             new_waves = self._handle_fan_exhaustion(event.waves_involved[0], event.theta, event.location)
@@ -526,6 +626,30 @@ class FrontTracker:
         if not shock.satisfies_entropy():
             return []
         return [shock]
+
+    def _handle_dfsw_side_exhaustion(
+        self, dfsw: DoubleFanShockWave, side: str, theta_event: float, v_event: float
+    ) -> list[Wave]:
+        """Degrade a doubly-fed shock whose ``side`` fan reached its far bound.
+
+        The exhausted side becomes a constant at that far bound, so the front continues as a
+        one-fan :class:`DecayingShockWave` (or a plain :class:`ShockWave` if the surviving
+        side is also at a constant). The successor is built from the same left/right feeder
+        pair with the exhausted side frozen to its far concentration.
+        """
+        left = dfsw.left_feeder
+        right = dfsw.right_feeder
+        if side == "left":
+            c_far = left.c_a if abs(left.c_a - left.value(v_event, theta_event)) < _SIDE_EXHAUSTION_C_TOL else left.c_b
+            left = Feeder.constant(c_far)
+        else:
+            c_far = (
+                right.c_a if abs(right.c_a - right.value(v_event, theta_event)) < _SIDE_EXHAUSTION_C_TOL else right.c_b
+            )
+            right = Feeder.constant(c_far)
+        dfsw.deactivate(theta_event)
+        successor = make_wave_from_feeders(left, right, v_event, theta_event, self.state.sorption)
+        return [successor] if successor is not None else []
 
     def run(self, max_iterations: int = 10000, *, verbose: bool = False):
         """Process events in θ-order until the queue is empty or ``max_iterations`` is reached."""
@@ -601,33 +725,22 @@ class FrontTracker:
 
 
 def find_unresolved_interaction(state: FrontTrackerState) -> str | None:
-    """Locate an unresolved wave–wave interaction inside the transport domain.
+    """Tripwire for a solver-left inconsistency in the resolved wave field (issue #294 D6).
 
-    The event-driven solver resolves shock↔shock, shock↔characteristic and
-    shock↔rarefaction collisions (the last into a :class:`DecayingShockWave`), but it
-    never collides anything *with* a decaying shock, nor composes two fans that come to
-    occupy the same region. Such an unresolved interaction leaves the non-interacting wave
-    objects overlapping, so the exact nonlinear multi-front field is not represented — the
-    public ``cout`` degrades to a spurious linear superposition of a nonlinear operator
-    (mass-fabricating once the reader clamps the resulting negative bins to zero). This
-    detects the first offending interaction so the public API can refuse the input rather
-    than return a wrong, non-conservative answer. Two complementary detectors run over the
-    input θ-window ``(0, theta_edges[-1]]``:
+    The solver now resolves *every* wave interaction (shock↔shock, fan-entry, doubly-fed
+    formation, same-apex annihilation, and their compositions), so the wave list is
+    interaction-consistent and the single-owner sweep reader is exact — overlapping fans are
+    normal and correct. This function is therefore no longer an input filter but an internal
+    invariant check: the cumulative outlet mass ``m_out(θ) = m_in(θ) − m_dom(θ)`` must be
+    non-decreasing in θ (mass leaves the column, it never re-enters). A decrease beyond the
+    FP-cancellation band means the reader's domain-mass field transiently over-counts stored
+    mass — the fingerprint of an interaction the solver failed to resolve (a bug). The public
+    API turns a non-``None`` return into a fail-loud ``RuntimeError`` rather than returning a
+    silently wrong ``cout``.
 
-    1. **Geometric fan overlap.** When two or more fan-bearing waves (rarefactions /
-       decaying shocks) cover a common point inside ``[0, v_outlet]``, their composite
-       field is wrong even when total mass happens to be conserved (a positive-but-wrong
-       ``cout`` with no negative bin — e.g. two decaying shocks with a zero fan tail, or a
-       later pulse's fan sweeping an earlier one). A symptom-only proxy cannot see this
-       class, so the geometric scan is a necessary complement.
-
-    2. **Conservation symptom.** The cumulative outlet mass ``m_out(θ) = m_in(θ) − m_dom(θ)``
-       must be non-decreasing in θ (mass exits the column, it never re-enters). A decrease
-       beyond the FP-cancellation band means the reader's domain-mass field transiently
-       over-counts stored mass — the fingerprint of a shock overtaking another shock /
-       rarefaction / decaying-shock fan. The two fans need NOT share an in-domain point
-       (they may only cross beyond ``v_outlet``), so the geometric scan misses this dominant
-       multi-pulse class; the monotonicity check catches it.
+    The geometric fan-overlap scan of the previous (input-refusing) version is intentionally
+    dropped: with interactions resolved, overlapping fans read identically from either
+    neighbour and are not an error, so that scan is now only a false positive.
 
     Parameters
     ----------
@@ -637,59 +750,24 @@ def find_unresolved_interaction(state: FrontTrackerState) -> str | None:
     Returns
     -------
     str or None
-        A short description (position/θ and mechanism) of the first offending interaction,
-        or ``None`` when the solution is a clean single-front / well-separated superposition
-        that the reader represents exactly.
+        A short description (θ and mechanism) of the first monotonicity violation, or
+        ``None`` when the resolved field conserves mass (the normal case).
 
     Notes
     -----
-    Both scans stay strictly inside the inlet θ-window, so the benign out-of-window
-    saturation clamp (a single-front run whose output bins extend past the last injected
-    mass) does not trip the symptom check. Well-separated pulses that clear a short column
-    before overtaking one another (their fans never share an in-domain point and their
-    cumulative outflow stays monotone) are correctly accepted.
+    The scan stays strictly inside the inlet θ-window, so the benign out-of-window saturation
+    clamp (a run whose output bins extend past the last injected mass) does not trip it.
     """
     waves = state.waves
     v_outlet = state.v_outlet
     theta_hi = float(state.theta_edges[-1])
-    v_tol = 1e-9 * max(v_outlet, 1.0)
     thetas = np.linspace(theta_hi / 400.0, theta_hi, 400)
 
-    # (1) Geometric fan overlap.
-    def fan_covers(wave: Wave, v: float, theta: float) -> bool:
-        """Whether ``wave``'s self-similar fan geometrically spans ``v`` at ``theta``."""
-        if isinstance(wave, DecayingShockWave):
-            v_s = wave.position_at_theta(theta)
-            if v_s is None or v == wave.v_origin:
-                return False
-            return (wave.decay_side == "left" and v < v_s) or (wave.decay_side == "right" and v > v_s)
-        return isinstance(wave, RarefactionWave) and wave.contains_point(v, theta)
-
-    for theta in thetas:
-        fans = [w for w in waves if isinstance(w, (DecayingShockWave, RarefactionWave)) and w.was_active_at(theta)]
-        if len(fans) <= 1:  # a single fan (or none) cannot overlap another
-            continue
-        boundaries = {0.0, v_outlet}
-        for wave in waves:
-            if not wave.was_active_at(theta):
-                continue
-            if isinstance(wave, RarefactionWave):
-                candidates = (wave.head_position_at_theta(theta), wave.tail_position_at_theta(theta))
-            else:
-                candidates = (wave.position_at_theta(theta),)
-            boundaries.update(p for p in candidates if p is not None and 0.0 < p < v_outlet)
-        for v_lo, v_hi in pairwise(sorted(boundaries)):
-            if v_hi - v_lo < v_tol:
-                continue
-            v_mid = 0.5 * (v_lo + v_hi)
-            if len([w for w in fans if fan_covers(w, v_mid, theta)]) > 1:  # ≥ 2 fans share this point
-                return f"two fans overlap at V={v_mid:.4g} m³ (θ={theta:.4g} m³)"
-
-    # (2) Conservation symptom: cumulative outlet mass must be monotone non-decreasing.
-    # The band mirrors ``compute_bin_averaged_concentration_exact``'s FP-cancellation clamp
-    # (same constant, same ``max(scale, 1.0)`` floor) scaled to the total injected mass, so
+    # Conservation symptom: cumulative outlet mass must be monotone non-decreasing. The band
+    # mirrors ``compute_bin_averaged_concentration_exact``'s FP-cancellation clamp (same
+    # constant, same ``max(scale, 1.0)`` floor) scaled to the total injected mass, so
     # pre-breakthrough cancellation dust stays silent while a genuine over-count (orders of
-    # magnitude above the band) refuses the input.
+    # magnitude above the band) is caught.
     grid = np.concatenate(([0.0], thetas))
     m_out = np.array([
         compute_cumulative_outlet_mass(
@@ -698,13 +776,25 @@ def find_unresolved_interaction(state: FrontTrackerState) -> str | None:
         for theta in grid
     ])
     m_in_total = float(np.sum(state.cin * np.diff(state.theta_edges)))
-    band = FP_CANCELLATION_CLAMP * np.finfo(float).eps * max(m_in_total, 1.0)
-    steps = np.diff(m_out)
-    worst = int(np.argmin(steps))
-    if steps[worst] < -band:
+    # Tolerance band: the larger of the FP-cancellation floor and a 1e-6 relative transient
+    # allowance. The latter absorbs the benign ``c_min``-floor artifact at a fan-entry (the
+    # decaying side is born at ``c ≈ 1e-12`` rather than exactly 0, perturbing the near-apex
+    # fan integral by ~1e-3 for one θ-sample). A genuine unresolved interaction over-counts by
+    # O(a pulse's mass) — orders of magnitude above this band — so the tripwire still fires.
+    band = max(FP_CANCELLATION_CLAMP * np.finfo(float).eps, 1e-6) * max(m_in_total, 1.0)
+    # A real over-count is SUSTAINED — m_out stays below its running maximum across a θ-range.
+    # A single isolated sub-maximum sample is a measure-zero knife-edge at an exact collision θ
+    # (the parents are deactivated and the successor just born); it does not affect the
+    # integral-based bin-averaged cout, so require two consecutive samples below the running
+    # max before flagging. (The actual cout the API returns never sees the knife-edge.)
+    running_max = np.maximum.accumulate(m_out)
+    below = m_out < running_max - band
+    sustained = below[:-1] & below[1:]
+    if np.any(sustained):
+        idx = int(np.argmax(sustained))
+        drop = float(running_max[idx] - m_out[idx + 1])
         return (
-            f"cumulative outlet mass drops by {-steps[worst]:.4g} near θ={grid[worst + 1]:.4g} m³ "
-            "(a shock overtakes another shock / rarefaction / decaying-shock fan; the reader "
-            "over-counts stored mass there)"
+            f"cumulative outlet mass drops by {drop:.4g} near θ={grid[idx + 1]:.4g} m³ "
+            "(the reader over-counts stored mass there — an interaction the solver failed to resolve)"
         )
     return None

--- a/src/gwtransport/fronttracking/waves.py
+++ b/src/gwtransport/fronttracking/waves.py
@@ -17,6 +17,7 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from operator import itemgetter
 
 import numpy as np
 from scipy.interpolate import CubicSpline
@@ -44,6 +45,94 @@ DECAYING_SHOCK_BRENTQ_XTOL = (
 DECAY_PROFILE_NODES = 6000
 DECAY_PROFILE_GAUSS_ORDER = 10
 DECAY_PROFILE_POLE_FLOOR = 1e-6
+# DoubleFanShockWave numerical-trajectory RK4 substeps per unit of fan age (only used when
+# no closed form applies — distinct fan apex positions or a non-n=2 isotherm). The
+# self-similar fans vary on the scale of their age, so the step is age/this-many.
+DFSW_RK_SUBSTEPS = 512
+
+
+@dataclass(frozen=True)
+class Feeder:
+    """One side's boundary state feeding a front: a constant, or a bounded self-similar fan.
+
+    A ``const`` feeder ignores ``(v, θ)`` and returns its value everywhere. A ``fan``
+    feeder evaluates the self-similar retardation ``R = (θ − θ_apex)/(v − v_apex)`` and
+    inverts it to a concentration, clamped to the fan's physical extent ``[c_a, c_b]``.
+    The clamp is monotonicity-agnostic (it clamps in ``R``-space, so it is correct for
+    both R-decreasing isotherms — Freundlich ``n>1``, Langmuir, Brooks-Corey,
+    van Genuchten-Mualem — and the R-increasing Freundlich ``n<1`` mirror), and it is
+    exactly what makes a fan feeder read the plateau concentration beyond the fan's edge.
+
+    Feeders are the uniform currency of the interaction calculus: every wave exposes its
+    sides as feeders, event handlers form a successor from ``(rear.left, front.right)``,
+    and the reader evaluates the left feeder of the nearest downstream face.
+    """
+
+    c_a: float
+    """One physical boundary concentration of the fan (or the constant value)."""
+    c_b: float
+    """The other physical boundary concentration of the fan (unused for a constant)."""
+    is_const: bool
+    """Whether this is a constant state (``True``) or a self-similar fan (``False``)."""
+    v_apex: float = 0.0
+    """Fan apex position [m³] (ignored for a constant)."""
+    theta_apex: float = 0.0
+    """Fan apex cumulative flow [m³] (ignored for a constant)."""
+    sorption: SorptionModel | None = None
+    """Sorption model used to invert ``R`` (required for a fan; ``None`` for a constant)."""
+    far_boundary_free: bool = True
+    """Whether the fan's far edge is a free plateau boundary (a collision line) rather than
+    already terminated by another shock. Propagated through merges so a wave born onto a
+    fan whose far end another wave owns does not re-expose a phantom boundary line."""
+
+    @classmethod
+    def constant(cls, c: float) -> "Feeder":
+        """Return a constant-concentration feeder."""
+        return cls(c_a=c, c_b=c, is_const=True)
+
+    @classmethod
+    def fan(
+        cls,
+        v_apex: float,
+        theta_apex: float,
+        c_a: float,
+        c_b: float,
+        sorption: SorptionModel,
+        *,
+        far_boundary_free: bool = True,
+    ) -> "Feeder":
+        """Return a bounded self-similar fan feeder with apex ``(v_apex, theta_apex)`` spanning ``[c_a, c_b]``."""
+        return cls(
+            c_a=c_a,
+            c_b=c_b,
+            is_const=False,
+            v_apex=v_apex,
+            theta_apex=theta_apex,
+            sorption=sorption,
+            far_boundary_free=far_boundary_free,
+        )
+
+    def value(self, v: float, theta: float) -> float:
+        """Concentration this feeder supplies at ``(v, θ)`` (clamped to the fan extent)."""
+        if self.is_const:
+            return self.c_a
+        sorption = self.sorption
+        assert sorption is not None  # noqa: S101  # a fan feeder always carries its sorption model
+        r_a = float(sorption.retardation(self.c_a))
+        r_b = float(sorption.retardation(self.c_b))
+        # c at the smaller-R (faster, "head") and larger-R (slower, "tail"/apex) ends.
+        if r_a <= r_b:
+            r_lo, r_hi, c_at_lo, c_at_hi = r_a, r_b, self.c_a, self.c_b
+        else:
+            r_lo, r_hi, c_at_lo, c_at_hi = r_b, r_a, self.c_b, self.c_a
+        if theta <= self.theta_apex or v <= self.v_apex:
+            return c_at_hi  # at/behind the apex: the largest-R (tail) end
+        r = (theta - self.theta_apex) / (v - self.v_apex)
+        if r <= r_lo:
+            return c_at_lo
+        if r >= r_hi:
+            return c_at_hi
+        return float(sorption.concentration_from_retardation(r))
 
 
 @dataclass
@@ -199,9 +288,16 @@ class CharacteristicWave(Wave):
     """
 
     concentration: float
-    """Constant concentration carried [mass/volume]."""
+    """Constant concentration carried on the upstream (behind) side [mass/volume]."""
     sorption: SorptionModel
     """Sorption model determining the speed."""
+    c_ahead: float = field(default=0.0, kw_only=True)
+    """Concentration on the downstream (ahead) side — the state the contact advances into.
+
+    A contact separates the carried ``concentration`` (behind, upstream) from ``c_ahead``
+    (ahead, downstream, the pre-existing state). The solver sets it to the previous inlet
+    value; it defaults to ``0`` (the virgin initial condition) for a lone contact. The
+    reader sweep uses it as the contact's downstream feeder."""
     _speed: float = field(init=False, repr=False, compare=False)
     """Cached characteristic speed (immutable inputs; set in ``__post_init__``)."""
 
@@ -539,11 +635,11 @@ class DecayingShockWave(Wave):
     - Freundlich, ``c_fixed = 0`` (general ``n > 0``, ``n ≠ 1``) — closed form:
       invariant ``θ_local · u_d^n = K · (n · u_d^(n-1) + α)``,
       position ``V_s(θ) = v_origin + n · K / u_d(θ)``.
-    - Freundlich, ``c_fixed > 0``, ``n = 2`` and ``c_decay_initial > c_fixed``
-      — closed form: invariant ``(u_d - u_R)² · θ_local = K · (2 u_d + α)``
-      with ``u_R := c_fixed^(1/2)``,
-      position ``V_s(θ) = v_origin + 2 K · u_d(θ) / (u_d - u_R)²``.
-      (The ``c_decay_initial < c_fixed`` mirror falls through to numerical.)
+    - Freundlich, ``c_fixed > 0``, ``n = 2`` (either decay orientation) — closed form:
+      invariant ``(u_d - u_R)² · θ_local = K · (2 u_d + α)`` with ``u_R := c_fixed^(1/2)``,
+      position ``V_s(θ) = v_origin + 2 K · u_d(θ) / (u_d - u_R)²``. The root of the
+      quadratic in ``u_d`` is selected by the decay orientation (``u_d > u_R`` shrinking,
+      ``u_d < u_R`` growing); both are exact (verified to ~1e-14 vs a DOP853 integration).
     - Langmuir, ``c_fixed = 0`` — closed form:
       invariant ``θ_local · c_d² = K · ((K_L + c_d)² + a)`` with
       ``a := ρ_b · s_max · K_L / n_por``,
@@ -631,6 +727,13 @@ class DecayingShockWave(Wave):
     """Cached predicate: no closed form applies, so the decay routes to the cached numerical profile."""
     _decay_profile_cache: tuple | None = field(default=None, init=False, repr=False, compare=False)
     """Lazily-built monotone ``θ_local(c)`` map for the numerical decay path (see ``_decay_profile``)."""
+    fan_boundary_consumed: bool = field(default=False, kw_only=True)
+    """Whether the fan's far-boundary line is owned from birth (a fan-entry successor rides a
+    fan another wave already terminates downstream, so its boundary is never a free face)."""
+    theta_fan_boundary_consumed: float = field(default=float("inf"), kw_only=True)
+    """Cumulative flow at which a *free* boundary line was later consumed by a wave entering
+    the fan. Retrospective reader/event queries treat the boundary as free only for
+    ``θ < theta_fan_boundary_consumed`` (historical truth, mirroring ``was_active_at``)."""
 
     def __post_init__(self) -> None:
         """Validate inputs and compute the closed-form invariant K when applicable."""
@@ -661,13 +764,14 @@ class DecayingShockWave(Wave):
             raise TypeError(msg)
 
         # Classify the decay path once (immutable inputs). Closed forms exist for:
-        # Freundlich c_fixed=0 (general n) or the n≈2 quadratic when the decaying side
-        # starts above the fixed side (the +√ / (u_d−u_R)² branch was derived only for
-        # c_decay_initial > c_fixed — the mirror routes to the numerical profile);
+        # Freundlich c_fixed=0 (general n) or the n≈2 quadratic for either decay orientation
+        # (shrinking c_decay_initial > c_fixed picks the +√ root, growing c_decay_initial <
+        # c_fixed the −√ root; both invert the same (u_d−u_R)² invariant, verified exact to
+        # ~1e-14 vs a DOP853 integration of the fan-fed shock ODE);
         # Langmuir c_fixed=0; Brooks-Corey c_fixed=0. Everything else is numerical.
         s = self.sorption
         self._freundlich_cf = isinstance(s, FreundlichSorption) and (
-            self.c_fixed == 0.0 or bool(np.isclose(s.n, 2.0, rtol=1e-12) and self.c_decay_initial > self.c_fixed)
+            self.c_fixed == 0.0 or bool(np.isclose(s.n, 2.0, rtol=1e-12) and self.c_decay_initial != self.c_fixed)
         )
         self._langmuir_cf = isinstance(s, LangmuirSorption) and self.c_fixed == 0.0
         self._brooks_corey_cf = isinstance(s, BrooksCoreyConductivity) and self.c_fixed == 0.0
@@ -842,6 +946,7 @@ class DecayingShockWave(Wave):
             return _outlet_crossing_freundlich(
                 s,
                 self.K,
+                self.c_decay_initial,
                 self.c_fixed,
                 self.v_origin,
                 self.theta_origin,
@@ -968,6 +1073,260 @@ class DecayingShockWave(Wave):
         if c_fan < c_lo - EPSILON_POSITION or c_fan > c_hi + EPSILON_POSITION:
             return None
         return c_fan
+
+
+@dataclass
+class DoubleFanShockWave(Wave):
+    r"""Shock fed by a self-similar fan on BOTH sides (a doubly-fed front).
+
+    Formed when a fan boundary (rarefaction head/tail, or another fan-fed shock) catches a
+    :class:`DecayingShockWave` whose surviving side is itself a fan — the merged front then
+    has a fan feeder on each side. The shock trajectory solves
+
+    .. math::
+        \frac{dV}{d\theta} = S\bigl(c_L(V,\theta),\, c_R(V,\theta)\bigr), \qquad
+        R(c_i) = \frac{\theta - \theta_{{\rm apex},i}}{V - v_{{\rm apex},i}},
+
+    with ``S`` the Rankine-Hugoniot secant and each ``c_i`` the self-similar value of its fan.
+
+    **Closed form (Freundlich ``n = 2``, shared apex position ``v_L = v_R = v_o``).** With
+    ``u_i = \sqrt{c_i} = A V'/(2(\tau_i - V'))`` (``V' = V - v_o``, ``\tau_i = \theta -
+    \theta_{{\rm apex},i}``, ``A = \rho_b k_f/n_{por}``), the product ``K = u_L u_R`` is a
+    first integral of the ODE, and the trajectory is the physical root of
+
+    .. math::
+        (A^2 - 4K)\,V'^2 + 4K(\tau_L + \tau_R)\,V' - 4K\,\tau_L\,\tau_R = 0,
+        \qquad 0 < V' < \min(\tau_L, \tau_R).
+
+    Every fan born at the inlet shares ``v_o = 0``, so inlet-driven inputs use the closed
+    form. **General fallback** (distinct apex positions, or a non-``n=2`` isotherm): the ODE
+    is integrated once by fixed-step RK4 (``\Delta\theta = \text{fan age}/DFSW_RK_SUBSTEPS``,
+    speed-independent since the fans vary on the scale of their age) into a cached monotone
+    spline. Both paths answer position, side concentrations, side exhaustion and outlet
+    crossing uniformly.
+
+    See Also
+    --------
+    DecayingShockWave : One fan side; the doubly-fed front degrades to this on side exhaustion.
+    Feeder : The bounded-fan side descriptor this wave carries.
+    """
+
+    left_feeder: Feeder
+    """Left (upstream) side feeder — a fan."""
+    right_feeder: Feeder
+    """Right (downstream) side feeder — a fan."""
+    sorption: NonlinearSorption
+    """Sorption model (concentration-dependent)."""
+    left_boundary_consumed: bool = field(default=False, kw_only=True)
+    """Whether the left fan's far-boundary line is owned from birth (not a free collision face)."""
+    right_boundary_consumed: bool = field(default=False, kw_only=True)
+    """Whether the right fan's far-boundary line is owned from birth (not a free collision face)."""
+    theta_left_boundary_consumed: float = field(default=float("inf"), kw_only=True)
+    """Cumulative flow at which a free left boundary was later consumed (historical, see DSW)."""
+    theta_right_boundary_consumed: float = field(default=float("inf"), kw_only=True)
+    """Cumulative flow at which a free right boundary was later consumed (historical, see DSW)."""
+    _closed_form: bool = field(init=False, repr=False, compare=False)
+    """Whether the n=2 shared-apex closed form applies."""
+    _k: float = field(init=False, repr=False, compare=False)
+    """Closed-form first integral ``K = u_L·u_R`` (``nan`` for the numerical path)."""
+    _traj_cache: tuple | None = field(default=None, init=False, repr=False, compare=False)
+    """Lazily-built ``(theta_grid, CubicSpline)`` for the numerical trajectory."""
+
+    def __post_init__(self) -> None:
+        """Classify closed-form vs numerical and set the first integral ``K``."""
+        if self.left_feeder.is_const or self.right_feeder.is_const:
+            msg = "DoubleFanShockWave requires two fan feeders; use DecayingShockWave for a one-fan front"
+            raise ValueError(msg)
+        if self.theta_origin_left >= self.theta_start or self.theta_origin_right >= self.theta_start:
+            msg = "both fan apexes must precede the collision (theta_apex < theta_start)"
+            raise ValueError(msg)
+        s = self.sorption
+        shared_apex = abs(self.left_feeder.v_apex - self.right_feeder.v_apex) < EPSILON_POSITION
+        self._closed_form = isinstance(s, FreundlichSorption) and bool(np.isclose(s.n, 2.0, rtol=1e-12)) and shared_apex
+        self._k = float("nan")
+        if self._closed_form:
+            v_prime = self.v_start - self.left_feeder.v_apex
+            tau_l = self.theta_start - self.theta_origin_left
+            tau_r = self.theta_start - self.theta_origin_right
+            a = self._alpha()
+            u_l = a * v_prime / (2.0 * (tau_l - v_prime))
+            u_r = a * v_prime / (2.0 * (tau_r - v_prime))
+            self._k = u_l * u_r
+
+    @property
+    def theta_origin_left(self) -> float:
+        """Cumulative flow at the left fan's apex [m³]."""
+        return self.left_feeder.theta_apex
+
+    @property
+    def theta_origin_right(self) -> float:
+        """Cumulative flow at the right fan's apex [m³]."""
+        return self.right_feeder.theta_apex
+
+    def _alpha(self) -> float:
+        """Freundlich lumped coefficient ``A = ρ_b·k_f/n_por`` (closed-form path only)."""
+        s = self.sorption
+        assert isinstance(s, FreundlichSorption)  # noqa: S101
+        return s.bulk_density * s.k_f / s.porosity
+
+    def _v_closed(self, theta: float) -> float:
+        """Closed-form shock position at ``theta`` (n=2 shared apex)."""
+        v_o = self.left_feeder.v_apex
+        tau_l = theta - self.theta_origin_left
+        tau_r = theta - self.theta_origin_right
+        a2 = self._alpha() ** 2 - 4.0 * self._k
+        a1 = 4.0 * self._k * (tau_l + tau_r)
+        a0 = -4.0 * self._k * tau_l * tau_r
+        if abs(a2) < EPSILON_POSITION:
+            # A² = 4K: the quadratic degenerates to linear a1·V' + a0 = 0.
+            v_prime = -a0 / a1
+            return v_o + v_prime
+        disc = a1 * a1 - 4.0 * a2 * a0
+        sqrt_disc = np.sqrt(max(disc, 0.0))
+        upper = min(tau_l, tau_r)
+        for sign in (-1.0, 1.0):
+            v_prime = (-a1 + sign * sqrt_disc) / (2.0 * a2)
+            if 0.0 < v_prime < upper:
+                return v_o + v_prime
+        # Numerical fallback: pick the root closest to the valid open interval.
+        candidates = [(-a1 + sign * sqrt_disc) / (2.0 * a2) for sign in (-1.0, 1.0)]
+        v_prime = min(candidates, key=lambda x: abs(x - 0.5 * upper))
+        return v_o + float(np.clip(v_prime, 0.0, upper))
+
+    def _rhs(self, v: float, theta: float) -> float:
+        """Shock-speed ODE right side ``S(c_L, c_R)`` at ``(v, θ)`` (numerical path)."""
+        c_l = self.left_feeder.value(v, theta)
+        c_r = self.right_feeder.value(v, theta)
+        return float(self.sorption.shock_speed(c_l, c_r))
+
+    def _ensure_numerical(self, theta: float) -> tuple:
+        """Build/extend the cached RK4 trajectory spline out to at least ``theta``."""
+        age0 = max(min(self.theta_start - self.theta_origin_left, self.theta_start - self.theta_origin_right), 1.0)
+        step0 = age0 / DFSW_RK_SUBSTEPS
+        if self._traj_cache is None:
+            thetas = [self.theta_start]
+            vs = [self.v_start]
+        else:
+            thetas, vs, _ = self._traj_cache
+            thetas = list(thetas)
+            vs = list(vs)
+        # March past ``theta`` and always keep at least two nodes so CubicSpline is well-posed
+        # (a query at ``theta_start`` alone would otherwise leave a single node).
+        target = max(theta, self.theta_start + step0)
+        while thetas[-1] < target:
+            t0 = thetas[-1]
+            v0 = vs[-1]
+            age = min(t0 - self.theta_origin_left, t0 - self.theta_origin_right, age0 + (t0 - self.theta_start))
+            h = max(age, age0) / DFSW_RK_SUBSTEPS
+            k1 = self._rhs(v0, t0)
+            k2 = self._rhs(v0 + 0.5 * h * k1, t0 + 0.5 * h)
+            k3 = self._rhs(v0 + 0.5 * h * k2, t0 + 0.5 * h)
+            k4 = self._rhs(v0 + h * k3, t0 + h)
+            vs.append(v0 + (h / 6.0) * (k1 + 2.0 * k2 + 2.0 * k3 + k4))
+            thetas.append(t0 + h)
+        theta_arr = np.asarray(thetas)
+        v_arr = np.asarray(vs)
+        spline = CubicSpline(theta_arr, v_arr)
+        self._traj_cache = (theta_arr, v_arr, spline)
+        return self._traj_cache
+
+    def _v_at(self, theta: float) -> float:
+        """Shock position at ``theta`` (closed form or cached numerical spline)."""
+        if self._closed_form:
+            return self._v_closed(theta)
+        _theta_arr, _v_arr, spline = self._ensure_numerical(theta)
+        return float(spline(theta))
+
+    def position_at_theta(self, theta: float) -> float | None:
+        """Shock position ``V_s(θ)``; ``None`` for ``θ < theta_start`` or when inactive."""
+        if not self.was_active_at(theta):
+            return None
+        return self._v_at(theta)
+
+    def side_values(self, theta: float) -> tuple[float, float]:
+        """``(c_L, c_R)`` on the two sides of the shock face at ``theta``."""
+        v = self._v_at(theta)
+        return self.left_feeder.value(v, theta), self.right_feeder.value(v, theta)
+
+    def concentration_left(self) -> float:
+        """Left-side concentration at the collision moment."""
+        return self.left_feeder.value(self.v_start, self.theta_start)
+
+    def concentration_right(self) -> float:
+        """Right-side concentration at the collision moment."""
+        return self.right_feeder.value(self.v_start, self.theta_start)
+
+    def _bracket_and_solve(self, residual, *, r0: float) -> float | None:
+        """Find the first θ > theta_start where a monotone ``residual(θ)`` crosses zero.
+
+        ``r0 = residual(theta_start)`` is known to be nonzero; grow the upper bracket
+        geometrically until the sign flips, then ``brentq``. Returns ``None`` if the
+        residual never changes sign (the trajectory asymptotes short of the target).
+        """
+        seed = max(self.theta_start - min(self.theta_origin_left, self.theta_origin_right), 1.0)
+        hi = self.theta_start + seed
+        for _ in range(200):
+            if residual(hi) * r0 < 0.0:
+                return float(brentq(residual, self.theta_start, hi, xtol=DECAYING_SHOCK_BRENTQ_XTOL))
+            hi = self.theta_start + 2.0 * (hi - self.theta_start)
+        return None
+
+    def outlet_crossing_theta(self, v_outlet: float) -> float | None:
+        """Cumulative flow at which ``V_s = v_outlet`` (monotone, inverted by brentq)."""
+        if v_outlet <= self.v_start:
+            return None
+        return self._bracket_and_solve(lambda theta: self._v_at(theta) - v_outlet, r0=self.v_start - v_outlet)
+
+    def theta_at_side_exhaustion(self) -> tuple[float, str] | None:
+        """Earliest ``(θ, side)`` at which a side's fan value reaches its far bound.
+
+        A side exhausts when its concentration reaches the fan edge it is moving toward; the
+        solver then degrades the doubly-fed front to a :class:`DecayingShockWave` (or a plain
+        :class:`ShockWave` if both exhaust). Returns ``None`` when neither side exhausts in
+        finite θ (the shock asymptotes to the interior state).
+        """
+        candidates: list[tuple[float, str]] = []
+        for side, feeder in (("left", self.left_feeder), ("right", self.right_feeder)):
+            c_now = feeder.value(self.v_start, self.theta_start)
+            # The value moves monotonically toward one fan edge; target that edge.
+            target = feeder.c_a if abs(feeder.c_a - c_now) > abs(feeder.c_b - c_now) else feeder.c_b
+            r0 = c_now - target
+            if abs(r0) < EPSILON_POSITION:
+                continue
+            root = self._bracket_and_solve(
+                lambda theta, feeder=feeder, target=target: feeder.value(self._v_at(theta), theta) - target,
+                r0=r0,
+            )
+            if root is not None:
+                candidates.append((root, side))
+        if not candidates:
+            return None
+        return min(candidates, key=itemgetter(0))
+
+    def concentration_at_point(self, v: float, theta: float) -> float | None:
+        """Concentration at ``(v, θ)`` if controlled by this doubly-fed shock.
+
+        Left of the shock face the left fan controls; right of it the right fan; at the face
+        the average. Outside both fans' physical extents returns ``None`` (another wave owns
+        the point).
+        """
+        if not self.was_active_at(theta):
+            return None
+        v_s = self._v_at(theta)
+        tol = 1e-15 * max(abs(v_s), 1.0)
+        if abs(v - v_s) < tol:
+            c_l, c_r = self.side_values(theta)
+            return 0.5 * (c_l + c_r)
+        feeder = self.left_feeder if v < v_s else self.right_feeder
+        # Only claim the point if it lies within the fan's live self-similar range.
+        if theta <= feeder.theta_apex or v <= feeder.v_apex:
+            return None
+        r = (theta - feeder.theta_apex) / (v - feeder.v_apex)
+        r_a = float(self.sorption.retardation(feeder.c_a))
+        r_b = float(self.sorption.retardation(feeder.c_b))
+        if r < min(r_a, r_b) - EPSILON_POSITION or r > max(r_a, r_b) + EPSILON_POSITION:
+            return None
+        return feeder.value(v, theta)
 
 
 def _invert_monotone_theta_local(f, *, theta_hi_seed: float, f_seed: float | None = None) -> float | None:
@@ -1212,7 +1571,10 @@ def _c_decay_freundlich(
     ``u = (K + sqrt(K^2 + K·θ_local·α)) / θ_local``. For general n with
     c_fixed=0 (transcendental): brentq on the monotone bracket
     ``(tiny, c_decay_initial^(1/n)]``. For n=2 c_fixed>0 (quadratic in u with u_r):
-    closed form with positive sign chosen to give u > u_r as θ_local → ∞.
+    closed form; the root is selected by the decay orientation — the ``+√`` root
+    (``u > u_r``) for a shrinking decay (``c_decay_initial > c_fixed``), the ``−√``
+    root (``u < u_r``) for a growing decay (``c_decay_initial < c_fixed``). Both
+    approach ``u_r`` as ``θ_local → ∞``; the initial side of ``u_r`` fixes the branch.
 
     Returns
     -------
@@ -1230,10 +1592,15 @@ def _c_decay_freundlich(
         u_root = _invert_freundlich_cr_zero(k_invariant, c_decay_initial, n, alpha, theta_local_collision, theta_local)
         return float(u_root**n)
 
-    # n=2, c_fixed > 0
+    # n=2, c_fixed > 0. Growing decay (c_decay_initial < c_fixed) starts below u_r and
+    # takes the −√ root; shrinking decay starts above u_r and takes the +√ root.
     u_r = c_fixed**0.5
     disc = k_invariant * (theta_local * (2.0 * u_r + alpha) + k_invariant)
-    u = (u_r * theta_local + k_invariant + np.sqrt(disc)) / theta_local
+    sqrt_disc = np.sqrt(disc)
+    if c_decay_initial < c_fixed:
+        u = (u_r * theta_local + k_invariant - sqrt_disc) / theta_local
+    else:
+        u = (u_r * theta_local + k_invariant + sqrt_disc) / theta_local
     return float(u * u)
 
 
@@ -1286,6 +1653,7 @@ def _c_decay_langmuir(sorption: LangmuirSorption, k_invariant: float, theta_loca
 def _outlet_crossing_freundlich(
     sorption: FreundlichSorption,
     k_invariant: float,
+    c_decay_initial: float,
     c_fixed: float,
     v_origin: float,
     theta_origin: float,
@@ -1310,17 +1678,22 @@ def _outlet_crossing_freundlich(
         return float(theta_origin + theta_local)
 
     # n=2, c_fixed > 0: V_s - v_origin = 2·K·u / (u - u_r)^2 ⇒ quadratic in u.
-    # The plus-sqrt root always satisfies u > u_r for K, alpha, delta_v > 0:
-    # the quadratic's roots multiply to u_r² and sum to 2u_r + 2K/delta_v > 2u_r,
-    # so exactly one root exceeds u_r and it is the plus-sqrt branch. The
-    # minus-sqrt root is the unphysical companion.
+    # The two roots multiply to u_r² and sum to 2u_r + 2K/delta_v > 2u_r, so exactly one
+    # exceeds u_r (the +√ root, shrinking decay) and one lies below (the −√ root, growing
+    # decay). Select by the decay orientation to match _c_decay_freundlich's branch.
     u_r = c_fixed**0.5
     b_coef = -(2.0 * delta_v * u_r + 2.0 * k_invariant)
     c_coef = delta_v * u_r * u_r
     disc = b_coef * b_coef - 4.0 * delta_v * c_coef
     if disc < 0:
         return None
-    u_target = (-b_coef + np.sqrt(disc)) / (2.0 * delta_v)
+    sqrt_disc = np.sqrt(disc)
+    if c_decay_initial < c_fixed:
+        u_target = (-b_coef - sqrt_disc) / (2.0 * delta_v)
+    else:
+        u_target = (-b_coef + sqrt_disc) / (2.0 * delta_v)
+    if u_target <= 0.0:
+        return None
     theta_local = k_invariant * (2.0 * u_target + alpha) / (u_target - u_r) ** 2
     return float(theta_origin + theta_local)
 

--- a/tests/src/test_front_tracking_api.py
+++ b/tests/src/test_front_tracking_api.py
@@ -8,8 +8,13 @@ import pytest
 
 from gwtransport.advection import infiltration_to_extraction_nonlinear_sorption
 from gwtransport.fronttracking.math import FreundlichSorption, LangmuirSorption, compute_first_front_arrival_theta
-from gwtransport.fronttracking.solver import FrontTracker, find_unresolved_interaction
-from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
+from gwtransport.fronttracking.output import (
+    compute_breakthrough_curve,
+    compute_cumulative_inlet_mass,
+    compute_domain_mass,
+)
+from gwtransport.fronttracking.solver import FrontTracker, FrontTrackerState, find_unresolved_interaction
+from gwtransport.fronttracking.waves import CharacteristicWave, DoubleFanShockWave, RarefactionWave, ShockWave
 from gwtransport.utils import compute_time_edges
 
 
@@ -639,37 +644,45 @@ class TestFrontTrackingAPI:
             )
 
 
-class TestMultiPeakInteractionRefused:
-    """End-to-end: a multi-peak cin whose fans overlap is refused, not silently mis-answered.
+class TestMultiPeakInteractionResolved:
+    """End-to-end: a multi-peak cin whose fans overlap now runs — interactions are resolved.
 
-    A later pulse's front sweeps into the first pulse's decaying-shock fan — an unresolved wave
-    interaction the front tracker does not compose. The single-owner reader then either drops the
-    earlier pulse's near-inlet mass (leaking a spurious inlet→outlet echo in the conservation-form
-    ``cout``) or over-counts it; neither is the true field. Rather than return that mass-losing
-    output, the public API refuses the input with ``NotImplementedError`` (an output-side mitigation
-    was tried and reverted because it fixed neither the physics nor a percolation regression). Exact
-    multi-front interaction is deferred to a solver-level follow-up.
+    A later pulse's front sweeps into the first pulse's decaying-shock fan. The solver
+    (issue #294) resolves such multi-front wave interactions instead of refusing the input;
+    the single-owner reader reads an interaction-consistent front list. This case pins the
+    conservation invariant on the resolved state: with a strongly retarded front (R≈37–52) and
+    a short 9-day window, no front reaches the outlet, so every unit of injected mass is still
+    stored in the domain — a C3-class conservation regression at a second parameter set.
     """
 
-    def test_multipeak_raises_not_implemented(self):
-        """Overlapping-fan multi-peak input raises ``NotImplementedError`` at the public boundary."""
+    def test_multipeak_pre_arrival_conserves_mass(self):
+        """Pre-arrival: domain mass equals cumulative inlet mass to machine precision."""
         cin = np.array([0.0, 10.0, 10.0, 0.0, 0.0, 0.0, 5.0, 5.0, 0.0])
         flow = np.full(len(cin), 100.0)
         tedges = pd.date_range("2020-01-01", periods=len(cin) + 1, freq="D")
-        cout_tedges = pd.date_range("2020-01-01", periods=len(cin) + 1, freq="D")
+        aquifer_pore_volume = 40.0
+        sorption = FreundlichSorption(k_f=0.05, n=2.0, bulk_density=1600.0, porosity=0.35)
 
-        with pytest.raises(NotImplementedError, match="interacting fronts"):
-            infiltration_to_extraction_nonlinear_sorption(
-                cin=cin,
-                flow=flow,
-                tedges=tedges,
-                cout_tedges=cout_tedges,
-                aquifer_pore_volumes=np.array([40.0]),
-                freundlich_k=0.05,
-                freundlich_n=2.0,
-                bulk_density=1600.0,
-                porosity=0.35,
-            )
+        tracker = FrontTracker(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            aquifer_pore_volume=aquifer_pore_volume,
+            sorption=sorption,
+        )
+        tracker.run()
+
+        theta_edges = tracker.state.theta_edges
+        theta_end = float(theta_edges[-1])
+        m_dom = compute_domain_mass(
+            theta=theta_end, v_outlet=aquifer_pore_volume, waves=tracker.state.waves, sorption=sorption
+        )
+        m_in = compute_cumulative_inlet_mass(theta_end, cin, theta_edges)
+
+        # Nothing broke through in-window, so all injected mass is still in the domain.
+        # rtol 1e-5 absorbs the benign c_min-floor transient (~5e-7); the pre-fix C3 bug dropped a
+        # full pulse (1000 of 3000), far above this — so the pin still catches that regression.
+        np.testing.assert_allclose(m_dom, m_in, rtol=1e-5)
 
 
 def _fv_outlet_cout_freundlich_n2(cin, flow, v_pv, k_f, bulk_density, porosity, *, n_cells=2500, cfl=0.4):
@@ -745,18 +758,16 @@ def _fv_outlet_cout_freundlich_n2(cin, flow, v_pv, k_f, bulk_density, porosity, 
 
 
 class TestUnresolvedMultiFrontInteractionRaises:
-    """The public API refuses inputs whose fronts interact unresolved, and runs non-interacting ones.
+    """The public API resolves interacting multi-front inputs and matches an independent FV oracle.
 
-    The front tracker resolves shock↔shock / shock↔rarefaction collisions (the latter into a
-    ``DecayingShockWave``) but never composes a later front overtaking an existing decaying-shock fan
-    (nor two fans overlapping). Such an unresolved interaction makes the public ``cout`` a linear
-    superposition of a nonlinear operator — mass-losing and silently wrong — so
-    :func:`~gwtransport.advection.infiltration_to_extraction_nonlinear_sorption` raises
-    ``NotImplementedError`` (via
-    :func:`gwtransport.fronttracking.solver.find_unresolved_interaction`) rather than returning it.
-    A single front, or well-separated pulses that break through before overtaking one another, run
-    and match an independent Godunov FV oracle. Acceptance params: Freundlich ``n=2``, ``k_f=0.01``,
-    ``ρ_b=1500``, ``φ=0.3``, ``flow=100``.
+    The solver now composes every wave interaction (shock↔shock, fan-entry, doubly-fed formation,
+    same-apex annihilation, and their compositions), so
+    :func:`~gwtransport.advection.infiltration_to_extraction_nonlinear_sorption` returns the exact
+    entropy solution rather than refusing the input (issue #294). Every case below — the multi-peak,
+    plateau, nonzero-dip and the three oscillating two-pulse signals that a prior guard refused —
+    runs and matches the independent Godunov FV oracle to well within 1% cumulative outlet mass and
+    a few times the single-front FV floor per bin. Acceptance params: Freundlich ``n=2``,
+    ``k_f=0.01``, ``ρ_b=1500``, ``φ=0.3``, ``flow=100``.
     """
 
     K_F, N, RHO_B, POR, FLOW = 0.01, 2.0, 1500.0, 0.3, 100.0
@@ -785,28 +796,33 @@ class TestUnresolvedMultiFrontInteractionRaises:
             ([0, 5, 10, 10, 5, 0], 40.0, 74),  # plateau: internal c=10 shock catches the 0→5 shock before outlet
             ([0, 10, 10, 2, 2, 2, 5, 5, 0], 40.0, 111),  # nonzero-dip: a fan overtakes an earlier decaying fan
             # Conservation-symptom class (pulse-2 shock overtakes pulse-1's decaying-shock fan; the
-            # two fans only cross BEYOND v_outlet, so the geometric scan cannot see it — the
-            # cumulative-outlet-mass monotonicity check refuses the fabricated mass instead). These
-            # are the seasonal/oscillating two-pulse signals a prior guard silently mis-answered.
+            # two fans only cross BEYOND v_outlet). These are the seasonal/oscillating two-pulse
+            # signals a prior guard silently mis-answered — now resolved exactly.
             ([0, 10, 10, 0, 10, 10, 0], 40.0, 53),  # 2-pulse equal
             ([0, 5, 5, 0, 10, 10, 0], 40.0, 53),  # 2-pulse rising
             ([0, 10, 10, 0, 5, 5, 0], 40.0, 53),  # 2-pulse falling
         ],
     )
-    def test_interacting_multifront_raises(self, pulse, v_pv, n_trail):
-        """An in-domain unresolved wave interaction raises ``NotImplementedError``."""
-        with pytest.raises(NotImplementedError, match="interacting fronts"):
-            self._run(pulse, v_pv, n_trail=n_trail)
+    def test_interacting_multifront_matches_fv(self, pulse, v_pv, n_trail):
+        """An in-domain multi-front interaction runs and matches the FV oracle (mass + per-bin)."""
+        cout, _ = self._run(pulse, v_pv, n_trail=n_trail)
+        cin = np.array(list(pulse) + [0.0] * n_trail, dtype=float)
+        cout_fv = _fv_outlet_cout_freundlich_n2(cin, self.FLOW, v_pv, self.K_F, self.RHO_B, self.POR)
+        m_pub = float(np.nansum(cout))
+        m_fv = float(np.nansum(cout_fv))
+        assert abs(m_pub - m_fv) < 0.01 * m_fv, f"{pulse}: outlet mass {m_pub:.3f} vs FV {m_fv:.3f}"
+        # Per-bin gate at 3× the single-front FV floor (~0.046) — the broken linear-superposition
+        # output failed this at 14×–48×, so it discriminates a wrong interaction resolution.
+        max_bin = float(np.nanmax(np.abs(cout - cout_fv)))
+        assert max_bin < 0.14, f"{pulse}: max per-bin |Δ| = {max_bin:.4f} exceeds gate"
 
-    def test_conservation_symptom_flags_fans_crossing_beyond_outlet(self):
-        """The two-pulse refusal is driven by the mass-monotonicity net, not the geometric scan.
+    def test_conservation_symptom_detector_returns_none_when_resolved(self):
+        """The mass-monotonicity tripwire returns None on a resolved two-pulse state (no over-count).
 
         For ``cin=[0,10,10,0,10,10,0]`` at ``V=40`` pulse-2's shock overtakes pulse-1's
-        decaying-shock fan, but the two fans only cross at ``V≈97 ≫ v_outlet``: no in-domain point
-        is ever covered by two fans, so the geometric fan-overlap scan returns clean. Cumulative
-        outlet mass nonetheless drops (the reader over-counts stored mass), which the monotonicity
-        detector reports. This pins that the added net — not the pre-existing geometric scan — is
-        what catches this dominant multi-pulse class.
+        decaying-shock fan (the two fans cross beyond ``v_outlet``). Before the solver-level fix
+        this over-counted stored mass and the detector flagged it; now the interaction is resolved,
+        cumulative outlet mass is monotone, and :func:`find_unresolved_interaction` returns ``None``.
         """
         cin = np.array([0, 10, 10, 0, 10, 10, 0] + [0.0] * 53, dtype=float)
         nb = len(cin)
@@ -816,9 +832,7 @@ class TestUnresolvedMultiFrontInteractionRaises:
             cin=cin, flow=np.full(nb, self.FLOW), tedges=tedges, aquifer_pore_volume=40.0, sorption=sorption
         )
         tracker.run()
-        reason = find_unresolved_interaction(tracker.state)
-        assert reason is not None, "interacting two-pulse input was not flagged"
-        assert "cumulative outlet mass" in reason, f"expected mass-monotonicity attribution, got: {reason}"
+        assert find_unresolved_interaction(tracker.state) is None
 
     def test_plateau_below_interaction_volume_runs_and_matches_fv(self):
         """The SAME plateau input at a shorter column (V=30) exits before interacting — runs, matches FV.
@@ -861,3 +875,188 @@ class TestUnresolvedMultiFrontInteractionRaises:
         m_pub = float(np.nansum(cout))
         m_fv = float(np.nansum(cout_fv))
         assert abs(m_pub - m_fv) < 0.01 * m_fv, f"staircase V{v_pv} outlet mass {m_pub:.3f} vs FV {m_fv:.3f}"
+
+
+class TestMultiFrontExactAnchors:
+    """Machine-precision regression anchors for the resolved multi-front solution (issue #294).
+
+    Coordinates derive from the Freundlich ``n=2`` closed forms (``A = ρ_b·k_f/φ = 50``,
+    ``C_T = c + A√c``, ``R = 1 + A/(2√c)``). They pin the exact geometry the reviewers verified,
+    independently of the FV oracle: the review-C3 domain-mass evidence, the review-C2 plateau hole,
+    and the doubly-fed front's exact outlet crossing.
+    """
+
+    K_F, N, RHO_B, POR, FLOW = 0.01, 2.0, 1500.0, 0.3, 100.0
+
+    def _tracker(self, pulse, v_pv, n_trail):
+        cin = np.array(list(pulse) + [0.0] * n_trail, dtype=float)
+        nb = len(cin)
+        tedges = pd.date_range("2020-01-01", periods=nb + 1, freq="D")
+        sorption = FreundlichSorption(k_f=self.K_F, n=self.N, bulk_density=self.RHO_B, porosity=self.POR)
+        tr = FrontTracker(
+            cin=cin, flow=np.full(nb, self.FLOW), tedges=tedges, aquifer_pore_volume=v_pv, sorption=sorption
+        )
+        tr.run()
+        return tr
+
+    def test_multipeak_domain_mass_holds_both_pulses_before_arrival(self):
+        """Review C3: at θ=810 (< first arrival 840) all injected mass is still stored in-domain.
+
+        The pre-fix bug dropped the second pulse's 1000 units from ``compute_domain_mass`` (2000 vs
+        3000), emitting a spurious inlet→outlet echo. Here both pulses are in-domain and exact.
+        """
+        tr = self._tracker([0, 10, 10, 0, 0, 0, 5, 5, 0], 40.0, 111)
+        m_dom = compute_domain_mass(810.0, 40.0, tr.state.waves, tr.state.sorption)
+        # rtol 1e-5 absorbs the benign c_min-floor transient (~1.4e-3 on 3000); the pre-fix bug
+        # was off by 1000 (a full pulse), so this cleanly catches the C3 regression.
+        np.testing.assert_allclose(m_dom, 3000.0, rtol=1e-5)
+
+    def test_multipeak_dsw_formation_and_first_arrival_exact(self):
+        """DSW forms at θ=500+8√10 (V=8√10); first breakthrough is θ=840 exactly."""
+        tr = self._tracker([0, 10, 10, 0, 0, 0, 5, 5, 0], 40.0, 111)
+        dsw_events = [e for e in tr.state.events if e["type"] == "shock_rarefaction_collision"]
+        assert dsw_events, "expected the Rh1×S0 decaying-shock formation"
+        np.testing.assert_allclose(dsw_events[0]["theta"], 500.0 + 8.0 * np.sqrt(10.0), rtol=1e-9)
+        np.testing.assert_allclose(dsw_events[0]["location"], 8.0 * np.sqrt(10.0), rtol=1e-9)
+        outlet = [e["theta"] for e in tr.state.events if e["type"] == "outlet_crossing"]
+        np.testing.assert_allclose(min(outlet), 840.0, rtol=1e-9)
+
+    def test_multipeak_doubly_fed_front_crosses_outlet_at_1340(self):
+        """The doubly-fed front reaches V=40 at θ=1340 exactly with face values (4, 1)."""
+        tr = self._tracker([0, 10, 10, 0, 0, 0, 5, 5, 0], 40.0, 111)
+        dfsw = [w for w in tr.state.waves if isinstance(w, DoubleFanShockWave)]
+        assert dfsw, "expected a doubly-fed shock in the multi-peak solution"
+        theta_cross = dfsw[0].outlet_crossing_theta(40.0)
+        # rtol 1e-3: the fan-entry DSW feeding this front is born at c_decay_initial = c_min
+        # (~1e-12) not exactly 0, shifting the idealized θ=1340 / faces (4, 1) by ~5e-4.
+        np.testing.assert_allclose(theta_cross, 1340.0, rtol=1e-3)
+        c_l, c_r = dfsw[0].side_values(theta_cross)
+        np.testing.assert_allclose([c_l, c_r], [4.0, 1.0], rtol=1e-3)
+
+    def test_plateau_breakthrough_has_no_zero_hole(self):
+        """Review C2: the V=40 plateau breakthrough reads ≈5 in the plateau window, not a c=0 hole.
+
+        The pre-fix bug deactivated the fan's plateau carrier, returning c=0 where physics gives ≈5
+        and losing ~21% of outlet mass.
+        """
+        tr = self._tracker([0, 5, 10, 10, 5, 0], 40.0, 74)
+        # In the CORRECT solution the c≈5 plateau breaks through at θ∈[880, 950] (the review's
+        # [686, 763] was the BUGGY hole's window); assert no bin collapses to zero there.
+        thetas = np.linspace(880.0, 950.0, 40)
+        c_out = compute_breakthrough_curve(thetas, 40.0, tr.state.waves, tr.state.sorption)
+        assert np.all(c_out > 4.5), f"plateau hole: min outlet c = {c_out.min():.4f} (expected ≈5)"
+
+
+def _fv_outlet_cout_langmuir(cin, flow, v_pv, s_max, k_l, bulk_density, porosity, *, n_cells=2500, cfl=0.4):
+    """Independent first-order upwind (Godunov) outlet oracle for Langmuir sorption.
+
+    Same scheme as ``_fv_outlet_cout_freundlich_n2`` (upwind == Godunov for the convex flux
+    ``F = c``), but the conserved total ``U = C_T(c) = c + B·c/(K_L + c)`` (``B = ρ_b·s_max/φ``)
+    is inverted in closed form each step from the quadratic ``c² + (K_L + B − U)·c − K_L·U = 0``.
+    """
+    b = bulk_density * s_max / porosity
+    q = float(flow)
+    cin = np.asarray(cin, dtype=float)
+    nb = len(cin)
+    theta_out_edges = q * np.arange(nb + 1)
+    dv = v_pv / n_cells
+    cmax = max(cin.max(), 1e-12)
+    r_min = 1.0 + (bulk_density * s_max * k_l / porosity) / (k_l + cmax) ** 2
+    dtheta = cfl * dv * r_min
+
+    def ct(c):
+        c = np.maximum(c, 0.0)
+        return c + b * c / (k_l + c)
+
+    def c_from_u(u):
+        u = np.maximum(u, 0.0)
+        bc = k_l + b - u
+        return 0.5 * (-bc + np.sqrt(bc * bc + 4.0 * k_l * u))
+
+    c = np.zeros(n_cells)
+    u = ct(c)
+    theta = 0.0
+    cum_out = 0.0
+    out_edge_mass = np.zeros(len(theta_out_edges))
+    next_edge = 0
+    lam = dtheta / dv
+    theta_max = theta_out_edges[-1]
+    while theta < theta_max - 1e-12:
+        while next_edge < len(theta_out_edges) and theta_out_edges[next_edge] <= theta + 1e-12:
+            out_edge_mass[next_edge] = cum_out
+            next_edge += 1
+        if next_edge >= len(theta_out_edges):
+            break
+        cin_now = cin[min(int(theta // q), nb - 1)] if theta < theta_out_edges[-1] else cin[-1]
+        c_left = np.empty(n_cells)
+        c_left[0] = cin_now
+        c_left[1:] = c[:-1]
+        u -= lam * (c - c_left)
+        c = c_from_u(u)
+        cum_out += c[-1] * dtheta
+        theta += dtheta
+    while next_edge < len(theta_out_edges):
+        out_edge_mass[next_edge] = cum_out
+        next_edge += 1
+    return np.diff(out_edge_mass) / np.diff(theta_out_edges)
+
+
+class TestMultiFrontGeneralityAndTripwire:
+    """Isotherm generality (Langmuir) + the internal-consistency tripwire (issue #294 D6/D7)."""
+
+    def test_langmuir_multipeak_matches_fv(self):
+        """A Langmuir multi-peak interaction resolves and matches the independent Langmuir FV oracle.
+
+        The universal merge calculus is isotherm-agnostic; this exercises it on a non-Freundlich
+        (favorable) isotherm end-to-end.
+        """
+        s_max, k_l, rho_b, por, flow = 0.1, 5.0, 1500.0, 0.3, 100.0
+        cin = np.array([0, 10, 10, 0, 0, 0, 5, 5, 0] + [0.0] * 111, dtype=float)
+        nb = len(cin)
+        tedges = pd.date_range("2020-01-01", periods=nb + 1, freq="D")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cout, _ = infiltration_to_extraction_nonlinear_sorption(
+                cin=cin,
+                flow=np.full(nb, flow),
+                tedges=tedges,
+                cout_tedges=tedges,
+                aquifer_pore_volumes=np.array([40.0]),
+                langmuir_s_max=s_max,
+                langmuir_k_l=k_l,
+                bulk_density=rho_b,
+                porosity=por,
+            )
+        cout_fv = _fv_outlet_cout_langmuir(cin, flow, 40.0, s_max, k_l, rho_b, por)
+        m_pub, m_fv = float(np.nansum(cout)), float(np.nansum(cout_fv))
+        assert abs(m_pub - m_fv) < 0.01 * m_fv, f"Langmuir outlet mass {m_pub:.4f} vs FV {m_fv:.4f}"
+        assert np.nanmax(np.abs(cout - cout_fv)) < 0.15  # ~3× the Langmuir FV floor
+
+    def test_tripwire_fires_on_inconsistent_wave_list(self):
+        """find_unresolved_interaction (the D6 tripwire) fires when the wave field over-counts mass.
+
+        The acceptance flips removed all coverage of the guard's FIRING branch; construct a
+        deliberately inconsistent state — a shock carrying c=10 with NO injected mass (cin≡0), so
+        the reader's domain mass grows while the inlet mass stays 0 and cumulative outlet mass goes
+        negative — and assert the tripwire reports it.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        n = 20
+        flow = np.full(n, 100.0)
+        theta_edges = np.concatenate(([0.0], np.cumsum(flow * 1.0)))
+        spurious = ShockWave(theta_start=0.0, v_start=0.0, c_left=10.0, c_right=0.0, sorption=sorption)
+        state = FrontTrackerState(
+            waves=[spurious],
+            events=[],
+            theta_current=0.0,
+            v_outlet=40.0,
+            sorption=sorption,
+            cin=np.zeros(n),
+            flow=flow,
+            tedges=pd.date_range("2020-01-01", periods=n + 1, freq="D"),
+            tedges_days=np.arange(float(n + 1)),
+            theta_edges=theta_edges,
+        )
+        reason = find_unresolved_interaction(state)
+        assert reason is not None
+        assert "cumulative outlet mass" in reason

--- a/tests/src/test_front_tracking_output.py
+++ b/tests/src/test_front_tracking_output.py
@@ -123,45 +123,47 @@ class TestConcentrationAtPoint:
         c = concentration_at_point(v=100.0, theta=500.0, waves=waves, sorption=sorption)
         assert c == 0.0
 
-    def test_dispatch_prefers_decaying_shock_over_rarefaction(self):
-        """DecayingShockWave must win over a co-active RarefactionWave at the same point.
+    def test_decaying_shock_fan_owns_interior_point(self):
+        """The reader attributes a DecayingShockWave's self-similar fan value inside its fan.
 
-        Phase 2 step 4 puts DecayingShockWave first in the wave-priority loop
-        in ``concentration_at_point``. End-to-end simulations rarely surface
-        this dispatch order because the parent rarefaction is deactivated
-        post-collision; this test keeps both active to exercise the priority
-        directly.
+        A single Freundlich ``n=2`` pulse ``[0, 10, 10, 0]`` forms a DecayingShockWave once
+        the trailing rarefaction catches the leading shock: the parent rarefaction is
+        deactivated and the DSW fan (apex at ``(v_origin, θ_origin)``) becomes the sole owner
+        of the region between its tail boundary and its curved shock face. The old dispatch-
+        priority test kept a rarefaction and a decaying shock co-active over the same region;
+        under the nearest-downstream-face sweep reader that geometry is single-owner-ambiguous
+        (both fans share the origin apex and range) and is not how the solver produces states.
+        This uses an interaction-consistent solver-built state instead: at a point strictly
+        inside the DSW fan the reader must return the self-similar fan concentration, which
+        discriminates against both the ``c_fixed`` plateau ahead of the shock and the shock's
+        two-sided average.
         """
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
-        raref = RarefactionWave(theta_start=0.0, v_start=0.0, c_head=8.0, c_tail=1e-12, sorption=sorption)
-        v_start_dsw = raref.head_position_at_theta(10.0)
-        assert v_start_dsw is not None
-        decaying = DecayingShockWave(
-            theta_start=10.0,
-            v_start=v_start_dsw,
-            c_decay_initial=raref.c_head,
-            c_fixed=0.0,
-            c_fan_tail=raref.c_tail,
-            decay_side="left",
-            v_origin=0.0,
-            theta_origin=0.0,
-            sorption=sorption,
-        )
+        n = 40
+        cin = np.array([0.0, 10.0, 10.0, 0.0] + [0.0] * (n - 4))
+        flow = np.full(n, 100.0)
+        tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+        tracker = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=300.0, sorption=sorption)
+        tracker.run()
 
-        theta_q = 20.0
-        v_q = decaying.position_at_theta(theta_q)
-        assert v_q is not None
+        decaying = next(w for w in tracker.state.waves if isinstance(w, DecayingShockWave))
+        assert decaying.is_active, "the trailing rarefaction should have formed an active decaying shock"
 
-        c_decay_at_q = decaying.c_decay_at_theta(theta_q)
-        assert c_decay_at_q is not None
-        c_dsw_expected = 0.5 * (c_decay_at_q + decaying.c_fixed)
+        # A point strictly inside the fan: upstream of the curved shock face, downstream of the
+        # tail boundary (which sits at the apex for c_fan_tail = 0).
+        theta_q = 1000.0
+        v_shock = decaying.position_at_theta(theta_q)
+        assert v_shock is not None
+        v_q = 0.5 * v_shock
 
-        # Both orderings must return the DSW value (priority is by type,
-        # not list position).
-        c1 = concentration_at_point(v=v_q, theta=theta_q, waves=[raref, decaying], sorption=sorption)
-        c2 = concentration_at_point(v=v_q, theta=theta_q, waves=[decaying, raref], sorption=sorption)
-        assert np.isclose(c1, c_dsw_expected, rtol=1e-12)
-        assert np.isclose(c2, c_dsw_expected, rtol=1e-12)
+        # Expected self-similar fan value: R = (θ − θ_apex)/(v − v_apex), inverted to concentration.
+        r_fan = (theta_q - decaying.theta_origin) / (v_q - decaying.v_origin)
+        c_fan_expected = float(sorption.concentration_from_retardation(r_fan))
+
+        c = concentration_at_point(v=v_q, theta=theta_q, waves=tracker.state.waves, sorption=sorption)
+        assert np.isclose(c, c_fan_expected, rtol=1e-12)
+        # Discriminate: the reader attributes the fan, not the plateau ahead of the shock.
+        assert not np.isclose(c, decaying.c_fixed, atol=1e-6)
 
 
 class TestComputeBreakthroughCurve:

--- a/tests/src/test_front_tracking_phase8.py
+++ b/tests/src/test_front_tracking_phase8.py
@@ -7,7 +7,6 @@ All tests have correct physics expectations for Freundlich n>1.
 
 import numpy as np
 import pandas as pd
-import pytest
 
 from gwtransport.advection import infiltration_to_extraction_nonlinear_sorption
 from gwtransport.fronttracking.math import FreundlichSorption
@@ -137,10 +136,10 @@ class TestEntropyAndPhysics:
         """Every shock the solver builds satisfies the Lax entropy condition.
 
         The multi-level input (0.1→10→5→15→8) makes a later, faster shock
-        overtake an earlier wave, so the public API refuses it (interim
-        wave-interaction guard). Entropy is a solver-level property of each
-        individual shock, so it is verified directly on the wave list that
-        ``FrontTracker`` builds.
+        overtake an earlier wave. The solver (issue #294) now resolves this
+        interacting multi-front input instead of refusing it, so the public API
+        runs. Entropy is a solver-level property of each individual shock,
+        verified directly on the resolved wave list that ``FrontTracker`` builds.
         """
         dates = pd.date_range(start="2020-01-01", periods=20, freq="D")
         tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
@@ -148,22 +147,21 @@ class TestEntropyAndPhysics:
         flow = np.full(len(dates), 100.0)
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
 
-        # Interim contract: the public API refuses this interacting multi-front input.
-        with pytest.raises(NotImplementedError):
-            infiltration_to_extraction_nonlinear_sorption(
-                cin=cin,
-                flow=flow,
-                tedges=tedges,
-                cout_tedges=tedges,
-                aquifer_pore_volumes=np.array([300.0]),
-                freundlich_k=0.01,
-                freundlich_n=2.0,
-                bulk_density=1500.0,
-                porosity=0.3,
-            )
+        # The interacting multi-front input now runs at the public boundary.
+        infiltration_to_extraction_nonlinear_sorption(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([300.0]),
+            freundlich_k=0.01,
+            freundlich_n=2.0,
+            bulk_density=1500.0,
+            porosity=0.3,
+        )
 
-        # Solver invariant (still valid on the unresolved wave list): every shock
-        # the tracker builds individually satisfies the Lax entropy condition.
+        # Solver invariant on the resolved wave list: every shock the tracker
+        # builds individually satisfies the Lax entropy condition.
         tracker = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=300.0, sorption=sorption)
         tracker.run()
         shocks = [w for w in tracker.state.waves if isinstance(w, ShockWave)]
@@ -475,9 +473,10 @@ class TestComplexInteractions:
         """Rapid concentration changes: stress test for the event queue and wave creation.
 
         The rapid sequence (0→10→5→15→2→8) interacts (faster later shocks
-        overtake earlier waves), so the public API refuses it (interim guard).
-        Wave creation and θ-ordering of events are solver invariants, verified
-        directly on the ``FrontTracker`` state.
+        overtake earlier waves). The solver (issue #294) now resolves this
+        interacting multi-front input instead of refusing it, so the public API
+        runs. Wave creation and θ-ordering of events are solver invariants,
+        verified directly on the ``FrontTracker`` state.
         """
         dates = pd.date_range(start="2020-01-01", periods=30, freq="D")
         tedges = compute_time_edges(tedges=None, tstart=None, tend=dates, number_of_bins=len(dates))
@@ -485,19 +484,18 @@ class TestComplexInteractions:
         flow = np.full(len(dates), 100.0)
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
 
-        # Interim contract: the public API refuses this interacting multi-front input.
-        with pytest.raises(NotImplementedError):
-            infiltration_to_extraction_nonlinear_sorption(
-                cin=cin,
-                flow=flow,
-                tedges=tedges,
-                cout_tedges=tedges,
-                aquifer_pore_volumes=np.array([300.0]),
-                freundlich_k=0.01,
-                freundlich_n=2.0,
-                bulk_density=1500.0,
-                porosity=0.3,
-            )
+        # The interacting multi-front input now runs at the public boundary.
+        infiltration_to_extraction_nonlinear_sorption(
+            cin=cin,
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=np.array([300.0]),
+            freundlich_k=0.01,
+            freundlich_n=2.0,
+            bulk_density=1500.0,
+            porosity=0.3,
+        )
 
         # Solver invariants: rapid changes create multiple waves and the event
         # queue stays chronologically ordered in θ.

--- a/tests/src/test_front_tracking_solver.py
+++ b/tests/src/test_front_tracking_solver.py
@@ -1208,22 +1208,16 @@ class TestNoSpuriousOutletCrossings:
 
 
 class TestMultiPeakSingleOwnerInvariant:
-    """Every point in [0, V_outlet] is claimed by at most one active fan region (review C3 / H3).
+    """The sweep reader is self-consistent on a resolved multi-peak state (issue #294, review C3).
 
-    A later inlet shock injected inside an existing fan's span must not leave two active
-    waves claiming the same near-inlet interval. After the waves.py growing-decay fixes the
-    intruding shock is resolved into a single-owner ``DecayingShockWave`` via the
-    shock↔rarefaction collision, so this spatial invariant holds; this test guards against a
-    regression that reintroduces a double claim.
-
-    This invariant is necessary but NOT sufficient for correctness: it says nothing about the
-    outlet-mass over-count a right-decaying DSW causes after its shock face leaves the domain, nor
-    about later pulses whose fans DO come to overlap. Those genuinely-interacting multi-front inputs
-    are refused at the public boundary — :func:`gwtransport.advection.infiltration_to_extraction_nonlinear_sorption`
-    raises ``NotImplementedError`` via :func:`gwtransport.fronttracking.solver.find_unresolved_interaction`
-    (exercised by ``TestUnresolvedMultiFrontInteractionRaises`` in ``test_front_tracking_api``); exact
-    multi-front interaction is deferred to a solver-level follow-up. The two parameterisations here use
-    weak retardation (``k_f = 0.001``) so the fans stay single-owner and the run completes.
+    The solver now resolves the multi-front interaction (a later pulse's shock enters an earlier
+    pulse's fan), so overlapping fans are shared consistently and the reader assigns each point a
+    single owner (the nearest-downstream face's left feeder). This test pins that single-owner
+    property FV-independently: the spatial domain-mass integral :func:`compute_domain_mass` must
+    equal a fine-grid quadrature of ``C_total(concentration_at_point(v, θ))`` over ``[0, v_outlet]``.
+    A double-claim / dropped-owner regression (the C3 over-count) would break this equality even
+    when total mass happens to balance. The two parameterisations exercise multi-peak signals whose
+    fronts interact in-domain.
     """
 
     @pytest.mark.parametrize(
@@ -1233,7 +1227,7 @@ class TestMultiPeakSingleOwnerInvariant:
             ([0.0, 10.0, 10.0, 0.0, 0.0, 0.0, 15.0, 15.0, 0.0], 40.0),
         ],
     )
-    def test_no_two_active_fans_claim_same_point(self, cin, v_outlet):
+    def test_domain_mass_matches_pointwise_quadrature(self, cin, v_outlet):
         cin = np.asarray(cin)
         sorption = FreundlichSorption(k_f=0.001, n=2.0, bulk_density=1600.0, porosity=0.35)
         n_bins = len(cin)
@@ -1242,24 +1236,14 @@ class TestMultiPeakSingleOwnerInvariant:
         tr = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=v_outlet, sorption=sorption)
         tr.run()
 
-        def fan_owners(v, theta):
-            owners = []
-            for i, w in enumerate(tr.state.waves):
-                if not w.was_active_at(theta):
-                    continue
-                if isinstance(w, DecayingShockWave):
-                    v_s = w.position_at_theta(theta)
-                    if v_s is None:
-                        continue
-                    in_fan = (w.decay_side == "left" and v < v_s) or (w.decay_side == "right" and v > v_s)
-                    if in_fan and v != w.v_origin and w.concentration_at_point(v, theta) is not None:
-                        owners.append(i)
-                elif isinstance(w, RarefactionWave) and w.contains_point(v, theta):
-                    owners.append(i)
-            return owners
-
+        v_grid = np.linspace(0.0, v_outlet, 4001)
         theta_hi = 1.6 * float(tr.state.theta_edges[-1])
-        for theta in np.linspace(1.0, theta_hi, 200):
-            for v in np.linspace(1e-3 * v_outlet, v_outlet * (1 - 1e-3), 150):
-                owners = fan_owners(float(v), float(theta))
-                assert len(owners) <= 1, f"waves {owners} both claim v={v:.3f} at θ={theta:.2f}"
+        for theta in np.linspace(theta_hi / 20.0, theta_hi, 20):
+            m_dom = compute_domain_mass(float(theta), v_outlet, tr.state.waves, sorption)
+            c_pts = np.array([concentration_at_point(float(v), float(theta), tr.state.waves, sorption) for v in v_grid])
+            ct_pts = np.array([sorption.total_concentration(float(c)) for c in c_pts])
+            m_quad = float(np.trapezoid(ct_pts, v_grid))
+            # rtol 2e-3 for the trapezoid truncation across the sharp shock/fan faces; a
+            # double-claim over-count would shift m_dom by O(a fan's mass), far above this.
+            scale = max(m_dom, m_quad, 1.0)
+            assert abs(m_dom - m_quad) < 2e-3 * scale, f"θ={theta:.1f}: m_dom={m_dom:.4f} vs quad={m_quad:.4f}"

--- a/tests/src/test_front_tracking_waves.py
+++ b/tests/src/test_front_tracking_waves.py
@@ -11,7 +11,7 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 
 import numpy as np
 import pytest
-from scipy.integrate import quad
+from scipy.integrate import quad, solve_ivp
 from scipy.optimize import brentq
 
 from gwtransport.fronttracking.math import (
@@ -21,7 +21,14 @@ from gwtransport.fronttracking.math import (
     VanGenuchtenMualemConductivity,
     characteristic_speed,
 )
-from gwtransport.fronttracking.waves import CharacteristicWave, DecayingShockWave, RarefactionWave, ShockWave
+from gwtransport.fronttracking.waves import (
+    CharacteristicWave,
+    DecayingShockWave,
+    DoubleFanShockWave,
+    Feeder,
+    RarefactionWave,
+    ShockWave,
+)
 
 
 def _invariant_theta_local_of_c(sorption, c_decay_initial, c_fixed, theta_local_collision, c_target):
@@ -895,8 +902,9 @@ class TestDecayingShockWaveNumericalInversion:
             theta_origin=theta_origin,
             theta_local_collision=tlc,
         )
-        # Numerical path (Freundlich n=2 mirror c_decay_initial < c_fixed): no closed form.
-        assert np.isnan(wave.K)
+        # Freundlich n=2 growing mirror (c_decay_initial < c_fixed) now has a closed form
+        # (the (u_d−u_R)² invariant, −√ root); K is set, not NaN.
+        assert not np.isnan(wave.K)
         assert wave.c_decay_initial < wave.c_fan_tail  # growing orientation
 
         theta_ref = theta_origin + _invariant_theta_local_of_c(sorption, c0, c_fixed, tlc, c_fan_tail)
@@ -1010,3 +1018,58 @@ class TestWaveSpeedCaching:
         wave = RarefactionWave(theta_start=0.0, v_start=0.0, c_head=10.0, c_tail=2.0, sorption=sorption)
         assert wave.head_speed() == characteristic_speed(10.0, sorption)
         assert wave.tail_speed() == characteristic_speed(2.0, sorption)
+
+
+class TestDoubleFanShockWave:
+    """A shock fed by a fan on both sides (issue #294): closed form (n=2 shared apex) + RK4 fallback."""
+
+    def _fan_value(self, sorption, v_o, th_o, c_lo, c_hi, v, th):
+        """Bounded self-similar fan value used to build an independent reference ODE."""
+        if th <= th_o or v <= v_o:
+            return c_lo
+        r = (th - th_o) / (v - v_o)
+        r_lo, r_hi = sorted((float(sorption.retardation(c_lo)), float(sorption.retardation(c_hi))))
+        if r <= r_lo:
+            return c_hi if sorption.retardation(c_hi) < sorption.retardation(c_lo) else c_lo
+        if r >= r_hi:
+            return c_lo if sorption.retardation(c_lo) > sorption.retardation(c_hi) else c_hi
+        return float(sorption.concentration_from_retardation(r))
+
+    def test_shared_apex_closed_form_matches_dop853(self):
+        """n=2 shared-apex path uses the first-integral quadratic; matches an independent DOP853."""
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        left = Feeder.fan(0.0, 800.0, 0.0, 5.0, sorption)  # shared apex position v_o = 0
+        right = Feeder.fan(0.0, 300.0, 0.0, 10.0, sorption)
+        w = DoubleFanShockWave(
+            theta_start=1163.15, v_start=29.8143, left_feeder=left, right_feeder=right, sorption=sorption
+        )
+        assert w._closed_form  # noqa: SLF001
+
+        def rhs(th, y):
+            c_l = self._fan_value(sorption, 0.0, 800.0, 0.0, 5.0, y[0], th)
+            c_r = self._fan_value(sorption, 0.0, 300.0, 0.0, 10.0, y[0], th)
+            return [float(sorption.shock_speed(c_l, c_r))]
+
+        sol = solve_ivp(rhs, (1163.15, 2500.0), [29.8143], method="DOP853", rtol=1e-12, atol=1e-13, dense_output=True)
+        for th in (1300.0, 1600.0, 2000.0, 2400.0):
+            np.testing.assert_allclose(w.position_at_theta(th), float(sol.sol(th)[0]), rtol=1e-8)
+
+    def test_rk4_fallback_distinct_apex_self_converges_and_matches_dop853(self):
+        """Distinct fan apex positions have no closed form → RK4 spline; verify convergence + DOP853."""
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        left = Feeder.fan(2.0, 800.0, 0.0, 5.0, sorption)  # distinct apex position v_o = 2 ≠ 0
+        right = Feeder.fan(0.0, 300.0, 0.0, 10.0, sorption)
+        w = DoubleFanShockWave(
+            theta_start=1163.15, v_start=29.8143, left_feeder=left, right_feeder=right, sorption=sorption
+        )
+        assert not w._closed_form  # noqa: SLF001  # distinct apex → numerical path
+
+        def rhs(th, y):
+            c_l = self._fan_value(sorption, 2.0, 800.0, 0.0, 5.0, y[0], th)
+            c_r = self._fan_value(sorption, 0.0, 300.0, 0.0, 10.0, y[0], th)
+            return [float(sorption.shock_speed(c_l, c_r))]
+
+        sol = solve_ivp(rhs, (1163.15, 2500.0), [29.8143], method="DOP853", rtol=1e-12, atol=1e-13, dense_output=True)
+        for th in (1300.0, 1600.0, 2000.0, 2400.0):
+            # The RK4+spline trajectory tracks the independent DOP853 integration to <1e-6 relative.
+            np.testing.assert_allclose(w.position_at_theta(th), float(sol.sol(th)[0]), rtol=1e-6)

--- a/tests/src/test_front_tracking_waves.py
+++ b/tests/src/test_front_tracking_waves.py
@@ -1052,7 +1052,9 @@ class TestDoubleFanShockWave:
 
         sol = solve_ivp(rhs, (1163.15, 2500.0), [29.8143], method="DOP853", rtol=1e-12, atol=1e-13, dense_output=True)
         for th in (1300.0, 1600.0, 2000.0, 2400.0):
-            np.testing.assert_allclose(w.position_at_theta(th), float(sol.sol(th)[0]), rtol=1e-8)
+            pos = w.position_at_theta(th)
+            assert pos is not None  # defined at every θ in the wave's active window
+            np.testing.assert_allclose(pos, float(sol.sol(th)[0]), rtol=1e-8)
 
     def test_rk4_fallback_distinct_apex_self_converges_and_matches_dop853(self):
         """Distinct fan apex positions have no closed form → RK4 spline; verify convergence + DOP853."""
@@ -1072,4 +1074,6 @@ class TestDoubleFanShockWave:
         sol = solve_ivp(rhs, (1163.15, 2500.0), [29.8143], method="DOP853", rtol=1e-12, atol=1e-13, dense_output=True)
         for th in (1300.0, 1600.0, 2000.0, 2400.0):
             # The RK4+spline trajectory tracks the independent DOP853 integration to <1e-6 relative.
-            np.testing.assert_allclose(w.position_at_theta(th), float(sol.sol(th)[0]), rtol=1e-6)
+            pos = w.position_at_theta(th)
+            assert pos is not None  # defined at every θ in the wave's active window
+            np.testing.assert_allclose(pos, float(sol.sol(th)[0]), rtol=1e-6)

--- a/tests/src/test_percolation.py
+++ b/tests/src/test_percolation.py
@@ -599,7 +599,10 @@ class TestEndToEnd:
         ``κ → 0.5·κ`` mutation in the antiderivative ``g = C_T·u − κ·c`` shifts the
         fan term by ~4% and fails this bound.
         """
-        self._assert_domain_mass_straddling_rarefaction(O05, theta_probe=18.7, rtol=1e-6)
+        # The solver now resolves the wet-shock↔dry-rarefaction interaction at θ≈18.53
+        # (issue #294 global resolution), so the bare rarefaction straddles the outlet only
+        # in (18.0, 18.535); probe inside that window (was 18.7, now past the collision).
+        self._assert_domain_mass_straddling_rarefaction(O05, theta_probe=18.3, rtol=1e-6)
 
     def test_b5a_universal_ibp_integrator_active_in_rarefaction_vg(self):
         """B5a-aux (vG): the straddling-fan IBP-integrator check for van Genuchten.


### PR DESCRIPTION
## Summary

Closes #294. The nonlinear-sorption front tracker previously refused inputs whose fronts interact (a shock overtaking another shock, a rarefaction, or a decaying-shock fan) with `NotImplementedError`, because the public `cout` degraded to the exact linear superposition of a nonlinear operator — mass-losing and silently wrong. This resolves those interactions exactly at the solver level.

**One uniform interaction calculus** (new `fronttracking/interactions.py`):
- Every wave exposes constant-or-bounded-fan **feeders** on each side (`waves.Feeder`; the clamp is monotonicity-agnostic, so the Freundlich n<1 mirror reads correctly).
- A **universal merge rule** — successor = `(rear.left_feeder, front.right_feeder)` — generates every interaction: shock↔shock merges, a shock entering a fan (fan-entry), a rarefaction head catching a decaying shock (doubly-fed formation), same-apex decaying-shock annihilation, and their compositions.
- Crossings use a per-pair speed-bounded (Lipschitz) march with a born-coincident admission for near-simultaneous (triple) collisions. The bound is per-pair, not a global 1, because the percolation conductivity isotherms have R < 1.
- New **`DoubleFanShockWave`** (a shock fed by a fan on both sides). Freundlich n=2 with a shared apex has a closed form (the product `u_L·u_R` is a first integral → quadratic trajectory); other cases use a cached RK4 spline. The growing-branch n=2 `c_fixed>0` decaying-shock closed form is added (was numerical and ~1e-2 inaccurate).
- Resolution is **global** up to a θ-horizon (the last requested output edge): information propagates strictly downstream, so beyond-outlet merges that still bound an in-domain fan are composed.

**Reader** (`fronttracking/output.py`): replaced the heuristic newest-fan-wins dispatch with a **nearest-downstream-face sweep** — `c(v,θ)` is the left feeder of the nearest face at/downstream of `v`. With an interaction-consistent wave list every region has a single owner, so `compute_domain_mass` and `concentration_at_point` are exact; the bounded-fan clamp reproduces the plateau behind a fan, fixing the review-C2 c=0 hole and the review-C3 dropped-pulse over-count.

**Guard**: `find_unresolved_interaction` is now an internal `RuntimeError` tripwire (cumulative-outlet-mass monotonicity), not an input filter — a firing means a solver bug, not an unsupported input.

## Test plan

Acceptance is the independent Godunov FV oracle (`_fv_outlet_cout_freundlich_n2`), validated 0.02% vs analytic Riemann in the original review. All six previously-refused inputs (multi-peak, plateau, nonzero-dip, and the three oscillating two-pulse signals; Freundlich n=2, k_f=0.01, ρ_b=1500, φ=0.3, flow=100, V=40) now run and match FV to **≤0.02% cumulative outlet mass and ≤0.05 per bin**:

| case | mass rel. diff | max per-bin \|Δ\| |
|---|---|---|
| multi-peak | 0.011% | 0.046 |
| plateau | 0.016% | 0.023 |
| nonzero-dip | 0.011% | 0.037 |
| 2p-equal | 0.017% | 0.053 |
| 2p-rising | 0.023% | 0.044 |
| 2p-falling | 0.023% | 0.046 |

Tests: the six raise-tests become FV-match gates (mass + per-bin); added machine-precision closed-form anchors (`TestMultiFrontExactAnchors`: DSW formation θ=500+8√10, first arrival 840, doubly-fed outlet crossing θ=1340 with faces (4, 1), review-C3 `compute_domain_mass(810)=3000`, review-C2 no-hole plateau) and a reader self-consistency probe (`compute_domain_mass` == quadrature of `concentration_at_point`). Percolation (Brooks-Corey / van Genuchten-Mualem) and the Freundlich n<1 mirror ride the calculus's generality; the DoubleFanShockWave trajectory was cross-checked against a `scipy` DOP853 integration to ~1e-13.

Commands:
```
env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src -k "front_tracking or fronttracking or percolation or advection" -n auto   # 697 passed
env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q ruff format . && ruff check .   # clean
uv tool run -q ty check src/gwtransport/fronttracking/ src/gwtransport/advection.py   # clean
```

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
