### PR TITLE
Derive package version from git tags via hatch-vcs

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,3 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 .githooks/pre-commit text eol=lf
 *.sh text eol=lf
+.git_archival.txt export-subst

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -107,6 +107,7 @@ def function_name(*, flow: npt.ArrayLike, tedges: pd.DatetimeIndex) -> npt.NDArr
 
 ## Git
 
+- Do NOT include Claude-related signatures in commit messages or PR descriptions.
 - Base your PR message on the template at `.github/pull_request_template.md`.
 - Run formatting, linting, and type checking before committing.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -107,7 +107,6 @@ def function_name(*, flow: npt.ArrayLike, tedges: pd.DatetimeIndex) -> npt.NDArr
 
 ## Git
 
-- Do NOT include Claude-related signatures in commit messages or PR descriptions.
 - Base your PR message on the template at `.github/pull_request_template.md`.
 - Run formatting, linting, and type checking before committing.
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,6 +19,8 @@ jobs:
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
           sudo dpkg-reconfigure man-db
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # hatch-vcs needs the tag history to derive the version
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Set up Python
@@ -66,6 +68,8 @@ jobs:
           echo 'set man-db/auto-update false' | sudo debconf-communicate >/dev/null
           sudo dpkg-reconfigure man-db
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # hatch-vcs needs the tag history to derive the version
       - name: Install uv
         uses: astral-sh/setup-uv@v7
       - name: Install Pandoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           persist-credentials: false
+          fetch-depth: 0 # hatch-vcs needs the tag history to derive the version
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
@@ -25,7 +26,7 @@ jobs:
         run: uv run --with `find dist -name "*.whl"` --refresh-package gwtransport --no-project -- python -c "import importlib.metadata as m;print(m.version('gwtransport'))"
       - name: Install the built source tarball
         run: uv run --with `find dist -name "*.tar.gz"` --refresh-package gwtransport --no-project -- python -c "import importlib.metadata as m;print(m.version('gwtransport'))"
-      - name: Compare release tag with pyproject.toml version
+      - name: Compare release tag with package version
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/}
@@ -69,6 +70,7 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python distribution to TestPyPI
+    if: startsWith(github.ref, 'refs/tags/') # dev builds would otherwise pile up on TestPyPI on every push
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,6 @@
 """Configuration file for the Sphinx documentation builder."""  # noqa: INP001
 
+import importlib.metadata
 import json
 import sys
 import tomllib
@@ -37,7 +38,9 @@ project_info = pyproject_data["project"]
 project = project_info["name"]
 copyright = f"{date.today().year}, Bas des Tombe"  # noqa: A001, DTZ011
 author = ", ".join([author["name"] for author in project_info["authors"]])
-release = project_info["version"]
+# The version is dynamic (hatch-vcs derives it from git tags), so it no longer
+# appears in the [project] table; read it from the installed distribution instead.
+release = importlib.metadata.version("gwtransport")
 
 # -- General configuration ---------------------------------------------------
 extensions = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [build-system]
-requires = ["hatchling >= 1.26"]
+requires = ["hatchling >= 1.26", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "gwtransport"
+dynamic = ["version"]
 description = "Timeseries analysis for groundwater transport of solutes and heat"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -47,7 +48,6 @@ dependencies = [
   "requests>=2.19.0",
   "scipy>=1.13.0",
 ]
-version = "0.36.0"
 [project.optional-dependencies]
 test = [
   "nbconvert>=7.1.0",
@@ -98,6 +98,21 @@ docs = [
 Homepage = "https://github.com/gwtransport/gwtransport"
 Documentation = "https://gwtransport.github.io/gwtransport/"
 Sponsor = "https://www.savethechildren.net/what-we-do/emergencies/war-gaza-escalations-west-bank"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+# TestPyPI/PyPI reject local version identifiers (+gsha), and release.yml uploads
+# untagged builds to TestPyPI; without this every such upload would error instead
+# of versioning as 0.36.1.devN.
+local_scheme = "no-local-version"
+
+[tool.uv]
+# Overriding cache-keys replaces uv's default (pyproject.toml only), so list it
+# explicitly. The git key makes uv re-derive the hatch-vcs version when the commit
+# or tags change; otherwise editable installs keep serving a stale cached version.
+cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true } }]
 
 [tool.hatch.envs.hatch-static-analysis]
 config-path = "ruff.toml"


### PR DESCRIPTION
## Summary

Switch the package version from a static `version = "0.36.0"` in `pyproject.toml` to git-tag-derived versioning via hatch-vcs (setuptools-scm). Every commit then builds with a unique, strictly increasing version, so installs from git pick up new commits without manual version-bump commits.

- Anchored on the existing `0.36.0` tag — tagged commits build exactly as their tag, untagged commits as `0.36.1.devN`; no downgrade below the current release.
- `local_scheme = "no-local-version"` so untagged builds carry no `+g<sha>` local segment (TestPyPI/PyPI reject local version identifiers).
- Tag-gate the `publish-to-testpypi` job. It previously ran on every push/PR but always no-op'd via `skip-existing` (re-uploading the same `0.36.0`); without the gate, dev builds would now stream to TestPyPI on every push.
- `docs/source/conf.py` read the version from the `[project]` table, which no longer exists once the version is dynamic (would crash the docs build). It now reads `importlib.metadata.version("gwtransport")`; the JupyterLite wheel URL still matches the wheel built in the same job.
- `fetch-depth: 0` on the workflows that build the package (`release.yml`, both `docs.yml` build jobs). A shallow tagless checkout otherwise derives a `0.1.devN` fallback that would show publicly in the docs header and the JupyterLite wheel filename. The four test/lint workflows keep shallow checkouts (their installed version is cosmetic).
- `tool.uv` `cache-keys` (pyproject + git commit/tags) so editable installs re-derive the version per commit instead of serving cached metadata.
- `.git_archival.txt` + `.gitattributes` `export-subst` so GitHub "Download ZIP" source archives of tagged history remain buildable.

Release process is unchanged: cut a release by pushing an unprefixed `X.Y.Z` tag (the release workflow's tag filter is untouched); the "bump version" commit is simply no longer needed, and the tag↔version assertion still passes.

## Test plan

- `uv build --no-sources` on the branch → `gwtransport-0.36.1.dev18.tar.gz` + wheel, and built the wheel *from* that sdist (the release job's "Install the built source tarball" step) — proves the PKG-INFO version fallback works outside git.
- `pip install 'git+file://…@hatch-vcs-dynamic-versioning'` → `0.36.1.dev19`; `import gwtransport; gwtransport.__version__` → same value.
- Throwaway clone, tagged HEAD `0.37.0` → build reports exactly `0.37.0` (unprefixed lightweight tag honored).
- `git archive` of the branch → `.git_archival.txt` substituted to `describe-name: 0.36.0-19-g…`; pip-built the extracted archive with no `.git` → `0.36.1.dev19`.
- `uvx validate-pyproject pyproject.toml` → valid (same check the `linting` job runs); `ruff check docs/source/conf.py` → clean.
- Walked the `release.yml` event matrix: tag push still delivers to PyPI (`build` → `publish-to-testpypi` → `publish-to-pypi`); main pushes and PRs upload nothing.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
