### PR TITLE
fix(fronttracking): resolve doubly-fed side exhaustion via the universal merge (#317)

### DIFF
--- a/docs/theory/front_tracking_interactions.md
+++ b/docs/theory/front_tracking_interactions.md
@@ -199,23 +199,22 @@ merge — but these are compositions of the same three primitives, not new ones.
 Wave objects (`waves.py`) and events (`events.py`, `EventType` at `:67`) are
 _representations_ of the primitives above:
 
-| code object / event     | file:line                             | primitive realized                                          | reachable?                                |
-| ----------------------- | ------------------------------------- | ----------------------------------------------------------- | ----------------------------------------- |
-| `CharacteristicWave`    | `waves.py:256`                        | contact / constant-state characteristic                     | yes (smooth regions)                      |
-| `ShockWave`             | `waves.py:342`                        | shock                                                       | yes                                       |
-| `RarefactionWave`       | `waves.py:440`                        | rarefaction fan                                             | yes                                       |
-| `DecayingShockWave`     | `waves.py:604`                        | shock adjacent to **one** fan                               | yes (shock↔fan)                           |
-| `DoubleFanShockWave`    | `waves.py:1079`                       | shock adjacent to **two** fans                              | yes (doubly-fed formation)                |
-| `CHAR_CHAR_COLLISION`   | handler `handlers.py:32`              | two contacts compress → shock (genesis)                     | yes                                       |
-| `SHOCK_SHOCK_COLLISION` | `handlers.py:95`                      | shock↔shock merge                                           | yes                                       |
-| `SHOCK_CHAR_COLLISION`  | `handlers.py:152`                     | contact into shock (may emit a fan)                         | yes                                       |
-| `RAREF_CHAR_COLLISION`  | `handlers.py:305`                     | contact absorbed at a fan boundary                          | yes                                       |
-| `SHOCK_RAREF_COLLISION` | `handlers.py:223`                     | shock→fan (tail) and fan→shock (head) → `DecayingShockWave` | yes                                       |
-| `WAVE_MERGE`            | `interactions.py:394` `resolve_merge` | universal merge (any DSW/DFSW face pair)                    | yes (transitively, multi-front)           |
-| `DSW_FAN_EXHAUSTED`     | `solver.py:594`                       | degradation: `DecayingShockWave` → plain `ShockWave`        | yes                                       |
-| `RAREF_RAREF_COLLISION` | **no-op** `solver.py:560`             | (impossible interaction)                                    | detected, correctly not resolved — see §4 |
-| `DFSW_SIDE_EXHAUSTED`   | `solver.py:630`                       | degradation: `DoubleFanShockWave` → DSW/ShockWave           | **reachability under audit (§4)**         |
-| `OUTLET_CROSSING`       | `handlers.py:354`                     | boundary bookkeeping                                        | yes                                       |
+| code object / event     | file:line                             | primitive realized                                                                           | reachable?                                |
+| ----------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `CharacteristicWave`    | `waves.py:256`                        | contact / constant-state characteristic                                                      | yes (smooth regions)                      |
+| `ShockWave`             | `waves.py:342`                        | shock                                                                                        | yes                                       |
+| `RarefactionWave`       | `waves.py:440`                        | rarefaction fan                                                                              | yes                                       |
+| `DecayingShockWave`     | `waves.py:604`                        | shock adjacent to **one** fan                                                                | yes (shock↔fan)                           |
+| `DoubleFanShockWave`    | `waves.py:1079`                       | shock adjacent to **two** fans                                                               | yes (doubly-fed formation)                |
+| `CHAR_CHAR_COLLISION`   | handler `handlers.py:32`              | two contacts compress → shock (genesis)                                                      | yes                                       |
+| `SHOCK_SHOCK_COLLISION` | `handlers.py:95`                      | shock↔shock merge                                                                            | yes                                       |
+| `SHOCK_CHAR_COLLISION`  | `handlers.py:152`                     | contact into shock (may emit a fan)                                                          | yes                                       |
+| `RAREF_CHAR_COLLISION`  | `handlers.py:305`                     | contact absorbed at a fan boundary                                                           | yes                                       |
+| `SHOCK_RAREF_COLLISION` | `handlers.py:223`                     | shock→fan (tail) and fan→shock (head) → `DecayingShockWave`                                  | yes                                       |
+| `WAVE_MERGE`            | `interactions.py:394` `resolve_merge` | universal merge (any DSW/DFSW face pair, incl. a DFSW's own boundary line — side exhaustion) | yes (transitively, multi-front)           |
+| `DSW_FAN_EXHAUSTED`     | `solver.py:594`                       | degradation: `DecayingShockWave` → plain `ShockWave`                                         | yes                                       |
+| `RAREF_RAREF_COLLISION` | **no-op** `solver.py:560`             | (impossible interaction)                                                                     | detected, correctly not resolved — see §4 |
+| `OUTLET_CROSSING`       | `handlers.py:354`                     | boundary bookkeeping                                                                         | yes                                       |
 
 The universal merge calculus (`interactions.py`): every wave exposes **faces** (`Face`,
 `:53`) separating a left/right **`Feeder`** (a constant state or a bounded self-similar fan,
@@ -252,35 +251,49 @@ forms. The solver's shock/rarefaction repertoire is complete.
 _Action:_ no compound-wave handling and no "detect-and-reject non-convex flux" scan are
 required. Document convexity; treat the vestigial vG-M 2-point guard per §2.2.
 
-### 4.3 Under audit (require constructed inputs or impossibility proofs)
+### 4.3 Doubly-fed side exhaustion — RESOLVED through the universal merge (issue #317)
 
-- **`DFSW_SIDE_EXHAUSTED`** (`solver.py:630`, `theta_at_side_exhaustion` `waves.py:1280`):
-  no test drives a doubly-fed shock whose fan side reaches its far bound within the horizon.
-  When both fan tails sit at the `R→∞` singular state (`c→0`, favorable), the shock reaches
-  the edge only as `θ→∞` (asymptotic — hence `None` observed). Determine whether a
-  **nonzero-background** multi-pulse (fan tail `c > 0`) produces finite-θ side exhaustion. If
-  yes → tested interaction; if provably asymptotic-only → delete the handler + non-existence
-  test.
+A `DoubleFanShockWave` side ends in finite θ **exactly** when the shock face crosses one of
+its own fan boundary lines. Lax entropy (`λ(c_L) ≥ σ ≥ λ(c_R)`) admits only two such
+crossings: the left fan's slow upstream-far characteristic catching the shock from behind
+(the `n<1` mirror, where the fan's far ray outruns the shock), or the shock catching the
+right fan's fast downstream-far characteristic. Both are the **same primitive** as every
+other face merge — a boundary line overtaking (or being overtaken by) a shock face — so they
+are resolved by the one universal `WAVE_MERGE` path: the merge builds the degraded successor
+from `(const far-bound feeder | surviving fan feeder)` and retires the exhausted boundary
+line. The face-pair loop admits the crossing of a DFSW's shock face with its **own** boundary
+line (`solver.py`); the loose born-coincident admission is disabled for same-wave pairs so a
+front born a small distance from its own boundary and diverging from it is not spuriously
+retired (exact coincidence still fires).
+
+This replaces the earlier dedicated `DFSW_SIDE_EXHAUSTED` detector
+(`theta_at_side_exhaustion` and its handler), which was **incomplete**: it targeted the fan
+edge _farther_ from the current side value (wrong whenever the wave is born mid-fan) and its
+residual was flattened to exactly zero by the feeder's fan-extent clamp, so the bracket never
+fired. That left the exhausted fan's boundary line exposed _beyond_ the shock — a ghost face
+the sweep reader misattributed, breaking outlet-mass monotonicity: the loud decline below.
+Geometry-, not regime-dependent (favorable Langmuir hits the same missed crossing).
+
 - **DFSW × DFSW** and **characteristic × fan** (via `WAVE_MERGE`): structurally reachable
-  (the face-pair loop admits them, `solver.py:394`) but untested. Construct a producing
+  (the face-pair loop admits them) but not separately pinned. Construct a producing
   input or prove impossibility.
 
-These are resolved in the companion audit steps (branch work), not in this reference.
+### 4.4 Former multi-front gap — unfavorable (`n<1`) and some Langmuir (issue #317, RESOLVED)
 
-### 4.4 Known multi-front gap — unfavorable (`n<1`) and some Langmuir (issue #317)
+The audit found the multi-front solver **declined** (left an unresolved interaction → the
+public API raised `RuntimeError`, never a silently-wrong `cout`) for some multi-pulse inputs:
 
-The randomized property sweep (§4.5) found that the multi-front solver **declines** (leaves
-an unresolved interaction → the public API raises `RuntimeError`, never a silently-wrong
-`cout`) for some multi-pulse inputs it does not yet resolve:
-
-- **Freundlich `n<1`** (concave / mirror geometry): a simple two-pulse input suffices —
+- **Freundlich `n<1`** (concave / mirror geometry): a simple two-pulse input sufficed —
   minimal reproducer `cin=[0,8,8,8,0,0,2,2,0]`, `V=10.6`.
 - **Langmuir**: some specific multi-pulse configs.
 - **Freundlich `n>1`** (favorable): robustly supported (0 declines over broad sweeps).
 
-Hypothesis: the Feeder/Face merge calculus was validated on the favorable (`n>1`) geometry;
-the `n<1` mirror (step-ups are rarefactions, step-downs are shocks) mishandles the shock↔fan
-merge. Pinned by `TestKnownMultiFrontGaps` (`xfail(strict=True)`); tracked in **issue #317**.
+Root cause: the missed doubly-fed side exhaustion of §4.3, not a mishandled shock↔fan merge —
+the merge calculus and every DSW/DFSW trajectory are correct in the `n<1` mirror (verified to
+`<1e-6` relative against independent DOP853 integration). Resolved by routing side exhaustion
+through the universal merge (§4.3). Pinned by `TestSideExhaustion`: the `n<1` reproducer with
+the exhaustion at the closed-form `θ=778.75`, `V=5/28` plus an FV-oracle cross-check, the
+public-API end-to-end resolution, and the two formerly-declining favorable Langmuir configs.
 
 ---
 

--- a/src/gwtransport/fronttracking/events.py
+++ b/src/gwtransport/fronttracking/events.py
@@ -83,9 +83,8 @@ class EventType(Enum):
     """A decaying shock's fan is exhausted (c_decay reached c_fan_tail)."""
     WAVE_MERGE = "wave_merge"
     """Two faces overtake (universal merge): any interaction involving a decaying/doubly-fed
-    shock — fan-entry, doubly-fed formation, same-apex annihilation, and their compositions."""
-    DFSW_SIDE_EXHAUSTED = "double_fan_side_exhausted"
-    """A doubly-fed shock's fan side reaches its far bound (degrades to a decaying shock/shock)."""
+    shock — fan-entry, doubly-fed formation, same-apex annihilation, side exhaustion (a
+    doubly-fed shock crossing its own fan boundary line), and their compositions."""
     OUTLET_CROSSING = "outlet_crossing"
     """Wave crosses outlet boundary."""
 
@@ -117,7 +116,7 @@ class Event:
     waves_involved: list  # List[Wave] - can't type hint due to circular import
     location: float
     boundary_type: str | None = None
-    faces: tuple | None = None  # (Face, Face) for WAVE_MERGE; ('left'|'right',) side for DFSW_SIDE_EXHAUSTED
+    faces: tuple | None = None  # (Face, Face) for WAVE_MERGE
 
     def __repr__(self):  # noqa: D105
         return (

--- a/src/gwtransport/fronttracking/interactions.py
+++ b/src/gwtransport/fronttracking/interactions.py
@@ -242,8 +242,17 @@ def find_face_crossing(
     marched with a per-pair speed bound ``Λ = speed_bound_a + speed_bound_b`` so a step
     ``Δθ = max(|g|/Λ, floor)`` cannot straddle a sign change unseen; each step also brackets
     the gap's interior minimum to catch a grazing double-crossing.
+
+    The loose near-coincidence admission at birth is enabled only for cross-wave pairs (exact
+    coincidence is always reported). Same-wave exhaustion pairs — a wave's shock face against
+    its own fan boundary line — suppress it: a front born a small distance from its own
+    boundary line may be legitimately diverging, and the loose admission would fire a spurious
+    immediate exhaustion.
     """
     wave_a, wave_b = face_a.wave, face_b.wave
+    # Loose born-coincidence admission is a cross-wave notion (a newborn wave touching a
+    # different neighbour it must immediately merge with); a wave's own two faces suppress it.
+    allow_born_coincident = wave_a is not wave_b
     theta_start = max(theta_current, wave_a.theta_start, wave_b.theta_start)
     if theta_start >= theta_horizon:
         return None
@@ -272,7 +281,7 @@ def find_face_crossing(
     pa0 = face_a.position(theta_start)
     born_now = abs(wave_a.theta_start - theta_start) <= floor or abs(wave_b.theta_start - theta_start) <= floor
     coincidence_tol = 1e-3 * max(abs(pa0) if pa0 is not None else 0.0, 1.0)
-    if abs(g_prev) < EPSILON_POSITION or (born_now and abs(g_prev) < coincidence_tol):
+    if abs(g_prev) < EPSILON_POSITION or (allow_born_coincident and born_now and abs(g_prev) < coincidence_tol):
         return (theta, pa0) if pa0 is not None else None
 
     while theta < theta_horizon:

--- a/src/gwtransport/fronttracking/solver.py
+++ b/src/gwtransport/fronttracking/solver.py
@@ -50,7 +50,6 @@ from gwtransport.fronttracking.handlers import (
 from gwtransport.fronttracking.interactions import (
     find_face_crossing,
     iter_faces,
-    make_wave_from_feeders,
     resolve_merge,
 )
 from gwtransport.fronttracking.math import (
@@ -65,16 +64,12 @@ from gwtransport.fronttracking.waves import (
     CharacteristicWave,
     DecayingShockWave,
     DoubleFanShockWave,
-    Feeder,
     RarefactionWave,
     ShockWave,
     Wave,
 )
 
 logger = logging.getLogger(__name__)
-
-# Concentration tolerance for matching a doubly-fed side value to a fan edge at exhaustion.
-_SIDE_EXHAUSTION_C_TOL = 1e-9
 
 
 @dataclass
@@ -397,10 +392,24 @@ class FrontTracker:
             theta_horizon = self.state.theta_horizon
             for i, fa in enumerate(all_faces):
                 for fb in all_faces[i + 1 :]:
-                    if fa.wave is fb.wave:
-                        continue
                     if not (isinstance(fa.wave, special_types) or isinstance(fb.wave, special_types)):
                         continue
+                    same_wave = fa.wave is fb.wave
+                    if same_wave and not (
+                        isinstance(fa.wave, DoubleFanShockWave) and {fa.role, fb.role} == {"shock", "boundary"}
+                    ):
+                        # Same-wave crossings other than a doubly-fed shock meeting its own fan
+                        # boundary line never occur (a DSW's fan exhaustion has its own exact
+                        # detector; two boundary lines of one wave diverge).
+                        continue
+                    # A doubly-fed shock crossing its OWN fan boundary line is that side's
+                    # exhaustion: the fan between them is spent, and the universal merge
+                    # (const far-bound feeder | surviving fan feeder) degrades the wave to a
+                    # DecayingShockWave while retiring the boundary — uniformly with every
+                    # other face merge. Entropy (λ(c_L) ≥ σ ≥ λ(c_R)) makes these crossings
+                    # the only finite-θ side endings: the left fan's slow (upstream-far) char
+                    # can only catch the shock from behind, the shock can only catch the
+                    # right fan's downstream-far char — exactly the two exposed lines.
                     crossing = find_face_crossing(fa, fb, theta_current, theta_horizon)
                     if crossing is None:
                         continue
@@ -420,21 +429,6 @@ class FrontTracker:
                         continue
                     candidates.append((theta, counter, EventType.WAVE_MERGE, [fa.wave, fb.wave], v, None, (fa, fb)))
                     counter += 1
-
-        # Doubly-fed side exhaustion: a DFSW fan side reaching its far bound degrades the wave.
-        for wave in active_waves:
-            if isinstance(wave, DoubleFanShockWave):
-                exhaust = wave.theta_at_side_exhaustion()
-                if exhaust is None:
-                    continue
-                theta_ex, side = exhaust
-                if theta_ex <= theta_current + collision_tol or theta_ex > self.state.theta_horizon:
-                    continue
-                v_ex = wave.position_at_theta(theta_ex)
-                if v_ex is None or v_ex < -collision_tol:
-                    continue
-                candidates.append((theta_ex, counter, EventType.DFSW_SIDE_EXHAUSTED, [wave], v_ex, None, (side,)))
-                counter += 1
 
         # Fan-exhaustion: a DecayingShockWave is valid only while c_decay stays
         # above c_fan_tail. When c_decay reaches c_fan_tail the fan is spent and
@@ -567,12 +561,6 @@ class FrontTracker:
             face_a, face_b = event.faces
             new_waves = resolve_merge(face_a, face_b, event.theta, event.location, self.state.sorption)
 
-        elif event.event_type == EventType.DFSW_SIDE_EXHAUSTED:
-            assert event.faces is not None  # noqa: S101  # DFSW_SIDE_EXHAUSTED carries the ('left'|'right',) side
-            new_waves = self._handle_dfsw_side_exhaustion(
-                event.waves_involved[0], event.faces[0], event.theta, event.location
-            )
-
         elif event.event_type == EventType.DSW_FAN_EXHAUSTED:
             new_waves = self._handle_fan_exhaustion(event.waves_involved[0], event.theta, event.location)
 
@@ -626,30 +614,6 @@ class FrontTracker:
         if not shock.satisfies_entropy():
             return []
         return [shock]
-
-    def _handle_dfsw_side_exhaustion(
-        self, dfsw: DoubleFanShockWave, side: str, theta_event: float, v_event: float
-    ) -> list[Wave]:
-        """Degrade a doubly-fed shock whose ``side`` fan reached its far bound.
-
-        The exhausted side becomes a constant at that far bound, so the front continues as a
-        one-fan :class:`DecayingShockWave` (or a plain :class:`ShockWave` if the surviving
-        side is also at a constant). The successor is built from the same left/right feeder
-        pair with the exhausted side frozen to its far concentration.
-        """
-        left = dfsw.left_feeder
-        right = dfsw.right_feeder
-        if side == "left":
-            c_far = left.c_a if abs(left.c_a - left.value(v_event, theta_event)) < _SIDE_EXHAUSTION_C_TOL else left.c_b
-            left = Feeder.constant(c_far)
-        else:
-            c_far = (
-                right.c_a if abs(right.c_a - right.value(v_event, theta_event)) < _SIDE_EXHAUSTION_C_TOL else right.c_b
-            )
-            right = Feeder.constant(c_far)
-        dfsw.deactivate(theta_event)
-        successor = make_wave_from_feeders(left, right, v_event, theta_event, self.state.sorption)
-        return [successor] if successor is not None else []
 
     def run(self, max_iterations: int = 10000, *, verbose: bool = False):
         """Process events in θ-order until the queue is empty or ``max_iterations`` is reached."""

--- a/src/gwtransport/fronttracking/waves.py
+++ b/src/gwtransport/fronttracking/waves.py
@@ -17,7 +17,6 @@ See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from operator import itemgetter
 
 import numpy as np
 from scipy.interpolate import CubicSpline
@@ -1102,8 +1101,8 @@ class DoubleFanShockWave(Wave):
     form. **General fallback** (distinct apex positions, or a non-``n=2`` isotherm): the ODE
     is integrated once by fixed-step RK4 (``\Delta\theta = \text{fan age}/DFSW_RK_SUBSTEPS``,
     speed-independent since the fans vary on the scale of their age) into a cached monotone
-    spline. Both paths answer position, side concentrations, side exhaustion and outlet
-    crossing uniformly.
+    spline. Both paths answer position, side concentrations and outlet crossing uniformly
+    (side exhaustion is detected externally, as the shock face crossing its own fan boundary).
 
     See Also
     --------
@@ -1276,32 +1275,6 @@ class DoubleFanShockWave(Wave):
         if v_outlet <= self.v_start:
             return None
         return self._bracket_and_solve(lambda theta: self._v_at(theta) - v_outlet, r0=self.v_start - v_outlet)
-
-    def theta_at_side_exhaustion(self) -> tuple[float, str] | None:
-        """Earliest ``(θ, side)`` at which a side's fan value reaches its far bound.
-
-        A side exhausts when its concentration reaches the fan edge it is moving toward; the
-        solver then degrades the doubly-fed front to a :class:`DecayingShockWave` (or a plain
-        :class:`ShockWave` if both exhaust). Returns ``None`` when neither side exhausts in
-        finite θ (the shock asymptotes to the interior state).
-        """
-        candidates: list[tuple[float, str]] = []
-        for side, feeder in (("left", self.left_feeder), ("right", self.right_feeder)):
-            c_now = feeder.value(self.v_start, self.theta_start)
-            # The value moves monotonically toward one fan edge; target that edge.
-            target = feeder.c_a if abs(feeder.c_a - c_now) > abs(feeder.c_b - c_now) else feeder.c_b
-            r0 = c_now - target
-            if abs(r0) < EPSILON_POSITION:
-                continue
-            root = self._bracket_and_solve(
-                lambda theta, feeder=feeder, target=target: feeder.value(self._v_at(theta), theta) - target,
-                r0=r0,
-            )
-            if root is not None:
-                candidates.append((root, side))
-        if not candidates:
-            return None
-        return min(candidates, key=itemgetter(0))
 
     def concentration_at_point(self, v: float, theta: float) -> float | None:
         """Concentration at ``(v, θ)`` if controlled by this doubly-fed shock.

--- a/tests/src/test_front_tracking_interactions.py
+++ b/tests/src/test_front_tracking_interactions.py
@@ -113,8 +113,8 @@ class TestRarefactionRarefactionNoInteraction:
         For the unfavorable (concave) flux, step-*ups* spread into rarefactions and there is no
         leading loading shock, so a strictly increasing inlet produces N same-family
         rarefactions that must all remain active with no collision and no merge successor. (This
-        is a pure-rarefaction layout with no multi-front interaction, so it is unaffected by the
-        ``n<1`` interaction gap in :class:`TestKnownMultiFrontGaps`.)
+        is a pure-rarefaction layout with no multi-front interaction, distinct from the resolved
+        ``n<1`` shock↔fan side exhaustion in :class:`TestSideExhaustion`.)
         """
         s = FreundlichSorption(k_f=0.05, n=0.5, bulk_density=1500.0, porosity=0.3)
         cin = np.array([0.0] + [2.0] * 8 + [5.0] * 8 + [8.0] * 8 + [11.0] * 40)
@@ -170,9 +170,10 @@ class TestNoSilentCorruption:
 
     Whenever ``find_unresolved_interaction`` returns ``None`` (the solver claims a complete
     resolution), the outlet ``cout`` must be conservation-consistent, match the independent FV
-    oracle, and be non-negative. Inputs the solver cannot resolve are declined LOUDLY (the
-    public API raises ``RuntimeError``); those are covered by :class:`TestKnownMultiFrontGaps`,
-    not silently mis-computed here. Theory doc §4.5.
+    oracle, and be non-negative. Any input the solver still cannot resolve is declined LOUDLY
+    (the public API raises ``RuntimeError``) rather than silently mis-computed here; the
+    formerly-declining ``n<1``/Langmuir side-exhaustion inputs are now resolved and covered by
+    :class:`TestSideExhaustion`. Theory doc §4.
     """
 
     @pytest.mark.parametrize(("pulse", "v_pv"), _FAVORABLE_CONFIGS, ids=[f"V{c[1]:g}" for c in _FAVORABLE_CONFIGS])
@@ -254,53 +255,147 @@ class TestNoSilentCorruption:
         np.testing.assert_allclose(m_dom, m_quad, rtol=1e-4, atol=1e-9)
 
 
-class TestKnownMultiFrontGaps:
-    """Documented completeness gaps in the #294/#316 multi-front solver.
+class TestSideExhaustion:
+    """Regression guards for the resolved #317 multi-front gap: doubly-fed side exhaustion.
 
-    The universal merge calculus was validated on the favorable (Freundlich ``n>1``) geometry;
-    the unfavorable (``n<1``, concave-flux) mirror — where step-ups are rarefactions and
-    step-downs are shocks — leaves some two-pulse shock↔fan interactions unresolved. The public
-    API surfaces this LOUDLY (``find_unresolved_interaction`` fires → ``RuntimeError``), so no
-    silently-wrong ``cout`` is ever returned. These tests assert the DESIRED behaviour (a
-    complete resolution) and are ``xfail(strict=True)``: a solver fix flips them to XPASS,
-    which fails the suite and flags that they should be un-xfailed. See
+    A :class:`DoubleFanShockWave` side ends in finite θ exactly when its shock face crosses
+    one of its own fan boundary lines — the left fan's slow upstream characteristic catching
+    the shock from behind (the ``n<1`` mirror, where fan characteristics outrun the shock),
+    or the shock catching the right fan's downstream characteristic. Lax entropy
+    (``λ(c_L) ≥ σ ≥ λ(c_R)``) forbids any other finite-θ side ending. The solver resolves
+    these same-wave face crossings through the universal ``WAVE_MERGE`` machinery: the merge
+    of the boundary line with the shock face builds the degraded successor
+    (``const far-bound | surviving fan``) and retires the boundary.
+
+    Before the fix, a special-case detector missed these crossings (it targeted the fan edge
+    farther from the current side value — wrong whenever the wave is born mid-fan — and the
+    feeder clamp flattened its residual to exactly zero, defeating the bracket), so the
+    exhausted fan's boundary line stayed exposed BEYOND the shock: a ghost face the reader
+    sweep used to misattribute the region between shock and line, breaking outlet-mass
+    monotonicity — the loud decline of issue #317 (Freundlich ``n<1`` two-pulse and several
+    favorable Langmuir multi-pulse inputs). See
     ``docs/theory/front_tracking_interactions.md`` §4.3.
     """
 
-    @pytest.mark.slow  # the declined run churns to the loop guard (~15 s) before giving up
-    @pytest.mark.xfail(
-        strict=True,
-        raises=AssertionError,  # pin the ASSERTION failing, not e.g. a decline->crash regression
-        reason="#316 multi-front solver leaves an unresolved interaction for unfavorable "
-        "Freundlich n<1 two-pulse inputs (mirror-regime shock<->fan merge). Tracked in #317.",
-    )
+    @pytest.mark.slow  # a fine FV-oracle cross-check over θ_end=2900 (~6 s)
     def test_freundlich_nlt1_two_pulse_resolves(self):
+        """The #317 minimal reproducer resolves, with the exhaustion pinned to its closed form.
+
+        For Freundlich exponent 2 (``n=0.5``) the doubly-fed secant collapses to the harmonic
+        mean of the two shared-apex fan rays, ``σ = 2V/((θ−θ_L)+(θ−θ_R))``, which integrates
+        to the linear-fractional trajectory ``V = (θ − (θ_L+θ_R)/2)/2401`` through the birth
+        point ``(725.15625, 5/32)`` (``θ_L=600``, ``θ_R=100``; ``2401 = 375.15625/(5/32)``).
+        Crossing the left fan's ``c=2`` characteristic ``V = (θ−600)/1001`` (``R(2)=1001``)
+        gives the side exhaustion at exactly ``θ = 778.75``, ``V = 5/28``. The solver's
+        RK4-spline trajectory plus the face-march/brentq reproduce the anchor to a relative
+        error of ~1e-9 (θ) and ~4e-9 (V) — both deterministic; the asserted rtols sit ~10-20×
+        above those floors.
+        """
         s = FreundlichSorption(k_f=0.05, n=0.5, bulk_density=1500.0, porosity=0.3)
         cin = np.array([0.0, 8.0, 8.0, 8.0, 0.0, 0.0, 2.0, 2.0, 0.0] + [0.0] * 20)
         tr = _run(s, cin, 10.6)
         assert find_unresolved_interaction(tr.state) is None
 
-    @pytest.mark.slow  # the declined run churns to the loop guard (~15 s) before giving up
-    def test_public_api_declines_n_lt_1_loudly(self):
-        """The gap surfaces as a public-API ``RuntimeError`` — never a silently-wrong cout.
+        # The side-exhaustion event: a same-wave merge (the DFSW's own boundary line × shock).
+        self_merges = [
+            ev
+            for ev in tr.state.events
+            if ev["type"] == "wave_merge" and ev["waves_before"][0] is ev["waves_before"][1]
+        ]
+        assert len(self_merges) == 1
+        ev = self_merges[0]
+        np.testing.assert_allclose(ev["theta"], 778.75, rtol=1e-8)
+        np.testing.assert_allclose(ev["location"], 5.0 / 28.0, rtol=1e-7)
+        (successor,) = ev["waves_after"]
+        assert isinstance(successor, DecayingShockWave)
+        assert successor.c_fixed == 2.0  # the exhausted left side froze at the fan's far bound
+        assert successor.decay_side == "right"
+        dfsw = ev["waves_before"][0]
+        assert not dfsw.is_active
+        np.testing.assert_allclose(dfsw.theta_deactivation, ev["theta"], rtol=0, atol=0)
+        np.testing.assert_allclose(dfsw.theta_left_boundary_consumed, ev["theta"], rtol=0, atol=0)
 
-        Guards ``advection.infiltration_to_extraction_nonlinear_sorption``'s ``find_unresolved_interaction``
-        raise-wiring end-to-end (the increment's central "never silently wrong" contract), which the
-        internal-only checks above do not exercise. When #317 is fixed this must stop raising — update
-        it to assert a valid cout then.
+        # Independent numerical gate: the resolved outlet matches the first-order FV oracle
+        # (0.05 = the oracle's own smearing floor at n_cells=160, cf. the staircase test above).
+        assert _fv_discrepancy(tr, s, 10.6, n_cells=160, stride=8) < 0.05
+
+    def test_public_api_resolves_n_lt_1(self):
+        """The public API returns a physical ``cout`` for the former #317 decline input.
+
+        Guards ``advection.infiltration_to_extraction_nonlinear_sorption`` end-to-end on the
+        input that used to raise ``RuntimeError`` (the loud decline): the returned bin averages
+        must be finite, non-negative, and the implied stored mass must be correct.
+
+        The stored-mass check must NOT be the closed-system balance ``m_out + m_dom == m_in``:
+        the public ``cout`` is *defined* per bin as ``Δ(m_in − m_dom)/Δθ`` (see
+        ``compute_bin_averaged_concentration_exact``), so that balance collapses to
+        ``m_in == m_in`` and passes even with a badly wrong ``compute_domain_mass`` (a uniform
+        50% ``m_dom`` error still balances to the FP floor — mutation-confirmed). Instead validate
+        ``compute_domain_mass`` against a genuinely *independent* reference — a fine trapezoid of
+        ``C_T(c(v, θ_end))`` sampled over ``[0, V]`` (a different integration than the analytic
+        fan IBP), which then pins ``m_out = m_in − m_dom``. (The resolved outlet field itself is
+        FV-oracle-gated in ``test_freundlich_nlt1_two_pulse_resolves``.)
         """
         cin = np.array([0.0, 8.0, 8.0, 8.0, 0.0, 0.0, 2.0, 2.0, 0.0] + [0.0] * 20)
         nb = len(cin)
         tedges = pd.date_range("2020-01-01", periods=nb + 1, freq="D")
-        with pytest.raises(RuntimeError, match="unresolved"):
-            infiltration_to_extraction_nonlinear_sorption(
-                cin=cin,
-                flow=np.full(nb, 100.0),
-                tedges=tedges,
-                cout_tedges=tedges,
-                aquifer_pore_volumes=[10.6],
-                freundlich_k=0.05,
-                freundlich_n=0.5,
-                bulk_density=1500.0,
-                porosity=0.3,
-            )
+        cout, structures = infiltration_to_extraction_nonlinear_sorption(
+            cin=cin,
+            flow=np.full(nb, 100.0),
+            tedges=tedges,
+            cout_tedges=tedges,
+            aquifer_pore_volumes=[10.6],
+            freundlich_k=0.05,
+            freundlich_n=0.5,
+            bulk_density=1500.0,
+            porosity=0.3,
+        )
+        cout = np.asarray(cout, dtype=float).ravel()
+        # Out-of-window bins are returned as 0.0; genuinely zero-throughflow bins as NaN.
+        # This all-positive-flow run has neither, so every bin is finite and non-negative.
+        assert np.all(np.isfinite(cout))
+        assert np.all(cout >= -1e-9)
+        state, s = structures[0]["tracker_state"], structures[0]["sorption"]
+        theta_end = float(state.theta_edges[-1])
+        m_in = float(np.sum(cin * 100.0))
+        m_out = float(np.sum(cout * 100.0))
+        assert m_out > 0.0
+        # Independent stored-mass reference: trapezoid of C_T over [0, V] (samples the field via
+        # concentration_at_point, then integrates numerically) vs the analytic fan integral in
+        # compute_domain_mass. The two integrations agree and CONVERGE (rel 3.4e-4 → 7.3e-5 → 1.9e-5
+        # at n_v 4e3 → 2e4 → 1e5), so compute_domain_mass is the trapezoid's limit; rtol 1e-3 sits
+        # ~3× above the n_v=4000 discretization floor, yet is ~400× tighter than the ~40% gap a
+        # uniform compute_domain_mass error opens — so this is NOT the m_in−m_dom tautology
+        # (mutation-confirmed). This pins the public cout, since cout ≡ (m_in − m_dom)/Δθ.
+        m_domain = compute_domain_mass(theta_end, 10.6, state.waves, s)
+        v = np.linspace(0.0, 10.6, 4000)
+        c_field = np.array([concentration_at_point(vi, theta_end, state.waves, s) for vi in v])
+        m_domain_indep = float(np.trapezoid(np.asarray(s.total_concentration(c_field), dtype=float), v))
+        np.testing.assert_allclose(m_domain, m_domain_indep, rtol=1e-3)
+        np.testing.assert_allclose(m_out, m_in - m_domain, rtol=1e-9)
+
+    @pytest.mark.parametrize(
+        ("cin", "v_pv"),
+        [
+            # Both former decline configs (found by a seeded random sweep on the unfixed
+            # solver; each declined loudly there). The first exercises the born-mid-fan
+            # geometry (the wrong-target defect); the second is the clamp-flatline-only
+            # fingerprint (its detector targeted the correct edge and still never fired).
+            ([0.0, 9, 9, 0, 0, 2.6, 2.6, 0, 8.8, 0, 0, 8.3], 8.8),
+            ([0.0, 3.3, 0.5, 0.5, 8.3, 6.1, 6.1, 5, 5, 0.3, 0.3], 11.6),
+        ],
+        ids=["multi-pulse", "staircase"],
+    )
+    def test_langmuir_multipulse_resolves(self, cin, v_pv):
+        """Favorable Langmuir multi-pulse inputs that formerly declined now resolve.
+
+        Side exhaustion is geometry-dependent, not regime-dependent: these favorable-regime
+        configs hit the same missed self-crossing. Each run must resolve completely and must
+        actually exercise the same-wave merge path (at least one such event fires).
+        """
+        s = LangmuirSorption(s_max=0.1, k_l=5.0, bulk_density=1500.0, porosity=0.3)
+        tr = _run(s, np.array(cin + [0.0] * 15, dtype=float), v_pv)
+        assert find_unresolved_interaction(tr.state) is None
+        assert any(
+            ev["type"] == "wave_merge" and ev["waves_before"][0] is ev["waves_before"][1] for ev in tr.state.events
+        )


### PR DESCRIPTION
## Summary

Resolves #317: the multi-front front tracker declined (raised `RuntimeError` from
`find_unresolved_interaction`) on a class of multi-pulse inputs — unfavorable Freundlich
`n<1` two-pulse inlets and several favorable Langmuir multi-pulse configs.

**Root cause.** A `DoubleFanShockWave` side ends in finite θ *exactly* when its shock face
crosses one of its own fan boundary lines. The dedicated detector for this
(`theta_at_side_exhaustion` → `DFSW_SIDE_EXHAUSTED`) was incomplete on two independent counts:

1. it targeted the fan edge *farther* from the current side value — wrong whenever the wave
   is born mid-fan (systematically so when a DFSW inherits a fan its predecessor had mostly
   consumed), and
2. even with the correct target, the feeder's fan-extent clamp flattens the exhaustion
   residual to exactly zero past the edge, so the strict-sign-change bracket never fires.

The side therefore never degraded, and the exhausted fan's boundary line stayed exposed
*beyond* the shock as a ghost face. The single-owner sweep reader misattributed the region
between the shock and that line, transiently mis-counting stored mass and breaking the
outlet-mass-monotonicity tripwire — the loud decline. The bug is geometry-dependent, not
regime-dependent (all DSW/DFSW trajectories and the merge calculus are correct in the `n<1`
mirror, verified to `<1e-6` relative against independent DOP853 integration).

**Fix.** Route side exhaustion through the existing universal `WAVE_MERGE` path. A DFSW's
shock face crossing its own boundary line is the same primitive as any other face merge —
the merge builds the degraded successor from `(const far-bound feeder | surviving fan feeder)`
and retires the boundary. Lax entropy (`λ(c_L) ≥ σ ≥ λ(c_R)`) makes these two crossings the
*only* finite-θ side endings, so no separate detector is needed. The face-pair loop now admits
a DFSW's `shock`×`boundary` self-crossing; `find_face_crossing` derives its born-coincident
admission from the pair (same-wave pairs suppress the loose near-coincidence branch — a front
born near its own boundary and diverging is not spuriously retired — while exact coincidence
still fires). Deletes `DFSW_SIDE_EXHAUSTED`, `theta_at_side_exhaustion`, and
`_handle_dfsw_side_exhaustion` (net leaner source).

## Test plan

- New `TestSideExhaustion` (replaces the `xfail(strict)` gap pins in `TestKnownMultiFrontGaps`):
  - `test_freundlich_nlt1_two_pulse_resolves` — the #317 minimal reproducer resolves; the
    self-merge is pinned to the closed-form `θ=778.75`, `V=5/28`, the successor is the expected
    `DecayingShockWave(c_fixed=2, decay_side='right')`, the parent DFSW and its left boundary
    are retired at the event θ, and the resolved outlet matches the first-order FV oracle
    (`_fv_discrepancy < 0.05`, the oracle's own smearing floor).
  - `test_public_api_resolves_n_lt_1` — the former decline input now returns a finite,
    non-negative `cout` through the public API, with the stored mass validated against an
    *independent* trapezoid of `C_T(c(v,θ))` — not the tautological `m_out + m_dom == m_in`
    balance, which (since `cout ≡ (m_in − m_dom)/Δθ`) passes even under a 50% `m_dom` error
    (mutation-confirmed).
  - `test_langmuir_multipulse_resolves[multi-pulse|staircase]` — the two formerly-declining
    favorable Langmuir configs resolve and exercise the same-wave merge path.
- `pytest tests/src -k "front_tracking or fronttracking"` → 521 passed, 2 skipped.
- `pytest tests/src` minus the RAM-heavy `radial_asr`/drift modules → 1870 passed, 2 skipped;
  `radial_asr` (43 passed) and the drift module pass in isolation.
- `ruff format` + `ruff check` clean; `ty check src/gwtransport/fronttracking/` clean.
- Theory doc `docs/theory/front_tracking_interactions.md` §4.3/§4.4 and the event table updated.
- Reviewed by the gated physics→tests→leanness pipeline: physics gate 0 Critical / 0 Major /
  0 Minor / 0 Questions (independently re-derived the geometry; FV-oracle- and baseline-verified).

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
