### PR TITLE
perf(fronttracking): cache wave speeds in one intersection kernel + scalar isotherm fast paths

### DIFF
--- a/src/gwtransport/fronttracking/events.py
+++ b/src/gwtransport/fronttracking/events.py
@@ -126,102 +126,78 @@ class Event:
         )
 
 
+def _line_intersection(
+    theta_start_a: float,
+    v_start_a: float,
+    speed_a: float,
+    theta_start_b: float,
+    v_start_b: float,
+    speed_b: float,
+    theta_current: float,
+) -> tuple[float, float] | None:
+    """First future crossing of two straight (V, θ) fronts, or ``None``.
+
+    Every characteristic/shock/rarefaction-boundary travels at a flow-free constant
+    speed, so each is a line ``V = v_start + speed·(θ − θ_start)``. Both are evaluated
+    from the shared reference ``θ_both = max(θ_start_a, θ_start_b, θ_current)`` and the
+    crossing is returned only when strictly in the future (``dθ > 0``).
+
+    ``V_intersect`` is evaluated on line ``a``: the ``dθ`` is invariant under an a↔b swap
+    (exact IEEE negation of numerator and denominator) but ``V_intersect`` is not, so the
+    four public wrappers pass the same operand order their pre-refactor bodies used.
+    """
+    if abs(speed_a - speed_b) < EPSILON_SPEED:
+        return None
+    theta_both = max(theta_start_a, theta_start_b, theta_current)
+    v_a = v_start_a + speed_a * (theta_both - theta_start_a)
+    v_b = v_start_b + speed_b * (theta_both - theta_start_b)
+    dtheta = (v_b - v_a) / (speed_a - speed_b)
+    if dtheta <= 0:
+        return None
+    return (theta_both + dtheta, v_a + speed_a * dtheta)
+
+
 def find_characteristic_intersection(char1, char2, theta_current: float) -> tuple[float, float] | None:
     """Find exact analytical intersection of two characteristics in (V, θ).
 
     Returns (θ_intersect, V_intersect) if the intersection lies in the future
     (θ > θ_current) and both characteristics are active there; otherwise None.
     """
-    s1 = characteristic_speed(char1.concentration, char1.sorption)
-    s2 = characteristic_speed(char2.concentration, char2.sorption)
-
-    if abs(s1 - s2) < EPSILON_SPEED:
-        return None
-
-    theta_both_active = max(char1.theta_start, char2.theta_start, theta_current)
-
-    v1 = characteristic_position(
-        char1.concentration, char1.sorption, char1.theta_start, char1.v_start, theta_both_active
+    return _line_intersection(
+        char1.theta_start, char1.v_start, char1.speed(), char2.theta_start, char2.v_start, char2.speed(), theta_current
     )
-    v2 = characteristic_position(
-        char2.concentration, char2.sorption, char2.theta_start, char2.v_start, theta_both_active
-    )
-
-    if v1 is None or v2 is None:
-        return None
-
-    # v1 + s1*dθ = v2 + s2*dθ
-    dtheta = (v2 - v1) / (s1 - s2)
-
-    if dtheta <= 0:
-        return None
-
-    theta_intersect = theta_both_active + dtheta
-    v_intersect = v1 + s1 * dtheta
-
-    return (theta_intersect, v_intersect)
 
 
 def find_shock_shock_intersection(shock1, shock2, theta_current: float) -> tuple[float, float] | None:
     """Find exact analytical intersection of two shocks in (V, θ)."""
-    s1 = shock1.speed
-    s2 = shock2.speed
-
-    if abs(s1 - s2) < EPSILON_SPEED:
-        return None
-
-    theta_both_active = max(shock1.theta_start, shock2.theta_start, theta_current)
-
-    v1_ref = shock1.v_start + shock1.speed * (theta_both_active - shock1.theta_start)
-    v2_ref = shock2.v_start + shock2.speed * (theta_both_active - shock2.theta_start)
-
-    dtheta = (v2_ref - v1_ref) / (s1 - s2)
-
-    if dtheta <= 0:
-        return None
-
-    theta_intersect = theta_both_active + dtheta
-    v_intersect = v1_ref + s1 * dtheta
-
-    return (theta_intersect, v_intersect)
+    return _line_intersection(
+        shock1.theta_start,
+        shock1.v_start,
+        shock1.speed,
+        shock2.theta_start,
+        shock2.v_start,
+        shock2.speed,
+        theta_current,
+    )
 
 
 def find_shock_characteristic_intersection(shock, char, theta_current: float) -> tuple[float, float] | None:
     """Find exact analytical intersection of a shock and a characteristic in (V, θ)."""
-    s_shock = shock.speed
-    s_char = characteristic_speed(char.concentration, char.sorption)
-
-    if abs(s_shock - s_char) < EPSILON_SPEED:
-        return None
-
-    theta_both_active = max(shock.theta_start, char.theta_start, theta_current)
-
-    v_shock = shock.v_start + shock.speed * (theta_both_active - shock.theta_start)
-
-    v_char = characteristic_position(
-        char.concentration, char.sorption, char.theta_start, char.v_start, theta_both_active
+    return _line_intersection(
+        shock.theta_start, shock.v_start, shock.speed, char.theta_start, char.v_start, char.speed(), theta_current
     )
-
-    if v_char is None:
-        return None
-
-    dtheta = (v_char - v_shock) / (s_shock - s_char)
-
-    if dtheta <= 0:
-        return None
-
-    theta_intersect = theta_both_active + dtheta
-    v_intersect = v_shock + s_shock * dtheta
-
-    return (theta_intersect, v_intersect)
 
 
 def find_rarefaction_boundary_intersections(raref, other_wave, theta_current: float) -> list[tuple[float, float, str]]:
     """Intersections of a rarefaction's head/tail with another wave.
 
     Both rarefaction boundaries propagate at characteristic speeds (head at
-    ``1/R(c_head)``, tail at ``1/R(c_tail)``), so we synthesize temporary
-    ``CharacteristicWave`` instances and reuse the analytical helpers.
+    ``1/R(c_head)``, tail at ``1/R(c_tail)``), so each is a straight (V, θ) line
+    fed directly into :func:`_line_intersection` — no temporary ``CharacteristicWave``
+    objects. The operand order matches the per-branch order the closed-form helpers
+    used before the refactor (``a`` is the raref boundary vs a characteristic, but the
+    SHOCK vs a raref boundary, so ``V_intersect`` — the new wave's ``v_start`` — is
+    bit-identical).
 
     Returns
     -------
@@ -230,73 +206,52 @@ def find_rarefaction_boundary_intersections(raref, other_wave, theta_current: fl
         where boundary_type is ``'head'`` or ``'tail'``.
     """
     intersections = []
-
-    head_char = CharacteristicWave(
-        theta_start=raref.theta_start,
-        v_start=raref.v_start,
-        concentration=raref.c_head,
-        sorption=raref.sorption,
-        is_active=raref.is_active,
-    )
-
-    tail_char = CharacteristicWave(
-        theta_start=raref.theta_start,
-        v_start=raref.v_start,
-        concentration=raref.c_tail,
-        sorption=raref.sorption,
-        is_active=raref.is_active,
-    )
+    raref_boundaries = ((raref.head_speed(), "head"), (raref.tail_speed(), "tail"))
 
     if isinstance(other_wave, CharacteristicWave):
-        result = find_characteristic_intersection(head_char, other_wave, theta_current)
-        if result:
-            intersections.append((result[0], result[1], "head"))
-
-        result = find_characteristic_intersection(tail_char, other_wave, theta_current)
-        if result:
-            intersections.append((result[0], result[1], "tail"))
+        for s_raref, tag in raref_boundaries:
+            hit = _line_intersection(
+                raref.theta_start,
+                raref.v_start,
+                s_raref,
+                other_wave.theta_start,
+                other_wave.v_start,
+                other_wave.speed(),
+                theta_current,
+            )
+            if hit:
+                intersections.append((hit[0], hit[1], tag))
 
     elif isinstance(other_wave, ShockWave):
-        result = find_shock_characteristic_intersection(other_wave, head_char, theta_current)
-        if result:
-            intersections.append((result[0], result[1], "head"))
-
-        result = find_shock_characteristic_intersection(other_wave, tail_char, theta_current)
-        if result:
-            intersections.append((result[0], result[1], "tail"))
+        # a=SHOCK, b=raref boundary (matches find_shock_characteristic_intersection's order).
+        for s_raref, tag in raref_boundaries:
+            hit = _line_intersection(
+                other_wave.theta_start,
+                other_wave.v_start,
+                other_wave.speed,
+                raref.theta_start,
+                raref.v_start,
+                s_raref,
+                theta_current,
+            )
+            if hit:
+                intersections.append((hit[0], hit[1], tag))
 
     elif isinstance(other_wave, RarefactionWave):
-        other_head_char = CharacteristicWave(
-            theta_start=other_wave.theta_start,
-            v_start=other_wave.v_start,
-            concentration=other_wave.c_head,
-            sorption=other_wave.sorption,
-            is_active=other_wave.is_active,
-        )
-
-        other_tail_char = CharacteristicWave(
-            theta_start=other_wave.theta_start,
-            v_start=other_wave.v_start,
-            concentration=other_wave.c_tail,
-            sorption=other_wave.sorption,
-            is_active=other_wave.is_active,
-        )
-
-        result = find_characteristic_intersection(head_char, other_head_char, theta_current)
-        if result:
-            intersections.append((result[0], result[1], "head"))
-
-        result = find_characteristic_intersection(head_char, other_tail_char, theta_current)
-        if result:
-            intersections.append((result[0], result[1], "head"))
-
-        result = find_characteristic_intersection(tail_char, other_head_char, theta_current)
-        if result:
-            intersections.append((result[0], result[1], "tail"))
-
-        result = find_characteristic_intersection(tail_char, other_tail_char, theta_current)
-        if result:
-            intersections.append((result[0], result[1], "tail"))
+        other_boundaries = (other_wave.head_speed(), other_wave.tail_speed())
+        for s_raref, tag in raref_boundaries:
+            for s_other in other_boundaries:
+                hit = _line_intersection(
+                    raref.theta_start,
+                    raref.v_start,
+                    s_raref,
+                    other_wave.theta_start,
+                    other_wave.v_start,
+                    s_other,
+                    theta_current,
+                )
+                if hit:
+                    intersections.append((hit[0], hit[1], tag))
 
     return intersections
 

--- a/src/gwtransport/fronttracking/math.py
+++ b/src/gwtransport/fronttracking/math.py
@@ -19,6 +19,7 @@ This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """
 
+import math
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 
@@ -223,6 +224,14 @@ class FreundlichSorption(NonlinearSorption):
     """Porosity [-]."""
     c_min: float = 1e-12
     """Minimum concentration threshold to prevent infinite retardation."""
+    _ret_coefficient: float = field(init=False, repr=False, compare=False)
+    """Cached ``(rho_b*k_f)/(n_por*n)`` — shared by the scalar and array paths."""
+    _ret_exponent: float = field(init=False, repr=False, compare=False)
+    """Cached ``(1/n) - 1`` retardation exponent."""
+    _ct_coefficient: float = field(init=False, repr=False, compare=False)
+    """Cached ``(rho_b/n_por)*k_f`` sorbed-mass coefficient."""
+    _cfr_inv_exponent: float = field(init=False, repr=False, compare=False)
+    """Cached ``1/((1/n) - 1)`` inversion exponent for concentration_from_retardation."""
 
     def __post_init__(self):
         """Validate parameters after initialization.
@@ -252,6 +261,11 @@ class FreundlichSorption(NonlinearSorption):
         if self.c_min < 0:
             msg = f"c_min must be non-negative, got {self.c_min}"
             raise ValueError(msg)
+
+        self._ret_exponent = (1.0 / self.n) - 1.0
+        self._ret_coefficient = (self.bulk_density * self.k_f) / (self.porosity * self.n)
+        self._ct_coefficient = (self.bulk_density / self.porosity) * self.k_f
+        self._cfr_inv_exponent = 1.0 / self._ret_exponent
 
     def retardation(self, c: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """
@@ -288,13 +302,21 @@ class FreundlichSorption(NonlinearSorption):
         Clamping with ``np.maximum`` before the power keeps a single general path
         for every ``(n, c_min)`` combination and avoids raising the base to a
         fractional power on negative ``c``.
+
+        A pure-float fast path handles the (dominant) scalar case, bit-identical to
+        the array path; it falls through to the array expression only when the
+        clamped ``c`` is ``0`` (``c_min == 0`` and ``c <= 0``), where numpy's
+        ``0.0**exponent`` yields the documented ``inf`` (n>1) / ``0`` (n<1) that a
+        pure ``0.0**neg`` would instead raise on.
         """
-        is_array = isinstance(c, np.ndarray)
+        if not isinstance(c, np.ndarray):
+            cf = float(c)
+            c_eff = max(self.c_min, cf)
+            if c_eff > 0.0:
+                return 1.0 + self._ret_coefficient * (c_eff**self._ret_exponent)
         c_eff = np.maximum(np.asarray(c), self.c_min)
-        exponent = (1.0 / self.n) - 1.0
-        coefficient = (self.bulk_density * self.k_f) / (self.porosity * self.n)
-        result = 1.0 + coefficient * (c_eff**exponent)
-        return result if is_array else float(result)
+        result = 1.0 + self._ret_coefficient * (c_eff**self._ret_exponent)
+        return result if isinstance(c, np.ndarray) else float(result)
 
     def total_concentration(self, c: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """
@@ -330,11 +352,12 @@ class FreundlichSorption(NonlinearSorption):
         shock speeds when ``c_R = 0`` (e.g. the canonical 0->c->0 pulse).
         Negative ``c`` is clamped to ``0`` defensively.
         """
-        is_array = isinstance(c, np.ndarray)
+        if not isinstance(c, np.ndarray):
+            cf = float(c)
+            c_eff = max(0.0, cf)
+            return c_eff + self._ct_coefficient * (c_eff ** (1.0 / self.n))
         c_arr = np.maximum(np.asarray(c), 0.0)
-        sorbed = (self.bulk_density / self.porosity) * self.k_f * (c_arr ** (1.0 / self.n))
-        result = c_arr + sorbed
-        return result if is_array else float(result)
+        return c_arr + self._ct_coefficient * (c_arr ** (1.0 / self.n))
 
     def concentration_from_retardation(self, r: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """
@@ -374,23 +397,20 @@ class FreundlichSorption(NonlinearSorption):
         >>> bool(np.isclose(c, 5.0, rtol=1e-14))
         True
         """
-        is_array = isinstance(r, np.ndarray)
-        r_arr = np.asarray(r)
-
         # FreundlichSorption.__post_init__ rejects |n-1| < EPSILON_FREUNDLICH_N,
         # so the previous n≈1 guard here was unreachable.
-        exponent = (1.0 / self.n) - 1.0
-        coefficient = (self.bulk_density * self.k_f) / (self.porosity * self.n)
-        base = (r_arr - 1.0) / coefficient
-        inversion_exponent = 1.0 / exponent
+        if not isinstance(r, np.ndarray):
+            base = (float(r) - 1.0) / self._ret_coefficient
+            if base > 0.0:
+                return max(base**self._cfr_inv_exponent, self.c_min)
+            return self.c_min
 
+        base = (np.asarray(r) - 1.0) / self._ret_coefficient
         # Mask base to a safe placeholder before exponentiation; NumPy emits
         # RuntimeWarning otherwise for base <= 0 with a fractional exponent.
         safe_base = np.where(base > 0, base, 1.0)
-        c = safe_base**inversion_exponent
-        result = np.where(base > 0, np.maximum(c, self.c_min), self.c_min)
-
-        return result if is_array else float(result)
+        c = safe_base**self._cfr_inv_exponent
+        return np.where(base > 0, np.maximum(c, self.c_min), self.c_min)
 
     def fan_converges_at_infinity(self) -> bool:
         """Freundlich ``n > 1``: ``c → 0`` as ``R → ∞`` (converges). ``n < 1``: ``c → ∞`` (diverges)."""
@@ -625,6 +645,8 @@ class LangmuirSorption(NonlinearSorption):
 
         self.a_coeff: float = self.bulk_density * self.s_max * self.k_l / self.porosity
         """Lumped retardation constant rho_b * s_max * K_L / n_por."""
+        self._ct_coefficient: float = (self.bulk_density / self.porosity) * self.s_max
+        """Cached ``(rho_b/n_por)*s_max`` sorbed-mass coefficient (scalar + array paths)."""
 
     def retardation(self, c: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """
@@ -651,11 +673,12 @@ class LangmuirSorption(NonlinearSorption):
         - R decreases with increasing C (higher C travels faster)
         - R → 1 as C → ∞ (all sorption sites saturated)
         """
-        is_array = isinstance(c, np.ndarray)
-        c_arr = np.asarray(c)
-        c_eff = np.maximum(c_arr, 0.0)
-        result = 1.0 + self.a_coeff / (self.k_l + c_eff) ** 2
-        return result if is_array else float(result)
+        if not isinstance(c, np.ndarray):
+            cf = float(c)
+            c_eff = max(0.0, cf)
+            return 1.0 + self.a_coeff / (self.k_l + c_eff) ** 2
+        c_eff = np.maximum(np.asarray(c), 0.0)
+        return 1.0 + self.a_coeff / (self.k_l + c_eff) ** 2
 
     def total_concentration(self, c: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """
@@ -674,12 +697,13 @@ class LangmuirSorption(NonlinearSorption):
         c_total : float or numpy.ndarray
             Total concentration [mass/volume]. Always >= c.
         """
-        is_array = isinstance(c, np.ndarray)
+        if not isinstance(c, np.ndarray):
+            cf = float(c)
+            c_eff = max(0.0, cf)
+            return cf + self._ct_coefficient * c_eff / (self.k_l + c_eff)
         c_arr = np.asarray(c)
         c_eff = np.maximum(c_arr, 0.0)
-        sorbed = (self.bulk_density / self.porosity) * self.s_max * c_eff / (self.k_l + c_eff)
-        result = c_arr + sorbed
-        return result if is_array else float(result)
+        return c_arr + self._ct_coefficient * c_eff / (self.k_l + c_eff)
 
     def concentration_from_retardation(self, r: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """
@@ -713,17 +737,18 @@ class LangmuirSorption(NonlinearSorption):
         >>> bool(np.isclose(c, 5.0, rtol=1e-14))
         True
         """
-        is_array = isinstance(r, np.ndarray)
-        r_arr = np.asarray(r)
+        if not isinstance(r, np.ndarray):
+            r_minus_1 = float(r) - 1.0
+            if r_minus_1 > 0.0:
+                return max(math.sqrt(self.a_coeff / r_minus_1) - self.k_l, 0.0)
+            return 0.0
 
-        r_minus_1 = r_arr - 1.0
+        r_minus_1 = np.asarray(r) - 1.0
         # Mask r_minus_1 to a safe placeholder before division to avoid the
         # RuntimeWarning emitted by np.where's eager evaluation when r == 1.
         safe_r_minus_1 = np.where(r_minus_1 > 0, r_minus_1, 1.0)
         c = np.where(r_minus_1 > 0, np.sqrt(self.a_coeff / safe_r_minus_1) - self.k_l, 0.0)
-        result = np.maximum(c, 0.0)
-
-        return result if is_array else float(result)
+        return np.maximum(c, 0.0)
 
 
 @dataclass
@@ -807,6 +832,14 @@ class BrooksCoreyConductivity(NonlinearSorption):
     """Exponent ``a = 3 + 2/λ`` (Burdine); set in ``__post_init__``."""
     delta_theta: float = field(init=False)
     """``θ_s − θ_r``; set in ``__post_init__``."""
+    _inv_a: float = field(init=False, repr=False, compare=False)
+    """Cached ``1/a`` total-concentration exponent (scalar + array paths)."""
+    _ret_coefficient: float = field(init=False, repr=False, compare=False)
+    """Cached ``Δθ/(a·K_s)`` retardation coefficient."""
+    _ret_exponent: float = field(init=False, repr=False, compare=False)
+    """Cached ``1/a − 1`` retardation exponent."""
+    _cfr_exponent: float = field(init=False, repr=False, compare=False)
+    """Cached ``−a/(a−1)`` inversion exponent for concentration_from_retardation."""
 
     def __post_init__(self) -> None:
         """Validate parameters and derive ``a``, ``delta_theta``.
@@ -830,31 +863,40 @@ class BrooksCoreyConductivity(NonlinearSorption):
             raise ValueError(msg)
         self.a = 3.0 + 2.0 / self.brooks_corey_lambda
         self.delta_theta = self.theta_s - self.theta_r
+        self._inv_a = 1.0 / self.a
+        self._ret_coefficient = self.delta_theta / (self.a * self.k_s)
+        self._ret_exponent = 1.0 / self.a - 1.0
+        self._cfr_exponent = -self.a / (self.a - 1.0)
 
     def total_concentration(self, c: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """``C_T(C) = Δθ · (C/K_s)^(1/a)``. Returns 0 at C=0 (no clamp)."""
-        is_array = isinstance(c, np.ndarray)
+        if not isinstance(c, np.ndarray):
+            cf = float(c)
+            c_eff = max(0.0, cf)
+            return self.delta_theta * (c_eff / self.k_s) ** self._inv_a
         c_arr = np.maximum(np.asarray(c, dtype=float), 0.0)
-        result = self.delta_theta * (c_arr / self.k_s) ** (1.0 / self.a)
-        return result if is_array else float(result)
+        return self.delta_theta * (c_arr / self.k_s) ** self._inv_a
 
     def retardation(self, c: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """``R(C) = (Δθ / (a·K_s)) · (C/K_s)^(1/a − 1)``. Clamped at ``_C_MIN``."""
-        is_array = isinstance(c, np.ndarray)
+        if not isinstance(c, np.ndarray):
+            cf = float(c)
+            c_eff = max(_C_MIN, cf)
+            return self._ret_coefficient * (c_eff / self.k_s) ** self._ret_exponent
         c_eff = np.maximum(np.asarray(c, dtype=float), _C_MIN)
-        result = (self.delta_theta / (self.a * self.k_s)) * (c_eff / self.k_s) ** (1.0 / self.a - 1.0)
-        return result if is_array else float(result)
+        return self._ret_coefficient * (c_eff / self.k_s) ** self._ret_exponent
 
     def concentration_from_retardation(self, r: float | npt.NDArray[np.float64]) -> float | npt.NDArray[np.float64]:
         """``C = K_s · (R · a · K_s / Δθ)^{−a/(a−1)}``. Result clamped at ``_C_MIN``."""
-        is_array = isinstance(r, np.ndarray)
-        r_arr = np.asarray(r, dtype=float)
-        base = r_arr * self.a * self.k_s / self.delta_theta
+        if not isinstance(r, np.ndarray):
+            base = float(r) * self.a * self.k_s / self.delta_theta
+            if base > 0.0:
+                return max(self.k_s * base**self._cfr_exponent, _C_MIN)
+            return _C_MIN
+        base = np.asarray(r, dtype=float) * self.a * self.k_s / self.delta_theta
         safe_base = np.where(base > 0, base, 1.0)
-        ratio = safe_base ** (-self.a / (self.a - 1.0))
-        c = self.k_s * ratio
-        result = np.where(base > 0, np.maximum(c, _C_MIN), _C_MIN)
-        return result if is_array else float(result)
+        ratio = safe_base**self._cfr_exponent
+        return np.where(base > 0, np.maximum(self.k_s * ratio, _C_MIN), _C_MIN)
 
 
 @dataclass

--- a/tests/src/test_front_tracking_events.py
+++ b/tests/src/test_front_tracking_events.py
@@ -19,7 +19,12 @@ from gwtransport.fronttracking.events import (
     find_shock_characteristic_intersection,
     find_shock_shock_intersection,
 )
-from gwtransport.fronttracking.math import ConstantRetardation, FreundlichSorption, characteristic_position
+from gwtransport.fronttracking.math import (
+    ConstantRetardation,
+    FreundlichSorption,
+    characteristic_position,
+    characteristic_speed,
+)
 from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
 
 freundlich_sorptions = [
@@ -733,3 +738,176 @@ class TestMachinePrecision:
 
             assert np.isclose(v1, v2, rtol=1e-14, atol=1e-15)
             assert np.isclose(v1, v_int, rtol=1e-14, atol=1e-15)
+
+
+def _ref_char_char(c1, c2, tc) -> tuple[float, float] | None:
+    """Pre-refactor ``find_characteristic_intersection`` body (independent reference)."""
+    s1 = characteristic_speed(c1.concentration, c1.sorption)
+    s2 = characteristic_speed(c2.concentration, c2.sorption)
+    if abs(s1 - s2) < 1e-15:
+        return None
+    tb = max(c1.theta_start, c2.theta_start, tc)
+    v1 = characteristic_position(c1.concentration, c1.sorption, c1.theta_start, c1.v_start, tb)
+    v2 = characteristic_position(c2.concentration, c2.sorption, c2.theta_start, c2.v_start, tb)
+    if v1 is None or v2 is None:
+        return None
+    dt = (v2 - v1) / (s1 - s2)
+    return None if dt <= 0 else (float(tb + dt), float(v1 + s1 * dt))
+
+
+def _ref_shock_shock(a, b, tc) -> tuple[float, float] | None:
+    """Pre-refactor ``find_shock_shock_intersection`` body."""
+    if abs(a.speed - b.speed) < 1e-15:
+        return None
+    tb = max(a.theta_start, b.theta_start, tc)
+    v1 = a.v_start + a.speed * (tb - a.theta_start)
+    v2 = b.v_start + b.speed * (tb - b.theta_start)
+    dt = (v2 - v1) / (a.speed - b.speed)
+    return None if dt <= 0 else (float(tb + dt), float(v1 + a.speed * dt))
+
+
+def _ref_shock_char(sh, ch, tc) -> tuple[float, float] | None:
+    """Pre-refactor ``find_shock_characteristic_intersection`` body (a=shock)."""
+    sc = characteristic_speed(ch.concentration, ch.sorption)
+    if abs(sh.speed - sc) < 1e-15:
+        return None
+    tb = max(sh.theta_start, ch.theta_start, tc)
+    vs = sh.v_start + sh.speed * (tb - sh.theta_start)
+    vc = characteristic_position(ch.concentration, ch.sorption, ch.theta_start, ch.v_start, tb)
+    if vc is None:
+        return None
+    dt = (vc - vs) / (sh.speed - sc)
+    return None if dt <= 0 else (float(tb + dt), float(vs + sh.speed * dt))
+
+
+def _ref_raref_bounds(raref, other, tc) -> list[tuple[float, float, str]]:
+    """Pre-refactor ``find_rarefaction_boundary_intersections`` body (temp CharacteristicWaves)."""
+    out: list[tuple[float, float, str]] = []
+    head = CharacteristicWave(
+        theta_start=raref.theta_start, v_start=raref.v_start, concentration=raref.c_head, sorption=raref.sorption
+    )
+    tail = CharacteristicWave(
+        theta_start=raref.theta_start, v_start=raref.v_start, concentration=raref.c_tail, sorption=raref.sorption
+    )
+    if isinstance(other, CharacteristicWave):
+        for bc, tag in ((head, "head"), (tail, "tail")):
+            r = _ref_char_char(bc, other, tc)
+            if r:
+                out.append((r[0], r[1], tag))
+    elif isinstance(other, ShockWave):
+        for bc, tag in ((head, "head"), (tail, "tail")):
+            r = _ref_shock_char(other, bc, tc)
+            if r:
+                out.append((r[0], r[1], tag))
+    elif isinstance(other, RarefactionWave):
+        o_head = CharacteristicWave(
+            theta_start=other.theta_start, v_start=other.v_start, concentration=other.c_head, sorption=other.sorption
+        )
+        o_tail = CharacteristicWave(
+            theta_start=other.theta_start, v_start=other.v_start, concentration=other.c_tail, sorption=other.sorption
+        )
+        for bc, tag in ((head, "head"), (tail, "tail")):
+            for ob in (o_head, o_tail):
+                r = _ref_char_char(bc, ob, tc)
+                if r:
+                    out.append((r[0], r[1], tag))
+    return out
+
+
+class TestLineIntersectionKernelEquivalence:
+    """The ``_line_intersection`` refactor is bit-identical to the pre-refactor helper bodies.
+
+    Each closed-form intersection helper now delegates to one shared kernel using the waves'
+    CACHED speeds. The refactor is only equivalence-preserving if the per-branch operand order
+    is exact: ``dθ`` is invariant under an a↔b swap but ``V_intersect`` (the successor wave's
+    ``v_start``) is NOT — the raref-vs-shock branch in particular must keep ``a = shock``. This
+    checks BOTH returned components bit-for-bit against an independent transcription of the
+    original bodies over a randomised battery of all four pair kinds and both isotherm regimes.
+    """
+
+    @staticmethod
+    def _both_bit_equal(got, want):
+        if (got is None) != (want is None):
+            return False
+        if got is None:
+            return True
+        return got[0].hex() == want[0].hex() and got[1].hex() == want[1].hex()
+
+    def _make_raref(self, rng, sorption):
+        for _ in range(20):
+            a, b = float(rng.uniform(0.5, 20.0)), float(rng.uniform(0.5, 20.0))
+            for c_head, c_tail in ((max(a, b), min(a, b)), (min(a, b), max(a, b))):
+                try:
+                    return RarefactionWave(
+                        theta_start=float(rng.uniform(0, 50)),
+                        v_start=float(rng.uniform(0, 50)),
+                        c_head=c_head,
+                        c_tail=c_tail,
+                        sorption=sorption,
+                    )
+                except ValueError:
+                    continue
+        return None
+
+    def test_parallel_speeds_return_none_in_kernel_and_reference(self):
+        """The kernel's ``|s_a - s_b| < EPSILON_SPEED`` early-return agrees with the reference.
+
+        Randomised concentrations never collide exactly, so the degenerate branch needs an
+        explicit equal-speed configuration to be exercised inside the equivalence battery.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        c1 = CharacteristicWave(theta_start=0.0, v_start=0.0, concentration=7.0, sorption=sorption)
+        c2 = CharacteristicWave(theta_start=3.0, v_start=11.0, concentration=7.0, sorption=sorption)
+        assert find_characteristic_intersection(c1, c2, 0.0) is None
+        assert _ref_char_char(c1, c2, 0.0) is None
+
+        s1 = ShockWave(theta_start=0.0, v_start=0.0, c_left=8.0, c_right=2.0, sorption=sorption)
+        s2 = ShockWave(theta_start=1.0, v_start=9.0, c_left=8.0, c_right=2.0, sorption=sorption)
+        assert find_shock_shock_intersection(s1, s2, 0.0) is None
+        assert _ref_shock_shock(s1, s2, 0.0) is None
+
+    @pytest.mark.parametrize("n", [2.0, 0.6])
+    def test_all_four_helpers_bit_identical_to_reference(self, n):
+        rng = np.random.default_rng(20260715)
+        sorption = FreundlichSorption(k_f=0.01, n=n, bulk_density=1500.0, porosity=0.3)
+
+        def mk_char():
+            return CharacteristicWave(
+                theta_start=float(rng.uniform(0, 50)),
+                v_start=float(rng.uniform(0, 50)),
+                concentration=float(rng.uniform(0.5, 20.0)),
+                sorption=sorption,
+            )
+
+        def mk_shock():
+            return ShockWave(
+                theta_start=float(rng.uniform(0, 50)),
+                v_start=float(rng.uniform(0, 50)),
+                c_left=float(rng.uniform(0.5, 20.0)),
+                c_right=float(rng.uniform(0.5, 20.0)),
+                sorption=sorption,
+            )
+
+        for _ in range(3000):
+            tc = float(rng.uniform(0, 50))
+            c1, c2 = mk_char(), mk_char()
+            assert self._both_bit_equal(find_characteristic_intersection(c1, c2, tc), _ref_char_char(c1, c2, tc))
+            s1, s2 = mk_shock(), mk_shock()
+            assert self._both_bit_equal(find_shock_shock_intersection(s1, s2, tc), _ref_shock_shock(s1, s2, tc))
+            sh, ch = mk_shock(), mk_char()
+            assert self._both_bit_equal(find_shock_characteristic_intersection(sh, ch, tc), _ref_shock_char(sh, ch, tc))
+            raref = self._make_raref(rng, sorption)
+            if raref is None:
+                continue
+            for other in (mk_char(), mk_shock(), self._make_raref(rng, sorption)):
+                if other is None:
+                    continue
+                got = find_rarefaction_boundary_intersections(raref, other, tc)
+                want = _ref_raref_bounds(raref, other, tc)
+                assert len(got) == len(want)
+                for g, w in zip(got, want, strict=True):
+                    # float() is identity here; it narrows the float-annotated element off the
+                    # int|float numeric-tower union so .hex() resolves.
+                    assert float(g[0]).hex() == float(w[0]).hex()  # θ bit-for-bit
+                    assert float(g[1]).hex() == float(w[1]).hex()  # V bit-for-bit
+                    assert g[2] == w[2]  # boundary tag

--- a/tests/src/test_front_tracking_math.py
+++ b/tests/src/test_front_tracking_math.py
@@ -991,3 +991,96 @@ class TestFluxCurvatureNoCompoundWaves:
         # brentq-inversion edge at saturation.
         lam = self._lambda_ordered_by_u(s, np.linspace(0.01, 0.6 * s.k_s, 400))
         assert np.all(np.diff(lam) > 0.0), f"vG-Mualem n_vG={n_vg}: λ not strictly increasing in U"
+
+
+_SCALAR_PATH_SORPTIONS = {
+    "freundlich_n2": FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3),
+    "freundlich_n05": FreundlichSorption(k_f=0.02, n=0.6, bulk_density=1400.0, porosity=0.35),
+    "freundlich_n3": FreundlichSorption(k_f=0.005, n=3.0, bulk_density=1600.0, porosity=0.28),
+    "freundlich_n2_cmin0": FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3, c_min=0.0),
+    "langmuir": LangmuirSorption(s_max=0.1, k_l=5.0, bulk_density=1500.0, porosity=0.3),
+    "brookscorey": BrooksCoreyConductivity(theta_r=0.01, theta_s=0.337, k_s=0.174, brooks_corey_lambda=0.25),
+}
+# Dense c/r grids plus the edges that select each branch: 0, sub-c_min, negative, the r<=1
+# / saturated corners, and (for freundlich_n2_cmin0) the c<=0 fall-through that must return inf.
+_SCALAR_PATH_C_GRID = np.concatenate([
+    np.linspace(1e-6, 30.0, 800),
+    np.logspace(-9.0, 1.4, 200),
+    np.array([0.0, -1.0, -1e-9, 1e-15, 1e-12, 1e-9]),
+])
+_SCALAR_PATH_R_GRID = np.concatenate([
+    np.linspace(1.0 + 1e-12, 60.0, 800),
+    1.0 + np.logspace(-9.0, 1.5, 200),
+    np.array([1.0, 0.9999, 0.5, 1.0000001, 1e6]),
+])
+
+
+class TestIsothermScalarFastPath:
+    """The pure-float scalar fast path is bit-identical to the array route it short-circuits.
+
+    ``retardation``/``total_concentration``/``concentration_from_retardation`` carry a
+    scalar branch (avoiding the numpy dispatch that dominated the front-tracking solver's
+    per-event cost). It MUST stay bit-for-bit equal to the value a scalar previously got by
+    routing through the array code — reproduced here as ``float(method(np.asarray(x)))``, the
+    0-d-array route the pre-optimisation scalar call took. (numpy's *1-D* ``x**2`` = ``x*x``
+    can differ from the scalar ``pow`` by 1 ULP, but that 0-d-vs-1-D quirk predates the fast
+    path and is not what the solver's scalar calls exercise — so we pin against the 0-d route.)
+    """
+
+    @pytest.mark.parametrize("name", list(_SCALAR_PATH_SORPTIONS))
+    @pytest.mark.parametrize("method", ["retardation", "total_concentration", "concentration_from_retardation"])
+    def test_scalar_matches_array_route_bit_for_bit(self, name, method):
+        sorption = _SCALAR_PATH_SORPTIONS[name]
+        grid = _SCALAR_PATH_R_GRID if method == "concentration_from_retardation" else _SCALAR_PATH_C_GRID
+        fn = getattr(sorption, method)
+        for x in grid:
+            xf = float(x)
+            scalar = float(fn(xf))
+            array_route = float(fn(np.asarray(xf)))  # 0-d array == the pre-fast-path scalar route
+            # Bit-for-bit, incl. inf==inf at the c_min=0 dry-soil corner (both raise divide-by-zero → inf).
+            assert scalar.hex() == array_route.hex(), (
+                f"{name}.{method}({xf!r}): scalar {scalar!r} != array-route {array_route!r}"
+            )
+
+    def test_values_pinned_to_hand_derived_literals(self):
+        """Absolute value pins, derived by hand from the constructor parameters.
+
+        The scalar-vs-array-route check above cannot see a mistyped ``__post_init__`` constant:
+        both branches read the SAME cached value, so a wrong one moves them together. The
+        round-trip tests (``R -> c -> R``) are likewise invariant to a coefficient error. These
+        literals are re-derived from the raw parameters, so they fail on a bad cache and also
+        anchor the array path (which the scalar path is pinned against).
+        """
+        # Freundlich k_f=0.01, n=2, rho_b=1500, n_por=0.3 -> coeff=(1500*0.01)/(0.3*2)=25, exp=1/2-1=-1/2
+        fr = _SCALAR_PATH_SORPTIONS["freundlich_n2"]
+        assert fr.retardation(5.0) == 12.180339887498949  # 1 + 25/sqrt(5)
+        assert fr.total_concentration(5.0) == 116.80339887498948  # 5 + (1500/0.3)*0.01*sqrt(5)
+        assert fr.concentration_from_retardation(3.0) == 156.25  # ((3-1)/25)**-2
+
+        # Langmuir s_max=0.1, K_L=5, rho_b=1500, n_por=0.3 -> A = 1500*0.1*5/0.3 = 2500
+        lg = _SCALAR_PATH_SORPTIONS["langmuir"]
+        assert lg.retardation(5.0) == 26.0  # 1 + 2500/(5+5)**2
+        assert lg.total_concentration(5.0) == 255.0  # 5 + (1500/0.3)*0.1*5/(5+5)
+        assert lg.concentration_from_retardation(5.0) == 20.0  # sqrt(2500/4) - 5
+
+        # Brooks-Corey theta_r=0.01, theta_s=0.337, K_s=0.174, lambda=0.25 -> a=3+2/0.25=11, dtheta=0.327
+        bc = _SCALAR_PATH_SORPTIONS["brookscorey"]
+        assert bc.retardation(0.05) == 0.5308240442093716  # (dtheta/(a*K_s))*(c/K_s)**(1/a-1)
+        assert bc.total_concentration(0.05) == 0.2919532243151544  # dtheta*(c/K_s)**(1/a)
+        assert bc.concentration_from_retardation(2.0) == 0.01162204771675795  # K_s*(R*a*K_s/dtheta)**(-a/(a-1))
+
+    def test_scalar_returns_python_float(self):
+        """Scalar inputs (incl. numpy scalars) return a builtin ``float``, matching the array-else branch."""
+        s = _SCALAR_PATH_SORPTIONS["langmuir"]
+        for x in (5.0, np.float64(5.0), 0, np.int64(3)):
+            assert type(s.retardation(x)) is float
+            assert type(s.total_concentration(x)) is float
+        assert type(s.concentration_from_retardation(2.0)) is float
+        assert type(s.concentration_from_retardation(np.float64(2.0))) is float
+
+    def test_freundlich_cmin0_dry_soil_returns_inf(self):
+        """The ``c_min=0`` + ``n>1`` + ``c<=0`` corner returns ``inf`` (not a ZeroDivisionError)."""
+        s = _SCALAR_PATH_SORPTIONS["freundlich_n2_cmin0"]
+        assert s.retardation(0.0) == float("inf")
+        assert s.retardation(-1.0) == float("inf")
+        assert characteristic_speed(0.0, s) == 0.0  # 1/inf


### PR DESCRIPTION
## Summary

Performance-only refactor of the front-tracking event-driven solver. Two **bit-identical** optimisations targeting the isotherm/speed scalar machinery that dominates per-event cost (the module is event-driven, so this cost is paid O(events x active-waves^2) times):

- **One cached-speed intersection kernel** (`events.py`). The four closed-form intersection helpers now delegate to a single `_line_intersection` kernel fed each wave's **cached** speed, instead of recomputing `characteristic_speed` through numpy on every pair check; `find_rarefaction_boundary_intersections` no longer allocates throwaway `CharacteristicWave` objects (3.35M allocations on the profiled case). Bit-identical: the cached speed *is* the same `characteristic_speed(c, sorption)` set once in `__post_init__`, and each wrapper preserves its exact per-branch operand order — the raref-vs-shock branch keeps `a=shock`, since `dtheta` is invariant under an a/b swap but `V_intersect` (the successor wave's `v_start`) is **not**.
- **Scalar isotherm fast paths** (`math.py`). Freundlich/Langmuir/Brooks-Corey `retardation`/`total_concentration`/`concentration_from_retardation` gain a pure-float scalar branch that skips the `np.asarray`/`np.maximum` dispatch (~775 ns -> ~90 ns per call). Per-method constants are cached in `__post_init__` and referenced by **both** branches (one formula, no duplicated closed form). Bit-identical to the pre-fix **scalar** behaviour (the 0-d-array route the solver used); the array path is unchanged. van Genuchten is untouched (it already loops scalar-wise via brentq).

### Impact

| case | before | after |
|---|---|---|
| Brooks-Corey percolation, daily `k_scaling`, 180 d | 19.7 s | **4.2 s (4.7x)** |
| staircase n=200 (pure-shock cascade) | 0.53 s | 0.53 s (unchanged) |

Pure-shock cascades are unchanged because their cost is the O(A^2) per-event candidate rebuild, not the isotherm calls.

### Not done here

- **Heap event queue** (the O(A^2) rebuild) is deferred. Its original design relied on the invariant that decaying shocks never enter pairwise collision loops — exactly what #294/#316's face-based multi-front system (`interactions.py`) changed. A correct heap must be co-designed with the merged `find_next_event` (transient faces, iterative `find_face_crossing`, boundary-consumption lifecycle), so it belongs in its own PR.
- **Not ported to Rust.** A compiled extension would break the `py3-none-any` wheel and the Pyodide/JupyterLite interactive docs, and would freeze a design while the multi-front engine is still settling — while leaving the O(A^2) scaling in place anyway.

## Test plan

- `pytest tests/src -k "front or percolation or advection or verify_physics or freundlich or diffusion"` -> **1128 passed**, 2 skipped, 1 xfailed. Includes the bit-exact flow-independence probe and the independent conservation oracles (FT-C1 / FT-M1).
- New guard tests, both bit-for-bit:
  - `TestIsothermScalarFastPath` - scalar path == the 0-d-array route over a dense grid incl. every branch edge (0, sub-`c_min`, negative c, r<=1, saturated) and the `c_min=0` / `n>1` dry-soil corner that must return `inf` rather than raise; plus **hand-derived value literals** that pin the cached constants independently (a wrong cache moves both branches together, so the consistency check alone cannot see it — verified by mutation).
  - `TestLineIntersectionKernelEquivalence` - all four helpers vs an independent transcription of the pre-refactor bodies, asserting **both** theta and V, over 3000 randomised configs x both isotherm regimes, plus the degenerate parallel-speed branch.
- Equivalence verified out-of-band during review: 72,000 randomised intersection comparisons and 337,148 scalar isotherm checks, worst ULP gap **0**; array path confirmed unchanged.
- `ruff format` + `ruff check` clean; `ty check` clean.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.