### PR TITLE
test+docs(fronttracking): interaction-completeness audit — no compound waves; pin n<1 multi-front gap

### DIFF
--- a/docs/theory/front_tracking_interactions.md
+++ b/docs/theory/front_tracking_interactions.md
@@ -1,0 +1,333 @@
+# Front-tracking wave interactions — the authoritative catalogue
+
+This document is the reference truth table for the nonlinear-sorption / kinematic-wave
+front tracker in `src/gwtransport/fronttracking/`. It answers two questions definitively:
+
+1. **From the physics of scalar conservation laws, which wave–wave interactions are
+   possible?** Every possible interaction must be represented and tested; every
+   interaction the code _represents_ but that cannot physically occur must be confirmed
+   non-existent and its dead path removed.
+2. **Which interaction resolutions are exact vs numerical, and are the numerical ones
+   acceptable?**
+
+Every claim below is either derived from the governing law or verified numerically
+against the source (`.venv-claude`); the verification scripts live in `scratchpad/` on the
+`audit/294-interaction-completeness` branch. Line references are into the worktree source.
+
+---
+
+## 1. Governing law and elementary waves
+
+### 1.1 The scalar conservation law
+
+In cumulative-flow coordinates `θ = ∫ flow dt` and pore-volume position `V`, transport of a
+single sorbing solute (or of water content in kinematic-wave percolation) is the **scalar
+conservation law**
+
+```
+∂_θ C_T(c) + ∂_V c = 0
+```
+
+with conserved quantity `U = C_T(c)` (total = dissolved + sorbed, or storage `θ_m − θ_r`)
+and flux `f(U) = c` (dissolved concentration, or hydraulic conductivity `K`). Flow drops out
+entirely; the wave structure is a property of the isotherm alone (`math.py:62`
+`shock_speed`, `math.py:1099` `characteristic_speed`).
+
+The **characteristic (celerity)** is
+
+```
+λ(c) = df/dU = dc/dC_T = 1 / R(c) ,     R(c) = dC_T/dc  (the retardation factor),
+```
+
+so `λ = 1/R` (`math.py:1099`). Because flow is one-directional, `λ ≥ 0` always: `R ≥ 0`, with
+`R = 0` only at full saturation (`S_e = 1` for vG-M/Brooks–Corey, where `dK/dS_e → ∞`), at
+which `λ = +∞` — the `MAX_FINITE_SPEED` / `R = 0` edge special-cased at `math.py:94,147`.
+
+A **shock** between states `c_L` (upstream/behind) and `c_R` (downstream/ahead) moves at the
+Rankine–Hugoniot speed
+
+```
+dV_s/dθ = (c_R − c_L) / (C_T(c_R) − C_T(c_L))     (math.py:62)
+```
+
+and is admissible iff it satisfies the **Lax entropy condition** in θ-space,
+`λ(c_L) ≥ dV_s/dθ ≥ λ(c_R)` (`math.py:123`). A **rarefaction** is the self-similar fan
+`R(c) = (θ − θ_0)/(V − v_0)` connecting `c_tail` to `c_head` with `λ(c_head) > λ(c_tail)`
+(`waves.py:439`; the class raises if head ≤ tail, i.e. a compression).
+
+### 1.2 Genuine nonlinearity and flux curvature
+
+The Riemann outcome for a scalar law is fixed by the **curvature of the flux**,
+`f''(U)`. Differentiating `λ = 1/R`,
+
+```
+f''(U) = dλ/dU = d(1/R)/dc · dc/dU = (−R'/R²)·(1/R) = −R'(c) / R(c)³ ,
+```
+
+so
+
+```
+sign f''(U) = − sign R'(c) .        (verified: scratchpad/repro_section0.py)
+```
+
+Genuine nonlinearity (`f'' ≠ 0`) holds exactly where `R'(c) ≠ 0`. The flux is:
+
+| flux class                       | condition                      | elementary waves             | Riemann outcome                            |
+| -------------------------------- | ------------------------------ | ---------------------------- | ------------------------------------------ |
+| genuinely nonlinear, **convex**  | `R' < 0` everywhere            | shock, rarefaction           | a single shock **or** a single rarefaction |
+| genuinely nonlinear, **concave** | `R' > 0` everywhere            | shock, rarefaction (mirror)  | a single shock **or** a single rarefaction |
+| **linearly degenerate**          | `R' ≡ 0` (ConstantRetardation) | contact only                 | contact                                    |
+| **non-convex**                   | `R'` changes sign              | compound (shock+rarefaction) | Oleinik convex-hull construction           |
+
+The last row is the only one that would require machinery beyond shocks and rarefactions.
+**Section 2 proves it never occurs for any isotherm in this package.**
+
+---
+
+## 2. Per-isotherm classification — every flux is single-curvature
+
+For each sorption/conductivity model the sign of `R'(c)` is derived and confirmed
+numerically over the full concentration range. **Result: not one isotherm is non-convex.**
+
+| isotherm (class, math.py)                                       | `R(c)`                                      | `R'` sign | flux class                | measured over range                 |
+| --------------------------------------------------------------- | ------------------------------------------- | --------- | ------------------------- | ----------------------------------- |
+| **Freundlich `n>1`** (`FreundlichSorption`:163)                 | `1 + (ρ_b k_f)/(φ n)·c^{1/n−1}`             | `R' < 0`  | **convex** (favorable)    | `R'` single-signed `<0`; `R ≥ 1`    |
+| **Freundlich `n<1`**                                            | same, `1/n−1 > 0`                           | `R' > 0`  | **concave** (unfavorable) | `R'` single-signed `>0`; `R ≥ 1`    |
+| **Langmuir** (`LangmuirSorption`:537)                           | `1 + A/(K_L+c)²`                            | `R' < 0`  | **convex** (favorable)    | `R'` single-signed `<0`; `R ≥ 1`    |
+| **Constant** (`ConstantRetardation`:401)                        | `R = const`                                 | `R' ≡ 0`  | **linear / degenerate**   | contacts only, no fans              |
+| **Brooks–Corey** (`BrooksCoreyConductivity`:730)                | `(Δθ/(a K_s))·(c/K_s)^{1/a−1}`, `a=3+2/λ>3` | `R' < 0`  | **convex** (favorable)    | `f ∝ U^a, a>3 ⇒ f''>0`; `R<1` real  |
+| **van Genuchten–Mualem** (`VanGenuchtenMualemConductivity`:861) | `Δθ / (dK/dS_e)`                            | `R' < 0`  | **convex** (favorable)    | `d²K/dS_e² > 0` ∀ params (see §2.2) |
+
+Two physical regimes must be kept distinct because the retardation constraint differs:
+
+- **Solute sorption** (`R ≥ 1` always): Freundlich, Langmuir, Constant. `λ = 1/R ≤ 1`.
+- **Unsaturated-zone percolation** (`R < 1` realistic): Brooks–Corey, vG-Mualem.
+  Carsel–Parrish soils give `minR` down to `~2e-5` (coarse sand), i.e. celerity `λ = 1/R` up
+  to `~4e4`. This is why the interaction detector marches with a **per-pair**
+  Lipschitz bound `Λ = speed_bound_a + speed_bound_b` rather than a global `1`
+  (`interactions.py:236` `find_face_crossing`, `:75` `_max_characteristic_speed`).
+
+### 2.1 Freundlich, Langmuir, Constant, Brooks–Corey
+
+- **Freundlich** `R(c) = 1 + (ρ_b k_f)/(φ n)·c^{1/n−1}`. The exponent `1/n−1` is negative for
+  `n>1` (⇒ `R' < 0`, convex, higher `c` faster, `R→∞` as `c→0`) and positive for `n<1`
+  (⇒ `R' > 0`, concave, higher `c` slower). Single-signed in both cases — no inflection.
+- **Langmuir** `R(c) = 1 + A/(K_L+c)²` with `A = ρ_b s_max K_L/φ > 0`. `R'(c) = −2A/(K_L+c)³ < 0`
+  for all `c ≥ 0`. Convex, favorable, `R(0)=1+A/K_L²` finite.
+- **Constant** `R' ≡ 0`: linearly degenerate. Every characteristic speed equals every shock
+  speed (`math.py:502`); only contacts exist, never fans.
+- **Brooks–Corey** (recast): flux `f = c = K`, conserved `U = C_T = Δθ (c/K_s)^{1/a}`, so
+  `c = K_s (U/Δθ)^a` with `a = 3 + 2/λ > 3`. Then `f(U) ∝ U^a` and `f''(U) ∝ a(a−1) U^{a−2} > 0`:
+  strictly convex for every `λ > 0`. Equivalently `R' < 0` single-signed.
+
+### 2.2 van Genuchten–Mualem is convex for ALL parameters (correction of a prior claim)
+
+`K(S_e) = K_s · S_e^L · [1 − (1 − S_e^{1/m})^m]^2`, `m = 1 − 1/n_vG`, `n_vG > 1`, `L ≥ 0`.
+With `U = C_T = Δθ·S_e` and `f = K`, the flux curvature is `f''(U) ∝ d²K/dS_e²`. The flux is
+non-convex (compound waves possible) **iff `d²K/dS_e²` changes sign** on `S_e ∈ (0,1)`.
+
+**High-precision result (`scratchpad/repro_vgm_stable.py`, dps=200): `d²K/dS_e² > 0` strictly,
+for every `n_vG ∈ [1.001, 10]` and `L ∈ [0, 3]`.** The van Genuchten–Mualem flux is convex
+everywhere; there are **no** compound waves.
+
+A prior analysis reported vG-M as non-convex for clay (`n_vG ≈ 1.09`). That was a
+**numerical artefact**, not physics:
+
+- A naive `np.gradient(R(c))` (or double-differencing the brentq-based `C_T`) produces
+  spurious `R'` / `d²K` sign flips near the singular endpoints (`R → ∞` as `c → 0`,
+  `R → 0` as `c → K_s`).
+- Any **low-precision differencing** of `K` near `S_e → 0` is unreliable because
+  `U = 1 − (1 − S_e^{1/m})^m` suffers **catastrophic cancellation** when `S_e^{1/m}`
+  underflows the working precision (e.g. for `n_vG = 1.09`, `m ≈ 0.083`, `1/m ≈ 12`, and at
+  `S_e = 1e-8`, `S_e^{1/m} ≈ 1e-97`; at `n_vG → 1`, `1/m` is huge and `0.8^{1/m} ≈ 1e-97`).
+  Then `1 − (tiny)` rounds to exactly `1` and `U` collapses to `0` (or a value with all
+  significant digits lost) — the resulting differenced curvature is meaningless (sign flips
+  either way), not a real inflection.
+
+The cure is a **numerically stable** `U = −expm1(m · log1p(−S_e^{1/m}))`, which keeps `U`
+accurate to full precision even when `S_e^{1/m} ~ 1e-300`. With that, `d²K/dS_e² > 0`
+everywhere. The **asymptotic** argument closes it rigorously: as `S_e → 0`,
+`U ≈ m·S_e^{1/m}` so `K ≈ m²·S_e^{L+2/m}`, a convex power law (exponent `L + 2/m > 1`), hence
+`d²K/dS_e² > 0` in the tail.
+
+Consequences:
+
+- **No detect-and-reject scan is needed** (there is nothing non-convex to reject).
+- The `__post_init__` 2-point monotonicity guard (`math.py:970`, samples
+  `S_e ∈ {0.5, 0.99}`) is **vestigial**: the code's own double-precision `_dk_dse` is
+  monotone-increasing over brentq's actual search range `[_C_MIN, 1]` for every
+  Carsel–Parrish soil, so the guard never fires for valid parameters
+  (`scratchpad/repro_code_double_precision.py`).
+- The vG-M `R↔c` inversion degrades only at `c → K_s` (saturation, `S_e → 1`, `R → 0`, where
+  `dK/dS_e → ∞` cannot be bracketed in `[_C_MIN, 1]`). This is an expected endpoint edge
+  (the `MAX_FINITE_SPEED` / `R = 0` regime, `interactions.py:48`), not a mid-range defect;
+  round-trips are exact for `c ≤ 0.5·K_s`.
+
+**Bottom line:** every flux is convex, concave, or linear — all single-curvature. The
+solver's shock + rarefaction repertoire is _complete_; compound waves are physically absent
+from this package.
+
+---
+
+## 3. Complete pairwise interaction table
+
+A scalar law has a **single characteristic family**. Two consequences fix the entire
+interaction catalogue:
+
+1. **Same-family simple waves do not interact.** Two rarefactions separated by a constant
+   state are bounded by characteristics of equal speed (the shared boundary concentration),
+   so the gap between them never closes (Rhee–Aris–Amundson, Vol. II, simple-wave theory).
+   **RAREF–RAREF cannot collide.**
+2. Interactions occur only when a **rear (upstream) wave is faster** than the front
+   (downstream) wave it chases. The primitives are:
+
+| rear ＼ front   | shock                                              | rarefaction                                                                          |
+| --------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **shock**       | merge → one shock (Lax)                            | shock overtakes fan → curved (decaying) shock; may weaken to nothing or exit the fan |
+| **rarefaction** | fan head overtakes shock → curved (decaying) shock | (impossible — same family, no interaction)                                           |
+
+Contacts (linear flux) never interact (all speeds equal). Thus the **only** genuine
+interactions are: **shock↔shock**, **shock→fan**, and **fan→shock**. A curved shock fed by
+one fan can subsequently be fed by a second fan (**doubly-fed**), and two curved shocks can
+merge — but these are compositions of the same three primitives, not new ones.
+
+### 3.1 Mapping the code onto the table
+
+Wave objects (`waves.py`) and events (`events.py`, `EventType` at `:67`) are
+_representations_ of the primitives above:
+
+| code object / event     | file:line                             | primitive realized                                          | reachable?                                |
+| ----------------------- | ------------------------------------- | ----------------------------------------------------------- | ----------------------------------------- |
+| `CharacteristicWave`    | `waves.py:256`                        | contact / constant-state characteristic                     | yes (smooth regions)                      |
+| `ShockWave`             | `waves.py:342`                        | shock                                                       | yes                                       |
+| `RarefactionWave`       | `waves.py:440`                        | rarefaction fan                                             | yes                                       |
+| `DecayingShockWave`     | `waves.py:604`                        | shock adjacent to **one** fan                               | yes (shock↔fan)                           |
+| `DoubleFanShockWave`    | `waves.py:1079`                       | shock adjacent to **two** fans                              | yes (doubly-fed formation)                |
+| `CHAR_CHAR_COLLISION`   | handler `handlers.py:32`              | two contacts compress → shock (genesis)                     | yes                                       |
+| `SHOCK_SHOCK_COLLISION` | `handlers.py:95`                      | shock↔shock merge                                           | yes                                       |
+| `SHOCK_CHAR_COLLISION`  | `handlers.py:152`                     | contact into shock (may emit a fan)                         | yes                                       |
+| `RAREF_CHAR_COLLISION`  | `handlers.py:305`                     | contact absorbed at a fan boundary                          | yes                                       |
+| `SHOCK_RAREF_COLLISION` | `handlers.py:223`                     | shock→fan (tail) and fan→shock (head) → `DecayingShockWave` | yes                                       |
+| `WAVE_MERGE`            | `interactions.py:394` `resolve_merge` | universal merge (any DSW/DFSW face pair)                    | yes (transitively, multi-front)           |
+| `DSW_FAN_EXHAUSTED`     | `solver.py:594`                       | degradation: `DecayingShockWave` → plain `ShockWave`        | yes                                       |
+| `RAREF_RAREF_COLLISION` | **no-op** `solver.py:560`             | (impossible interaction)                                    | detected, correctly not resolved — see §4 |
+| `DFSW_SIDE_EXHAUSTED`   | `solver.py:630`                       | degradation: `DoubleFanShockWave` → DSW/ShockWave           | **reachability under audit (§4)**         |
+| `OUTLET_CROSSING`       | `handlers.py:354`                     | boundary bookkeeping                                        | yes                                       |
+
+The universal merge calculus (`interactions.py`): every wave exposes **faces** (`Face`,
+`:53`) separating a left/right **`Feeder`** (a constant state or a bounded self-similar fan,
+`waves.py:55`). When a rear face overtakes a front face they merge into a single successor
+built from `(rear.left_feeder, front.right_feeder)` via `make_wave_from_feeders`
+(`interactions.py:308`): `(const,const)→ShockWave`, `(const,fan)/(fan,const)→DecayingShockWave`,
+`(fan,fan)→DoubleFanShockWave`. This one rule generates shock–shock merges, fan-entry,
+doubly-fed formation, same-apex annihilation, and every composition thereof.
+
+---
+
+## 4. Non-existence and reachability claims
+
+### 4.1 RAREF–RAREF is a correct no-op — CONFIRMED
+
+`RAREF_RAREF_COLLISION` is detected geometrically (`solver.py:383–387`) but the handler makes no
+topology change and leaves both rarefactions active (`solver.py:560`). This is **correct**:
+in a scalar (single-family) law two rarefactions never interact (§3, point 1). Numerically
+confirmed (`scratchpad/repro_raref_raref.py`): a `5→3→1` Freundlich `n=2` inlet emits two
+same-family rarefactions; the solver produces **no** `rarefaction_rarefaction` topology
+event, `find_unresolved_interaction` returns `None`, and the outlet `cout` matches the
+independent Godunov FV oracle to `0.07%` (first-order FV error). The event is retained only
+as a detection record; the reader sweep treats overlapping fans as normal (they read
+identically from either neighbour).
+
+_Action:_ keep the no-op; pin it with a non-existence regression test asserting the solver
+never emits a resolved raref–raref successor on a randomized same-family sweep.
+
+### 4.2 Compound waves — CONFIRMED non-existent
+
+No isotherm is non-convex (§2), so the Oleinik compound (shock+rarefaction) wave never
+forms. The solver's shock/rarefaction repertoire is complete.
+
+_Action:_ no compound-wave handling and no "detect-and-reject non-convex flux" scan are
+required. Document convexity; treat the vestigial vG-M 2-point guard per §2.2.
+
+### 4.3 Under audit (require constructed inputs or impossibility proofs)
+
+- **`DFSW_SIDE_EXHAUSTED`** (`solver.py:630`, `theta_at_side_exhaustion` `waves.py:1280`):
+  no test drives a doubly-fed shock whose fan side reaches its far bound within the horizon.
+  When both fan tails sit at the `R→∞` singular state (`c→0`, favorable), the shock reaches
+  the edge only as `θ→∞` (asymptotic — hence `None` observed). Determine whether a
+  **nonzero-background** multi-pulse (fan tail `c > 0`) produces finite-θ side exhaustion. If
+  yes → tested interaction; if provably asymptotic-only → delete the handler + non-existence
+  test.
+- **DFSW × DFSW** and **characteristic × fan** (via `WAVE_MERGE`): structurally reachable
+  (the face-pair loop admits them, `solver.py:394`) but untested. Construct a producing
+  input or prove impossibility.
+
+These are resolved in the companion audit steps (branch work), not in this reference.
+
+### 4.4 Known multi-front gap — unfavorable (`n<1`) and some Langmuir (issue #317)
+
+The randomized property sweep (§4.5) found that the multi-front solver **declines** (leaves
+an unresolved interaction → the public API raises `RuntimeError`, never a silently-wrong
+`cout`) for some multi-pulse inputs it does not yet resolve:
+
+- **Freundlich `n<1`** (concave / mirror geometry): a simple two-pulse input suffices —
+  minimal reproducer `cin=[0,8,8,8,0,0,2,2,0]`, `V=10.6`.
+- **Langmuir**: some specific multi-pulse configs.
+- **Freundlich `n>1`** (favorable): robustly supported (0 declines over broad sweeps).
+
+Hypothesis: the Feeder/Face merge calculus was validated on the favorable (`n>1`) geometry;
+the `n<1` mirror (step-ups are rarefactions, step-downs are shocks) mishandles the shock↔fan
+merge. Pinned by `TestKnownMultiFrontGaps` (`xfail(strict=True)`); tracked in **issue #317**.
+
+---
+
+## 5. Exactness of interaction resolution
+
+Two families of resolution paths exist. The direction of the audit is **one universal path**,
+not per-isotherm closed forms (leanness "one path"): the Feeder/Face merge calculus plus the
+universal numerical decay trajectory already resolve every `NonlinearSorption` and every
+Freundlich `n`.
+
+| resolution path                                                                                                                                      | file:line                      | accuracy                                                                                                                 | status                                                    |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------- |
+| Sweep-reader fan integrals (universal IBP antiderivative)                                                                                            | `output.py:592,601,1047`       | exact                                                                                                                    | keep (already single universal path)                      |
+| Merge calculus (`resolve_merge`/`make_wave_from_feeders`)                                                                                            | `interactions.py:308,394`      | exact (algebraic)                                                                                                        | keep                                                      |
+| `DecayingShockWave` universal decay profile (`_build_decay_profile`, Gauss–Legendre-10, 6000-node spline)                                            | `waves.py:1369`                | ~`1e-2` in the Freundlich `c_fixed>0` **growing** branch near the `c→0` floor (central-FD `R'`, `R'→∞`); to be tightened | keep + tighten (§ below)                                  |
+| `DoubleFanShockWave` universal RK4 (`_ensure_numerical`, fixed 512-step)                                                                             | `waves.py:1202`                | discretization-limited; convergence-tested                                                                               | keep                                                      |
+| Freundlich `n=2` DFSW shared-apex quadratic (`_v_closed`, `_alpha`, `_k`)                                                                            | `waves.py:1145,1166,1172`      | exact                                                                                                                    | **parallel special case → delete after equivalence test** |
+| Freundlich decaying-shock closed forms (`_compute_k_freundlich`, `_c_decay_freundlich`, `_invert_freundlich_cr_zero`, `_outlet_crossing_freundlich`) | `waves.py:1494,1560,1607,1653` | exact                                                                                                                    | **delete after equivalence test**                         |
+| Langmuir decaying-shock closed forms (`_compute_k_langmuir`, `_c_decay_langmuir`, `_outlet_crossing_langmuir`)                                       | `waves.py:1534,1635,1701`      | exact                                                                                                                    | **delete after equivalence test**                         |
+| Brooks–Corey decaying-shock closed form (`_c_decay_brooks_corey`)                                                                                    | `waves.py:1456`                | exact                                                                                                                    | **delete after equivalence test**                         |
+| dispatch flags (`_freundlich_cf`/`_langmuir_cf`/`_brooks_corey_cf`/`_numerical`, `_closed_form`)                                                     | `waves.py:773–778,1145`        | —                                                                                                                        | **delete with their branches**                            |
+
+**Tightening the universal path** (prerequisite to deleting the closed forms): the `~1e-2`
+growing-branch error is dominated by the **central finite-difference `R'`** in
+`_build_decay_profile` (`waves.py:1417`) where `R'→∞` at the `c→0` floor, compounded by a
+c-uniform node grid that under-resolves the steep integrand there. Every isotherm has an
+**analytic `R'`**; replacing the FD `R'` with the closed-form derivative (and refining the
+near-floor grid) drives the universal quadrature to a documented tolerance for all isotherms,
+after which the per-`n` closed forms are redundant and deleted (each behind a one-time
+equivalence test vs the universal path, with the analytic `n=2` solution and a DOP853
+trajectory kept as **test-only** anchors).
+
+Controlled approximations that remain (documented): the `c_min` dry-soil floor
+(`math.py:32`, `_C_MIN = 1e-12`) and the born-coincident `1e-3·V` triple-collision tolerance
+(`interactions.py:275`).
+
+---
+
+## 6. Literature
+
+- **Rhee, Aris & Amundson**, _First-Order Partial Differential Equations_, Vols. I–II —
+  chromatographic wave interactions and same-family simple-wave theory (the definitive
+  source for §3–§4).
+- **Helfferich & Klein**, _Multicomponent Chromatography_ — interference/coherence.
+- **LeVeque**, _Finite Volume Methods for Hyperbolic Problems_ — convex vs non-convex scalar
+  laws, Oleinik entropy condition, compound waves; Godunov upwind (the FV oracle basis).
+- **Smith (1983)**, _The theory of the kinematic wave in unsaturated flow_; **Charbeneau
+  (1984)**; **Sisson, Ferguson & van Genuchten (1980)** — kinematic-wave percolation,
+  convex conductivity flux, drainage/wetting fronts.
+- **Carsel & Parrish (1988)** — statistical distributions of soil hydraulic parameters
+  (the `n_vG`, `λ`, `θ_r`, `θ_s`, `K_s` grids used for the percolation regime).
+- **van Genuchten (1980)**; **Mualem (1976)**; **Brooks & Corey (1964)** — the retention /
+  conductivity constitutive models.

--- a/docs/theory/front_tracking_interactions.md
+++ b/docs/theory/front_tracking_interactions.md
@@ -153,11 +153,14 @@ everywhere. The **asymptotic** argument closes it rigorously: as `S_e → 0`,
 Consequences:
 
 - **No detect-and-reject scan is needed** (there is nothing non-convex to reject).
-- The `__post_init__` 2-point monotonicity guard (`math.py:970`, samples
-  `S_e ∈ {0.5, 0.99}`) is **vestigial**: the code's own double-precision `_dk_dse` is
-  monotone-increasing over brentq's actual search range `[_C_MIN, 1]` for every
-  Carsel–Parrish soil, so the guard never fires for valid parameters
-  (`scratchpad/repro_code_double_precision.py`).
+- The `__post_init__` 2-point monotonicity guard (samples `S_e ∈ {0.5, 0.99}`) was
+  **vestigial** and is removed: both sample points lie in the float64-well-resolved band
+  where `_dk_dse` is cleanly increasing, so `_dk_dse(0.5) < _dk_dse(0.99)` for every valid
+  Carsel–Parrish soil and the guard never fired. Its safety does **not** rest on `_dk_dse`
+  being monotone over the whole search range `[_C_MIN, 1]` — in fact `_dk_dse` is
+  double-precision _non_-monotone over a low-`S_e` sub-interval (the same catastrophic
+  cancellation), but that deep tail maps to `c < _C_MIN`, is unreachable by brentq, and is
+  therefore harmless.
 - The vG-M `R↔c` inversion degrades only at `c → K_s` (saturation, `S_e → 1`, `R → 0`, where
   `dK/dS_e → ∞` cannot be bracketed in `[_C_MIN, 1]`). This is an expected endpoint edge
   (the `MAX_FINITE_SPEED` / `R = 0` regime, `interactions.py:48`), not a mid-range defect;

--- a/src/gwtransport/fronttracking/math.py
+++ b/src/gwtransport/fronttracking/math.py
@@ -909,10 +909,12 @@ class VanGenuchtenMualemConductivity(NonlinearSorption):
     objective in ``concentration_from_retardation(R)``. The formula is
     inlined at both call sites, not exposed as a separate method.
 
-    The class checks monotonicity of ``dK_M/dS_e`` at a single pair of
-    sample points in ``__post_init__`` (cheap directional check). Truly
-    pathological parameter combinations that yield a non-monotone curve
-    surface as a ``brentq`` ValueError at the first inversion call.
+    ``dK_M/dS_e`` is strictly increasing for every ``n_vG > 1`` and
+    ``L ≥ 0`` (the conductivity flux is convex, ``d²K/dS_e² > 0``; proved at
+    200-digit precision in ``docs/theory/front_tracking_interactions.md`` §2),
+    so the brentq inversions are always well-posed — no monotonicity guard is
+    needed. A convex flux also means the transport admits only shocks and
+    rarefactions, never compound waves.
 
     Examples
     --------
@@ -941,14 +943,18 @@ class VanGenuchtenMualemConductivity(NonlinearSorption):
     """``θ_s − θ_r``; set in ``__post_init__``."""
 
     def __post_init__(self) -> None:
-        """Validate parameters and run a single-sample monotonicity check.
+        """Validate parameters and derive ``m``, ``delta_theta``.
+
+        No convexity/monotonicity guard is needed: ``dK_M/dS_e`` is strictly
+        increasing (the flux ``K(S_e)`` is convex, ``d²K/dS_e² > 0``) for every
+        ``n_vG > 1`` and ``L ≥ 0`` — proved at 200-digit precision in
+        ``docs/theory/front_tracking_interactions.md`` §2 — so the brentq
+        inversions are always well-posed.
 
         Raises
         ------
         ValueError
-            If parameters are outside their valid range, or if the cheap
-            monotonicity sample at ``S_e = 0.5`` vs ``0.99`` indicates
-            ``dK_M/dS_e`` is non-monotone (pathological).
+            If any parameter is outside its valid range.
         """
         if not 0.0 <= self.theta_r < self.theta_s:
             msg = f"theta_r must satisfy 0 <= theta_r < theta_s, got theta_r={self.theta_r}, theta_s={self.theta_s}"
@@ -967,17 +973,6 @@ class VanGenuchtenMualemConductivity(NonlinearSorption):
             raise ValueError(msg)
         self.m = 1.0 - 1.0 / self.van_genuchten_n
         self.delta_theta = self.theta_s - self.theta_r
-        # Cheap monotonicity sanity check on dK_M/dS_e.
-        s_low, s_high = 0.5, 0.99
-        if self._dk_dse(s_low) >= self._dk_dse(s_high):
-            msg = (
-                f"Non-monotone dK_M/dS_e detected at the sanity-check samples for "
-                f"van_genuchten_n={self.van_genuchten_n}, mualem_l={self.mualem_l}: "
-                f"dK_M/dS_e({s_low})={self._dk_dse(s_low):.6g} should be < "
-                f"dK_M/dS_e({s_high})={self._dk_dse(s_high):.6g}. "
-                f"Brentq inversions in this class assume monotone-increasing dK_M/dS_e."
-            )
-            raise ValueError(msg)
 
     def _k_se(self, s: float) -> float:
         """``K_M(S_e)`` evaluated at a scalar ``S_e``. Returns 0 at ``S_e = 0``."""

--- a/tests/src/_fv_oracle.py
+++ b/tests/src/_fv_oracle.py
@@ -1,0 +1,145 @@
+"""Independent Godunov upwind finite-volume oracle for front-tracking transport.
+
+The front tracker resolves the scalar conservation law ``∂_θ C_T(c) + ∂_V c = 0`` exactly
+(method of characteristics with shock/rarefaction bookkeeping). This module solves the *same*
+law by a completely different method — first-order Godunov upwind finite volumes — to provide
+an independent reference for the tracker's outlet concentration and stored mass.
+
+One path for every isotherm. Because the flux ``f(U) = c`` is monotone increasing in the
+conserved ``U = C_T(c)`` and the characteristic speed ``λ = df/dU = 1/R(c) > 0`` everywhere
+(one-directional flow), the Godunov interface flux reduces to pure **upwind**:
+``F_{i+1/2} = c_i``. The only isotherm-specific step is inverting ``U → c``; it is done by
+vectorised bisection on the monotone ``total_concentration`` (the tracker's forward map,
+which is not part of the interaction logic under test), so the oracle reimplements none of
+the shock/rarefaction/merge machinery it checks.
+
+First-order upwind is monotone and TVD, so it converges to the entropy solution as the grid
+refines; its error is O(ΔV) (numerical diffusion), which sets the agreement tolerance.
+
+This file is part of gwtransport which is released under AGPL-3.0 license.
+See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
+"""
+
+import numpy as np
+import numpy.typing as npt
+
+
+def c_from_total(
+    sorption,
+    u: npt.NDArray[np.floating],
+    *,
+    c_hi: float,
+    c_guess: npt.NDArray[np.floating] | None = None,
+    tol: float = 1e-12,
+    maxiter: int = 60,
+) -> npt.NDArray[np.floating]:
+    """Invert ``U = C_T(c)`` for ``c`` by safeguarded vectorised Newton.
+
+    The Newton derivative is free: ``dC_T/dc = R(c)`` is exactly the retardation factor, so
+    the update ``c <- c - (C_T(c) - U)/R(c)`` uses only the isotherm's forward maps (no
+    reimplementation of any inverse). Warm-started from ``c_guess`` (the previous timestep's
+    cells, which barely move), it converges in a handful of iterations; a fixed bisection
+    fallback would be ~10x slower for the same accuracy over a long march.
+
+    Parameters
+    ----------
+    sorption : SorptionModel
+        Any model with ``total_concentration`` and ``retardation``.
+    u : ndarray
+        Conserved totals ``C_T`` to invert. Non-negative.
+    c_hi : float
+        Upper clamp for ``c`` (kept for safety; ``c ≤ U`` since sorption only adds mass).
+    c_guess : ndarray, optional
+        Warm-start (previous cells). Defaults to ``min(U, c_hi)`` (a valid upper bracket).
+    tol : float, optional
+        Absolute convergence tolerance on ``|C_T(c) - U|`` (default 1e-12).
+    maxiter : int, optional
+        Newton iteration cap (default 60).
+
+    Returns
+    -------
+    ndarray
+        Dissolved concentration ``c`` with ``C_T(c) = u``.
+    """
+    u = np.asarray(u, dtype=float)
+    c = np.clip(np.minimum(u, c_hi) if c_guess is None else np.asarray(c_guess, dtype=float), 0.0, c_hi)
+    for _ in range(maxiter):
+        ct = np.asarray(sorption.total_concentration(c), dtype=float)
+        resid = ct - u
+        if np.max(np.abs(resid)) <= tol:
+            break
+        r = np.maximum(np.asarray(sorption.retardation(c), dtype=float), 1e-300)
+        c = np.clip(c - resid / r, 0.0, c_hi)
+    return c
+
+
+def upwind_fv_outlet(
+    sorption,
+    cin: npt.NDArray[np.floating],
+    theta_edges: npt.NDArray[np.floating],
+    v_outlet: float,
+    *,
+    n_cells: int = 1500,
+    cfl: float = 0.4,
+    c_hi: float | None = None,
+) -> tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]:
+    """Upwind FV march of ``U = C_T`` on ``[0, v_outlet]``; return outlet ``(θ, c)`` samples.
+
+    The column starts empty (``c = 0``). The inlet ghost cell carries ``cin(θ)`` at ``V = 0``.
+    The step ``Δθ`` is set from the CFL limit using the maximum characteristic speed
+    ``max 1/R`` over the inlet concentration range, then snapped so an integer number of steps
+    reaches ``θ_edges[-1]``.
+
+    Parameters
+    ----------
+    sorption : SorptionModel
+        Sorption/conductivity model.
+    cin : ndarray
+        Inlet concentration, constant per input bin; aligned with ``theta_edges``.
+    theta_edges : ndarray
+        Cumulative-flow bin edges (length ``len(cin) + 1``).
+    v_outlet : float
+        Outlet position (pore volume).
+    n_cells : int, optional
+        Number of V-cells (default 1500).
+    cfl : float, optional
+        Courant number (default 0.4).
+    c_hi : float, optional
+        Initial bracket for the ``U → c`` inversion; defaults to ``4·max(cin)``.
+
+    Returns
+    -------
+    theta : ndarray
+        θ at each recorded step.
+    cout : ndarray
+        Dissolved concentration in the outlet cell at each step.
+    """
+    cin = np.asarray(cin, dtype=float)
+    theta_edges = np.asarray(theta_edges, dtype=float)
+    c_max = float(cin.max())
+    c_hi = c_hi if c_hi is not None else max(c_max * 4.0, 1e-6)
+
+    dv = v_outlet / n_cells
+    u = np.zeros(n_cells)
+
+    c_probe = np.linspace(1e-9 * max(c_max, 1e-9), max(c_max, 1e-9), 200)
+    lam_max = float(np.max(1.0 / np.asarray(sorption.retardation(c_probe), dtype=float)))
+    theta_end = float(theta_edges[-1])
+    n_steps = max(int(np.ceil(theta_end / (cfl * dv / lam_max))), 1)
+    dtheta = theta_end / n_steps
+
+    theta = 0.0
+    rec_theta = np.empty(n_steps)
+    rec_cout = np.empty(n_steps)
+    c_cells = np.zeros(n_cells)  # warm-start carrier
+    for k in range(n_steps):
+        c_cells = c_from_total(sorption, u, c_hi=c_hi, c_guess=c_cells)  # concentrations at current θ
+        rec_theta[k] = theta
+        rec_cout[k] = c_cells[-1]  # outlet cell at current θ
+        idx = min(max(int(np.searchsorted(theta_edges, theta, side="right") - 1), 0), len(cin) - 1)
+        c_left = np.empty(n_cells)
+        c_left[0] = float(cin[idx])  # inlet ghost at V=0
+        c_left[1:] = c_cells[:-1]
+        u = np.maximum(u - (dtheta / dv) * (c_cells - c_left), 0.0)
+        theta += dtheta
+    return rec_theta, rec_cout

--- a/tests/src/test_front_tracking_interactions.py
+++ b/tests/src/test_front_tracking_interactions.py
@@ -4,9 +4,10 @@ Companion to ``docs/theory/front_tracking_interactions.md``. The ``interactions`
 (the Feeder/Face universal-merge calculus) previously had no dedicated test — it was only
 exercised transitively through the public-API multi-front runs. This file adds:
 
-- the RAREF-RAREF non-interaction guard (same-family simple waves never collide),
-- a "no silent corruption" randomized property sweep (whenever the solver does not flag an
-  unresolved interaction, its output is conservation-consistent and matches the FV oracle),
+- the RAREF-RAREF non-interaction *outcome* (same-family simple waves coexist without merging),
+- a "no silent corruption" property check over a fixed set of favorable multi-front inputs
+  (whenever the solver does not flag an unresolved interaction, its output is
+  conservation-consistent and matches the FV oracle),
 - confirmation that the favorable (Freundlich ``n>1``) regime is fully resolved, and
 - an ``xfail`` pinning the discovered multi-front completeness gap in the unfavorable
   (``n<1``) regime (declined LOUDLY via the public-API ``RuntimeError``, never silently wrong).
@@ -23,7 +24,12 @@ import pytest
 from _fv_oracle import upwind_fv_outlet  # ty: ignore[unresolved-import]  # tests/src on path via conftest
 
 from gwtransport.advection import infiltration_to_extraction_nonlinear_sorption
-from gwtransport.fronttracking.math import FreundlichSorption
+from gwtransport.fronttracking.math import (
+    BrooksCoreyConductivity,
+    ConstantRetardation,
+    FreundlichSorption,
+    LangmuirSorption,
+)
 from gwtransport.fronttracking.output import compute_domain_mass, concentration_at_point
 from gwtransport.fronttracking.solver import FrontTracker, find_unresolved_interaction
 from gwtransport.fronttracking.waves import DecayingShockWave, DoubleFanShockWave, RarefactionWave, ShockWave
@@ -70,13 +76,35 @@ _FAVORABLE_CONFIGS = [
 ]
 
 
+def test_fv_oracle_matches_analytic_contact():
+    """Known-answer self-check for the FV oracle: a constant-retardation contact.
+
+    Validates ``_fv_oracle.upwind_fv_outlet`` itself — the reference every tracker-vs-oracle
+    cross-check in this file leans on. For ``ConstantRetardation(R)`` a single ``0→c0`` inlet is a
+    contact discontinuity: it breaks through at ``θ = R·V`` and the outlet plateaus at ``c0``.
+    Catches a silent oracle regression (CFL/step-count, the ``U→c`` inversion, the ``max(·, 0)``
+    clamp) that would otherwise degrade all FV cross-checks without any localized failure.
+    """
+    r, c0, v_out = 2.0, 3.0, 5.0
+    sorption = ConstantRetardation(retardation_factor=r)
+    theta_edges = np.linspace(0.0, 25.0, 6)  # θ_end = 25 > R·V = 10 so breakthrough is captured
+    th, co = upwind_fv_outlet(sorption, np.full(5, c0), theta_edges, v_out, n_cells=200, cfl=0.4)
+    half_rise = float(th[np.searchsorted(co, c0 / 2.0)])
+    # first-order front smearing sets the breakthrough resolution to ~ΔV/V = 1/n_cells
+    np.testing.assert_allclose(half_rise, r * v_out, rtol=0.02)
+    np.testing.assert_allclose(co[-1], c0, rtol=1e-9)  # plateau to the inlet value
+
+
 class TestRarefactionRarefactionNoInteraction:
     """Two same-family rarefactions never interact (scalar single-family law).
 
     A rear rarefaction's head and the front rarefaction's tail both carry the separating
     constant state ``c*`` and move at the same celerity ``λ(c*)``; the gap is rigidly
-    translated and never closes (Rhee-Aris-Amundson). The solver's ``RAREF_RAREF_COLLISION``
-    no-op (``solver.py:560``) is therefore correct — see theory doc §4.1.
+    translated and never closes (Rhee-Aris-Amundson). These tests verify that *outcome* —
+    same-family rarefactions coexist and never spawn a merge/shock successor between them —
+    not the solver's ``RAREF_RAREF_COLLISION`` handler itself, which for physical inputs is
+    never reached (no ``rarefaction_rarefaction`` event is ever emitted), consistent with its
+    documented no-op status (see theory doc §4.1).
     """
 
     def test_unfavorable_staircase_is_all_coexisting_rarefactions(self):
@@ -101,12 +129,14 @@ class TestRarefactionRarefactionNoInteraction:
         # the resolved n<1 outlet is cross-checked against the FV oracle on a short config in
         # ``test_short_unfavorable_staircase_matches_fv`` below.
 
+    @pytest.mark.slow  # a fine FV-oracle cross-check: ~1e5 first-order upwind steps (~40 s serial)
     def test_short_unfavorable_staircase_matches_fv(self):
         """A short n<1 increasing staircase's resolved outlet matches the independent FV oracle.
 
         The only numerical (not just structural) validation of a resolved unfavorable-flux (concave,
-        mirror-regime) outlet — everything else in this file is favorable Freundlich n>1. Kept cheap
-        with a short series and small V so the first-order FV march stays a few thousand steps.
+        mirror-regime) outlet — everything else in this file is favorable Freundlich n>1. Even with a
+        short series and small V, the first-order FV march is ~1e5 steps (the CFL step scales with
+        ``V/n_cells`` while ``θ_end`` is fixed by the flow), so this is a slow independent cross-check.
         """
         s = FreundlichSorption(k_f=0.05, n=0.5, bulk_density=1500.0, porosity=0.3)
         cin = np.array([0.0] + [2.0] * 2 + [5.0] * 2 + [8.0] * 2 + [11.0] * 10)
@@ -118,13 +148,20 @@ class TestRarefactionRarefactionNoInteraction:
     def test_favorable_stepdowns_two_rarefactions_do_not_merge(self):
         """Freundlich ``n>1`` step-downs make two same-family rarefactions that never merge.
 
-        A leading loading shock forms (0→c step-up) and may catch the first fan, but the two
-        rarefactions themselves never collide and the solver stays self-consistent.
+        The inlet ``0→5→3→1`` forms a leading loading shock (``0→5`` step-up) followed by two
+        step-down rarefactions (fan1 ``5→3``, fan2 ``3→1``). The leading shock catches and
+        absorbs fan1 (a shock↔rarefaction interaction, not a rarefaction↔rarefaction one), so
+        exactly one rarefaction (fan2) survives — the two fans never merge *with each other*.
+        The surviving-rarefaction count and the FV cross-check pin that structure.
         """
         s = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
         cin = np.array([5.0] * 30 + [3.0] * 30 + [1.0] * 60)
         tr = _run(s, cin, 30.0)
         assert find_unresolved_interaction(tr.state) is None
+        active = [w for w in tr.state.waves if w.is_active]
+        # fan2 survives; fan1 is absorbed by the leading loading shock (never merged into fan2).
+        assert sum(isinstance(w, RarefactionWave) for w in active) == 1
+        assert not any(isinstance(w, DoubleFanShockWave) for w in active)
         assert _fv_discrepancy(tr, s, 30.0) < 0.02
 
 
@@ -164,6 +201,57 @@ class TestNoSilentCorruption:
         tr = _run(_FAVORABLE, np.array(pulse + [0.0] * 12, dtype=float), v_pv)
         assert find_unresolved_interaction(tr.state) is None
         assert _fv_discrepancy(tr, _FAVORABLE, v_pv, n_cells=120, stride=8) < 0.04
+
+    @pytest.mark.slow  # Langmuir multi-front resolution (~7 s) plus a ~5e3-step FV cross-check
+    def test_langmuir_resolved_run_conserves_and_matches_fv(self):
+        """Extend the "never silently wrong" net to a second isotherm (Langmuir).
+
+        The universal Feeder/Face merge calculus is claimed (theory doc §5) to resolve *every*
+        ``NonlinearSorption``, but every other resolved-run check here is Freundlich. A favorable
+        Langmuir two-pulse input is either fully resolved — mass-conserving and FV-consistent — or
+        declined loudly; this pins the resolved branch for Langmuir specifically.
+        """
+        s = LangmuirSorption(s_max=0.1, k_l=5.0, bulk_density=1500.0, porosity=0.3)
+        v_pv = 8.0
+        tr = _run(s, np.array([0.0, 6, 6, 0, 3, 3, 0] + [0.0] * 12, dtype=float), v_pv)
+        assert find_unresolved_interaction(tr.state) is None
+        theta_hi = float(tr.state.theta_edges[-1])
+
+        cout = np.array([concentration_at_point(v_pv, t, tr.state.waves, s) for t in np.linspace(1.0, theta_hi, 30)])
+        assert np.all(cout >= -1e-9), f"negative cout {cout.min()}"
+
+        theta_q = 0.4 * theta_hi
+        m_dom = compute_domain_mass(theta_q, v_pv, tr.state.waves, s)
+        # Langmuir's steeper fan makes the trapezoid reference converge more slowly than Freundlich's
+        # (rel ~9e-5 at n_v=6000, shrinking toward m_dom as n_v grows), so this gate is reference-error
+        # limited — not a defanged solver gate. m_dom (integrate_fan_spatial_exact) is exact.
+        m_quad = _independent_domain_mass(tr, s, v_pv, theta_q, n_v=6000)
+        np.testing.assert_allclose(m_dom, m_quad, rtol=3e-4, atol=1e-9)
+        # First-order FV diffusion runs higher for Langmuir's steeper fan than for Freundlich n>1.
+        assert _fv_discrepancy(tr, s, v_pv, n_cells=200, stride=8) < 0.06
+
+    def test_brooks_corey_resolved_run_conserves_and_nonnegative(self):
+        """Extend the resolved-branch conservation net to a third isotherm (Brooks-Corey).
+
+        A favorable Brooks-Corey two-pulse input is fully resolved (``find_unresolved`` None) and its
+        stored mass from ``integrate_fan_spatial_exact`` matches an independent pointwise trapezoid,
+        exercising Brooks-Corey's fan quadrature / merge calculus (theory doc §5's "every
+        ``NonlinearSorption``"). The FV-independent cross-check for a nonlinear isotherm is carried by
+        the Langmuir test above; Brooks-Corey's FV march is ~1e5 steps, too slow to repeat here.
+        """
+        s = BrooksCoreyConductivity(theta_r=0.045, theta_s=0.43, k_s=10.0, brooks_corey_lambda=0.5)
+        v_pv = 8.0
+        tr = _run(s, np.array([0.0, 6, 6, 0, 3, 3, 0] + [0.0] * 12, dtype=float), v_pv)
+        assert find_unresolved_interaction(tr.state) is None
+        theta_hi = float(tr.state.theta_edges[-1])
+
+        cout = np.array([concentration_at_point(v_pv, t, tr.state.waves, s) for t in np.linspace(1.0, theta_hi, 30)])
+        assert np.all(cout >= -1e-9), f"negative cout {cout.min()}"
+
+        theta_q = 0.4 * theta_hi
+        m_dom = compute_domain_mass(theta_q, v_pv, tr.state.waves, s)
+        m_quad = _independent_domain_mass(tr, s, v_pv, theta_q, n_v=6000)
+        np.testing.assert_allclose(m_dom, m_quad, rtol=1e-4, atol=1e-9)
 
 
 class TestKnownMultiFrontGaps:

--- a/tests/src/test_front_tracking_interactions.py
+++ b/tests/src/test_front_tracking_interactions.py
@@ -1,0 +1,218 @@
+"""Wave-interaction completeness tests for the multi-front front tracker.
+
+Companion to ``docs/theory/front_tracking_interactions.md``. The ``interactions`` module
+(the Feeder/Face universal-merge calculus) previously had no dedicated test — it was only
+exercised transitively through the public-API multi-front runs. This file adds:
+
+- the RAREF-RAREF non-interaction guard (same-family simple waves never collide),
+- a "no silent corruption" randomized property sweep (whenever the solver does not flag an
+  unresolved interaction, its output is conservation-consistent and matches the FV oracle),
+- confirmation that the favorable (Freundlich ``n>1``) regime is fully resolved, and
+- an ``xfail`` pinning the discovered multi-front completeness gap in the unfavorable
+  (``n<1``) regime (declined LOUDLY via the public-API ``RuntimeError``, never silently wrong).
+
+Independent reference: the Godunov upwind FV oracle in ``_fv_oracle``.
+
+This file is part of gwtransport which is released under AGPL-3.0 license.
+See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from _fv_oracle import upwind_fv_outlet  # ty: ignore[unresolved-import]  # tests/src on path via conftest
+
+from gwtransport.advection import infiltration_to_extraction_nonlinear_sorption
+from gwtransport.fronttracking.math import FreundlichSorption
+from gwtransport.fronttracking.output import compute_domain_mass, concentration_at_point
+from gwtransport.fronttracking.solver import FrontTracker, find_unresolved_interaction
+from gwtransport.fronttracking.waves import DecayingShockWave, DoubleFanShockWave, RarefactionWave, ShockWave
+
+
+def _run(sorption, cin, v_pv, flow=100.0):
+    cin = np.asarray(cin, dtype=float)
+    nb = len(cin)
+    tedges = pd.date_range("2020-01-01", periods=nb + 1, freq="D")
+    tr = FrontTracker(cin=cin, flow=np.full(nb, flow), tedges=tedges, aquifer_pore_volume=v_pv, sorption=sorption)
+    tr.run()
+    return tr
+
+
+def _fv_discrepancy(tr, sorption, v_pv, n_cells=200, stride=6):
+    """Integrated relative discrepancy between the exact tracker and the first-order FV oracle."""
+    th, co = upwind_fv_outlet(sorption, tr.state.cin, tr.state.theta_edges, v_pv, n_cells=n_cells, cfl=0.4)
+    mask = (th > 0) & (th <= float(tr.state.theta_edges[-1]))
+    th_s, co_s = th[mask][::stride], co[mask][::stride]
+    ct = np.array([concentration_at_point(v_pv, t, tr.state.waves, sorption) for t in th_s])
+    denom = np.trapezoid(np.abs(ct), th_s) + 1e-30
+    return float(np.trapezoid(np.abs(ct - co_s), th_s) / denom)
+
+
+def _independent_domain_mass(tr, sorption, v_pv, theta, n_v=4000):
+    """Independent stored-mass reference: ``∫₀^V C_T(c(v, θ)) dv`` via a fine trapezoid."""
+    v = np.linspace(0.0, v_pv, n_v)
+    c = np.array([concentration_at_point(vi, theta, tr.state.waves, sorption) for vi in v])
+    return float(np.trapezoid(np.asarray(sorption.total_concentration(c), dtype=float), v))
+
+
+# Favorable Freundlich (n>1) is the regime the multi-front solver fully resolves. These
+# hand-picked two/three-pulse inlets are each verified fast (<0.1 s) and interaction-complete.
+# Random sweeps are deliberately avoided: a minority of multi-pulse configs make the tracker
+# churn for many seconds (a #316 performance characteristic; the slow inputs are also the ones
+# that eventually decline), so a fixed, fast, deterministic set keeps the safety net cheap.
+_FAVORABLE = FreundlichSorption(k_f=0.008, n=2.0, bulk_density=1500.0, porosity=0.3)
+_FAVORABLE_CONFIGS = [
+    ([0.0, 6, 6, 0, 3, 3, 0], 8.0),
+    ([0.0, 8, 8, 8, 0, 4, 4, 0], 9.0),
+    ([0.0, 5, 5, 0, 0, 7, 7, 0], 10.0),
+    ([0.0, 9, 9, 0, 2, 2, 0], 7.0),
+    ([0.0, 4, 4, 4, 0, 0, 6, 6, 0], 11.0),
+]
+
+
+class TestRarefactionRarefactionNoInteraction:
+    """Two same-family rarefactions never interact (scalar single-family law).
+
+    A rear rarefaction's head and the front rarefaction's tail both carry the separating
+    constant state ``c*`` and move at the same celerity ``λ(c*)``; the gap is rigidly
+    translated and never closes (Rhee-Aris-Amundson). The solver's ``RAREF_RAREF_COLLISION``
+    no-op (``solver.py:560``) is therefore correct — see theory doc §4.1.
+    """
+
+    def test_unfavorable_staircase_is_all_coexisting_rarefactions(self):
+        """Freundlich ``n<1`` increasing staircase: every step-up is a rarefaction, all coexist.
+
+        For the unfavorable (concave) flux, step-*ups* spread into rarefactions and there is no
+        leading loading shock, so a strictly increasing inlet produces N same-family
+        rarefactions that must all remain active with no collision and no merge successor. (This
+        is a pure-rarefaction layout with no multi-front interaction, so it is unaffected by the
+        ``n<1`` interaction gap in :class:`TestKnownMultiFrontGaps`.)
+        """
+        s = FreundlichSorption(k_f=0.05, n=0.5, bulk_density=1500.0, porosity=0.3)
+        cin = np.array([0.0] + [2.0] * 8 + [5.0] * 8 + [8.0] * 8 + [11.0] * 40)
+        tr = _run(s, cin, 15.0)
+        active = [w for w in tr.state.waves if w.is_active]
+        n_raref = sum(isinstance(w, RarefactionWave) for w in active)
+        n_other = sum(isinstance(w, (ShockWave, DecayingShockWave, DoubleFanShockWave)) for w in active)
+        assert n_raref == 4, f"expected 4 coexisting rarefactions, got {n_raref}"
+        assert n_other == 0, "no shock/decaying/double-fan wave may form from same-family rarefactions"
+        assert find_unresolved_interaction(tr.state) is None
+        # This long-series staircase asserts only structure (a fine FV march over V=15 is expensive);
+        # the resolved n<1 outlet is cross-checked against the FV oracle on a short config in
+        # ``test_short_unfavorable_staircase_matches_fv`` below.
+
+    def test_short_unfavorable_staircase_matches_fv(self):
+        """A short n<1 increasing staircase's resolved outlet matches the independent FV oracle.
+
+        The only numerical (not just structural) validation of a resolved unfavorable-flux (concave,
+        mirror-regime) outlet — everything else in this file is favorable Freundlich n>1. Kept cheap
+        with a short series and small V so the first-order FV march stays a few thousand steps.
+        """
+        s = FreundlichSorption(k_f=0.05, n=0.5, bulk_density=1500.0, porosity=0.3)
+        cin = np.array([0.0] + [2.0] * 2 + [5.0] * 2 + [8.0] * 2 + [11.0] * 10)
+        tr = _run(s, cin, 6.0)
+        assert find_unresolved_interaction(tr.state) is None
+        assert sum(isinstance(w, RarefactionWave) for w in tr.state.waves if w.is_active) == 4
+        assert _fv_discrepancy(tr, s, 6.0, n_cells=160, stride=8) < 0.05
+
+    def test_favorable_stepdowns_two_rarefactions_do_not_merge(self):
+        """Freundlich ``n>1`` step-downs make two same-family rarefactions that never merge.
+
+        A leading loading shock forms (0→c step-up) and may catch the first fan, but the two
+        rarefactions themselves never collide and the solver stays self-consistent.
+        """
+        s = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        cin = np.array([5.0] * 30 + [3.0] * 30 + [1.0] * 60)
+        tr = _run(s, cin, 30.0)
+        assert find_unresolved_interaction(tr.state) is None
+        assert _fv_discrepancy(tr, s, 30.0) < 0.02
+
+
+class TestNoSilentCorruption:
+    """The solver is never SILENTLY wrong.
+
+    Whenever ``find_unresolved_interaction`` returns ``None`` (the solver claims a complete
+    resolution), the outlet ``cout`` must be conservation-consistent, match the independent FV
+    oracle, and be non-negative. Inputs the solver cannot resolve are declined LOUDLY (the
+    public API raises ``RuntimeError``); those are covered by :class:`TestKnownMultiFrontGaps`,
+    not silently mis-computed here. Theory doc §4.5.
+    """
+
+    @pytest.mark.parametrize(("pulse", "v_pv"), _FAVORABLE_CONFIGS, ids=[f"V{c[1]:g}" for c in _FAVORABLE_CONFIGS])
+    def test_resolved_run_conserves_and_nonnegative(self, pulse, v_pv):
+        cin = np.array(pulse + [0.0] * 12, dtype=float)
+        tr = _run(_FAVORABLE, cin, v_pv)
+        # favorable Freundlich n>1 multi-front is fully resolved (never silently wrong here)
+        assert find_unresolved_interaction(tr.state) is None
+        theta_hi = float(tr.state.theta_edges[-1])
+
+        cout = np.array([
+            concentration_at_point(v_pv, t, tr.state.waves, _FAVORABLE) for t in np.linspace(1.0, theta_hi, 30)
+        ])
+        assert np.all(cout >= -1e-9), f"negative cout {cout.min()}"
+
+        theta_q = 0.4 * theta_hi
+        m_dom = compute_domain_mass(theta_q, v_pv, tr.state.waves, _FAVORABLE)
+        m_quad = _independent_domain_mass(tr, _FAVORABLE, v_pv, theta_q, n_v=2000)
+        # rtol tight enough to constrain integrate_fan_spatial_exact: the only imprecision is the
+        # trapezoid reference's ~1e-8 error at n_v=2000; 1e-6 is 30x above that, not a defanged gate.
+        np.testing.assert_allclose(m_dom, m_quad, rtol=1e-6, atol=1e-9)
+
+    def test_outlet_cout_matches_fv_oracle(self):
+        """One FV cross-check (the expensive part) on a representative resolved config."""
+        pulse, v_pv = _FAVORABLE_CONFIGS[1]
+        tr = _run(_FAVORABLE, np.array(pulse + [0.0] * 12, dtype=float), v_pv)
+        assert find_unresolved_interaction(tr.state) is None
+        assert _fv_discrepancy(tr, _FAVORABLE, v_pv, n_cells=120, stride=8) < 0.04
+
+
+class TestKnownMultiFrontGaps:
+    """Documented completeness gaps in the #294/#316 multi-front solver.
+
+    The universal merge calculus was validated on the favorable (Freundlich ``n>1``) geometry;
+    the unfavorable (``n<1``, concave-flux) mirror — where step-ups are rarefactions and
+    step-downs are shocks — leaves some two-pulse shock↔fan interactions unresolved. The public
+    API surfaces this LOUDLY (``find_unresolved_interaction`` fires → ``RuntimeError``), so no
+    silently-wrong ``cout`` is ever returned. These tests assert the DESIRED behaviour (a
+    complete resolution) and are ``xfail(strict=True)``: a solver fix flips them to XPASS,
+    which fails the suite and flags that they should be un-xfailed. See
+    ``docs/theory/front_tracking_interactions.md`` §4.3.
+    """
+
+    @pytest.mark.slow  # the declined run churns to the loop guard (~15 s) before giving up
+    @pytest.mark.xfail(
+        strict=True,
+        raises=AssertionError,  # pin the ASSERTION failing, not e.g. a decline->crash regression
+        reason="#316 multi-front solver leaves an unresolved interaction for unfavorable "
+        "Freundlich n<1 two-pulse inputs (mirror-regime shock<->fan merge). Tracked in #317.",
+    )
+    def test_freundlich_nlt1_two_pulse_resolves(self):
+        s = FreundlichSorption(k_f=0.05, n=0.5, bulk_density=1500.0, porosity=0.3)
+        cin = np.array([0.0, 8.0, 8.0, 8.0, 0.0, 0.0, 2.0, 2.0, 0.0] + [0.0] * 20)
+        tr = _run(s, cin, 10.6)
+        assert find_unresolved_interaction(tr.state) is None
+
+    @pytest.mark.slow  # the declined run churns to the loop guard (~15 s) before giving up
+    def test_public_api_declines_n_lt_1_loudly(self):
+        """The gap surfaces as a public-API ``RuntimeError`` — never a silently-wrong cout.
+
+        Guards ``advection.infiltration_to_extraction_nonlinear_sorption``'s ``find_unresolved_interaction``
+        raise-wiring end-to-end (the increment's central "never silently wrong" contract), which the
+        internal-only checks above do not exercise. When #317 is fixed this must stop raising — update
+        it to assert a valid cout then.
+        """
+        cin = np.array([0.0, 8.0, 8.0, 8.0, 0.0, 0.0, 2.0, 2.0, 0.0] + [0.0] * 20)
+        nb = len(cin)
+        tedges = pd.date_range("2020-01-01", periods=nb + 1, freq="D")
+        with pytest.raises(RuntimeError, match="unresolved"):
+            infiltration_to_extraction_nonlinear_sorption(
+                cin=cin,
+                flow=np.full(nb, 100.0),
+                tedges=tedges,
+                cout_tedges=tedges,
+                aquifer_pore_volumes=[10.6],
+                freundlich_k=0.05,
+                freundlich_n=0.5,
+                bulk_density=1500.0,
+                porosity=0.3,
+            )

--- a/tests/src/test_front_tracking_math.py
+++ b/tests/src/test_front_tracking_math.py
@@ -924,30 +924,30 @@ class TestFluxCurvatureNoCompoundWaves:
     """
 
     @staticmethod
-    def _u_lambda(sorption, c_grid):
+    def _lambda_ordered_by_u(sorption, c_grid):
+        """Return ``λ(c)`` reordered by increasing ``U = C_T(c)`` (single-curvature ⇔ ``λ`` monotone)."""
         u = np.array([float(sorption.total_concentration(c)) for c in c_grid])
         lam = np.array([float(characteristic_speed(c, sorption)) for c in c_grid])
-        order = np.argsort(u)
-        return u[order], lam[order]
+        return lam[np.argsort(u)]
 
     def test_freundlich_n_gt_1_convex_favorable(self):
         """Freundlich ``n>1``: ``λ`` strictly increasing in ``U`` (convex, higher C faster)."""
         for n in (1.5, 2.0, 3.0):
             s = FreundlichSorption(k_f=0.01, n=n, bulk_density=1500.0, porosity=0.3)
-            _, lam = self._u_lambda(s, np.linspace(0.05, 20.0, 400))
+            lam = self._lambda_ordered_by_u(s, np.linspace(0.05, 20.0, 400))
             assert np.all(np.diff(lam) > 0.0), f"Freundlich n={n} not strictly convex"
 
     def test_freundlich_n_lt_1_concave_unfavorable(self):
         """Freundlich ``n<1``: ``λ`` strictly decreasing in ``U`` (concave, higher C slower)."""
         for n in (0.3, 0.5, 0.7):
             s = FreundlichSorption(k_f=0.05, n=n, bulk_density=1500.0, porosity=0.3)
-            _, lam = self._u_lambda(s, np.linspace(0.05, 20.0, 400))
+            lam = self._lambda_ordered_by_u(s, np.linspace(0.05, 20.0, 400))
             assert np.all(np.diff(lam) < 0.0), f"Freundlich n={n} not strictly concave"
 
     def test_langmuir_convex_favorable(self):
         """Langmuir: ``λ`` strictly increasing in ``U`` (convex, favorable)."""
         s = LangmuirSorption(s_max=0.1, k_l=5.0, bulk_density=1500.0, porosity=0.3)
-        _, lam = self._u_lambda(s, np.linspace(0.01, 30.0, 400))
+        lam = self._lambda_ordered_by_u(s, np.linspace(0.01, 30.0, 400))
         assert np.all(np.diff(lam) > 0.0)
 
     def test_constant_retardation_linearly_degenerate(self):
@@ -961,7 +961,7 @@ class TestFluxCurvatureNoCompoundWaves:
         """Brooks-Corey: ``λ`` strictly increasing in ``U`` (convex; ``f ∝ U^a``, ``a>3``)."""
         s = BrooksCoreyConductivity(theta_r=0.045, theta_s=0.43, k_s=10.0, brooks_corey_lambda=lam_bc)
         c = np.linspace(1e-3 * s.k_s, 0.95 * s.k_s, 400)
-        _, lam = self._u_lambda(s, c)
+        lam = self._lambda_ordered_by_u(s, c)
         assert np.all(np.diff(lam) > 0.0)
 
     @pytest.mark.parametrize(
@@ -989,5 +989,5 @@ class TestFluxCurvatureNoCompoundWaves:
         # float64 resolution and is instead covered by the 200-digit proof in
         # ``docs/theory/front_tracking_interactions.md`` §2. Working in the c-domain avoids the
         # brentq-inversion edge at saturation.
-        _, lam = self._u_lambda(s, np.linspace(0.01, 0.6 * s.k_s, 400))
+        lam = self._lambda_ordered_by_u(s, np.linspace(0.01, 0.6 * s.k_s, 400))
         assert np.all(np.diff(lam) > 0.0), f"vG-Mualem n_vG={n_vg}: λ not strictly increasing in U"

--- a/tests/src/test_front_tracking_math.py
+++ b/tests/src/test_front_tracking_math.py
@@ -907,3 +907,87 @@ def test_van_genuchten_validation_rejects_invalid(invalid_kwargs):
     """Coverage-only parametrised validation. Each invalid input raises ``ValueError``."""
     with pytest.raises(ValueError):
         VanGenuchtenMualemConductivity(**invalid_kwargs)
+
+
+class TestFluxCurvatureNoCompoundWaves:
+    """Every isotherm flux is single-curvature — none is non-convex — so compound
+    (shock+rarefaction) waves never occur.
+
+    The scalar law is ``∂_θ C_T(c) + ∂_V c = 0`` with conserved ``U = C_T(c)``, flux
+    ``f = c`` and celerity ``λ(U) = dc/dC_T = 1/R(c)``. Compound waves require the flux
+    curvature ``f'' = dλ/dU`` to CHANGE SIGN. Equivalently ``λ(U)`` must be non-monotone.
+    These tests assert ``λ`` is strictly monotone in ``U`` for every model (gradient-free:
+    monotonicity of the exact ``(U, λ)`` sequence, so no finite-difference noise), with the
+    sign fixed by the isotherm class (favorable ``R'<0`` ⇒ ``λ`` increasing; unfavorable
+    ``R'>0`` ⇒ decreasing; linear ⇒ constant). See
+    ``docs/theory/front_tracking_interactions.md`` §2.
+    """
+
+    @staticmethod
+    def _u_lambda(sorption, c_grid):
+        u = np.array([float(sorption.total_concentration(c)) for c in c_grid])
+        lam = np.array([float(characteristic_speed(c, sorption)) for c in c_grid])
+        order = np.argsort(u)
+        return u[order], lam[order]
+
+    def test_freundlich_n_gt_1_convex_favorable(self):
+        """Freundlich ``n>1``: ``λ`` strictly increasing in ``U`` (convex, higher C faster)."""
+        for n in (1.5, 2.0, 3.0):
+            s = FreundlichSorption(k_f=0.01, n=n, bulk_density=1500.0, porosity=0.3)
+            _, lam = self._u_lambda(s, np.linspace(0.05, 20.0, 400))
+            assert np.all(np.diff(lam) > 0.0), f"Freundlich n={n} not strictly convex"
+
+    def test_freundlich_n_lt_1_concave_unfavorable(self):
+        """Freundlich ``n<1``: ``λ`` strictly decreasing in ``U`` (concave, higher C slower)."""
+        for n in (0.3, 0.5, 0.7):
+            s = FreundlichSorption(k_f=0.05, n=n, bulk_density=1500.0, porosity=0.3)
+            _, lam = self._u_lambda(s, np.linspace(0.05, 20.0, 400))
+            assert np.all(np.diff(lam) < 0.0), f"Freundlich n={n} not strictly concave"
+
+    def test_langmuir_convex_favorable(self):
+        """Langmuir: ``λ`` strictly increasing in ``U`` (convex, favorable)."""
+        s = LangmuirSorption(s_max=0.1, k_l=5.0, bulk_density=1500.0, porosity=0.3)
+        _, lam = self._u_lambda(s, np.linspace(0.01, 30.0, 400))
+        assert np.all(np.diff(lam) > 0.0)
+
+    def test_constant_retardation_linearly_degenerate(self):
+        """Constant retardation: ``λ`` is constant in ``U`` (linearly degenerate, contacts only)."""
+        s = ConstantRetardation(retardation_factor=2.5)
+        lam = np.array([characteristic_speed(c, s) for c in np.linspace(0.1, 20.0, 50)])
+        np.testing.assert_allclose(lam, lam[0], rtol=1e-14)
+
+    @pytest.mark.parametrize("lam_bc", [0.15, 0.25, 0.5, 1.0, 2.0])
+    def test_brooks_corey_convex(self, lam_bc):
+        """Brooks-Corey: ``λ`` strictly increasing in ``U`` (convex; ``f ∝ U^a``, ``a>3``)."""
+        s = BrooksCoreyConductivity(theta_r=0.045, theta_s=0.43, k_s=10.0, brooks_corey_lambda=lam_bc)
+        c = np.linspace(1e-3 * s.k_s, 0.95 * s.k_s, 400)
+        _, lam = self._u_lambda(s, c)
+        assert np.all(np.diff(lam) > 0.0)
+
+    @pytest.mark.parametrize(
+        "n_vg",
+        [1.09, 1.15, 1.31, 1.41, 1.56, 1.89, 2.28, 2.68],  # Carsel-Parrish clay -> sand
+    )
+    def test_van_genuchten_mualem_convex_no_compound_waves(self, n_vg):
+        """vG-Mualem: ``λ = 1/R`` strictly increasing in ``U = C_T`` ⇒ convex ⇒ no compound waves.
+
+        This is the direct no-compound-wave test for the parameter the plan flagged as a
+        (spurious) non-convexity risk. A prior finite-difference analysis reported clay
+        (``n_vG≈1.09``) as non-convex; that was float64 cancellation in
+        ``U = 1 − (1 − S_e^{1/m})^m`` near ``S_e → 0`` (the astronomically small dry tail,
+        where ``dK/dS_e`` underflows float64 to 0). Working in the ``c``-domain via the
+        public ``characteristic_speed``/``total_concentration`` maps to well-resolved
+        ``S_e`` and is cleanly monotone. The full-range convexity (including the dry tail)
+        is proved at 200-digit precision in ``docs/theory/front_tracking_interactions.md`` §2.
+        """
+        s = VanGenuchtenMualemConductivity(theta_r=0.06, theta_s=0.40, k_s=10.0, van_genuchten_n=n_vg)
+        # Probe the float64-RESOLVABLE part of the range. c in [0.01, 0.6*k_s] maps to the upper S_e
+        # band (e.g. S_e in [0.91, 1.0] for clay n_vG=1.09) — this is a genuine limitation, not a
+        # choice: below it dK/dS_e underflows/jitters in float64 (the same catastrophic cancellation
+        # that produced the spurious "non-convex" reading). A GLOBAL non-convex regression is caught
+        # here (confirmed by mutation via the coarser-m soils); a dry-tail-LOCALIZED one is below
+        # float64 resolution and is instead covered by the 200-digit proof in
+        # ``docs/theory/front_tracking_interactions.md`` §2. Working in the c-domain avoids the
+        # brentq-inversion edge at saturation.
+        _, lam = self._u_lambda(s, np.linspace(0.01, 0.6 * s.k_s, 400))
+        assert np.all(np.diff(lam) > 0.0), f"vG-Mualem n_vG={n_vg}: λ not strictly increasing in U"


### PR DESCRIPTION
Interaction-completeness audit of the multi-front wave-interaction solver (follow-up to #294 / was stacked on #316), per `PLAN_294_interaction_completeness`.

## Summary

**Physics (theory doc, physics-reviewer approved).** New `docs/theory/front_tracking_interactions.md` — the authoritative interaction catalogue. Establishes (triple-verified, 200-digit precision) that **every isotherm flux is single-curvature** (Freundlich n>1 / Langmuir / Brooks-Corey / van-Genuchten-Mualem convex, Freundlich n<1 concave, Constant linear), so **compound waves never occur** — the solver's shock+rarefaction repertoire is complete. A prior "vG-M non-convex" claim was float64 catastrophic-cancellation noise in `U = 1-(1-S_e^{1/m})^m`.

## Changes
- **`math.py`:** remove the vestigial 2-point vG-M monotonicity guard in `VanGenuchtenMualemConductivity.__post_init__` (never fires for any valid `n_vG>1, L>=0`; `dK/dS_e` is provably strictly increasing) + document the convexity.
- **`tests/src/test_front_tracking_math.py`:** `TestFluxCurvatureNoCompoundWaves` — celerity `1/R` strictly monotone in `U=C_T` for every isotherm (gradient-free single-curvature check).
- **`tests/src/_fv_oracle.py`:** independent Godunov upwind FV oracle (one path for all isotherms via Newton `C_T->c` using `dC_T/dc=R`); self-gates to first-order FV error.
- **`tests/src/test_front_tracking_interactions.py`:** RAREF-RAREF non-interaction guard; favorable multi-front conservation + FV property checks; a public-API `RuntimeError` "declines loudly" test; and an `xfail(strict)` pinning the discovered n<1 gap.

## Finding (tracked as #317)
The multi-front solver is INCOMPLETE for the unfavorable **Freundlich n<1** mirror (and some Langmuir configs): it declines **loudly** (`find_unresolved_interaction` -> public-API `RuntimeError`), never returns a silently-wrong cout. Favorable n>1 is robustly supported. Minimal repro `cin=[0,8,8,8,0,0,2,2,0], V=10.6`. Pinned by `xfail(strict)`; related to #312.

## Testing
`27 passed, 1 xfailed` (the xfail pins #317). Physics-math reviewer: APPROVED. Test reviewer: APPROVE-WITH-FIXES (all fixes applied — domain-mass tolerance tightened 5e-3->1e-6, public-API-raises test added, short n<1 FV cross-check, xfail scoped). ruff / prettier / ty clean; math (128) + percolation (60) regression suites green.

Rebased onto `main` now that #316 has landed (#294 closed). The two audit commits apply cleanly on top of the merged multi-front solver. Deferred to follow-ons: §3 universal-path consolidation (delete per-n closed forms after tightening `_build_decay_profile` with analytic `R'`) and the full §4.2 isotherm×interaction grid.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
