### PR TITLE
fix: dt-weighted per-phase flow_scale restores radial_asr rebinning invariance (#333)

### DIFF
--- a/src/gwtransport/_radial_asr_compose.py
+++ b/src/gwtransport/_radial_asr_compose.py
@@ -58,11 +58,12 @@ def _fr_step_response(
 ) -> npt.NDArray[np.floating]:
     r"""Flux-resident step response ``G1(S; V') = L^{-1}[ghat_FR(p; V')/p](S)`` at one ``V'``.
 
-    The flushed-volume Laplace variable ``p`` enters the transfer function as ``s = flow_scale * p``
-    with ``A_0 = flow_scale / (2 c_geo)``. For ``D_m = 0`` the flow magnitude cancels (``ghat``
-    depends only on ``beta = 2 c_geo p / alpha_L``), so the response is the flow-independent S-clock
-    kernel -- exact for arbitrary within-phase variable flow. For ``D_m > 0`` the kernel depends on
-    ``A_0`` separately, so ``flow_scale`` must be the (constant) phase flow magnitude.
+    For ``D_m = 0`` the flushed-volume Airy kernel depends on the Laplace variable ``p`` only through
+    ``beta = 2 c_geo R p / alpha_L``, so it is evaluated directly in the flow-free canonical form
+    (``s = 2 c_geo p``, ``A_0 = 1``) -- exact for arbitrary within-phase variable flow and bit-independent of
+    ``flow_scale``. For ``D_m > 0`` the kernel depends on ``A_0 = flow_scale / (2 c_geo)`` separately, so the
+    Laplace variable enters as ``s = flow_scale * p`` and ``flow_scale`` must be the (constant) phase flow
+    magnitude.
 
     The de Hoog half-period is anchored to the FR arrival-volume mean at ``V'``
     (``mu = R c_geo[(r'+alpha_L)^2 + alpha_L^2 - r_w^2]``, KB Sec. 7 -- the breakthrough front),
@@ -76,15 +77,21 @@ def _fr_step_response(
     """
     r_p = np.sqrt(r_w**2 + v_prime / c_geo)
     mu = retardation_factor * c_geo * ((r_p + alpha_l) ** 2 + alpha_l**2 - r_w**2)
+    # D_m = 0: the Airy S-clock kernel depends on p only through beta = 2 c_geo R p / alpha_L, so evaluate it
+    # in the flow-free canonical form (a0 = 1, s = 2 c_geo p) -- routing flow_scale through s and a0 would
+    # round-trip it and leave ~1-ulp bit-noise the de Hoog QD stage amplifies. D_m > 0: the kernel depends on
+    # A_0 = flow_scale/(2 c_geo) separately, so use the (constant) phase flow magnitude.
+    s_mult = 2.0 * c_geo if molecular_diffusivity == 0.0 else flow_scale
+    a0 = s_mult / (2.0 * c_geo)  # 1.0 exactly for D_m = 0 (flow-free), flow_scale/(2 c_geo) for D_m > 0
 
     def f_hat(p: npt.NDArray[np.complexfloating]) -> npt.NDArray[np.complexfloating]:
         return (
             transfer_function(
-                s=flow_scale * p,
+                s=s_mult * p,
                 r=r_p,
                 r_w=r_w,
                 alpha_l=alpha_l,
-                a0=flow_scale / (2.0 * c_geo),
+                a0=a0,
                 d_m=molecular_diffusivity,
                 retardation_factor=retardation_factor,
                 inject="flux",
@@ -118,8 +125,8 @@ def single_cycle_echo_matrix(
     r"""Echo weight matrix ``W`` (``cout' = W @ cin'``) for one inject-then-extract cycle, one disk.
 
     The injection builds the resident profile with the FR kernel at the injection flow magnitude and
-    the extraction reads it out at the extraction flow magnitude. For ``D_m = 0`` the flow magnitudes
-    cancel (the S-clock kernel is flow-independent), so arbitrary within-phase variable flow is exact;
+    the extraction reads it out at the extraction flow magnitude. For ``D_m = 0`` the flow magnitudes are
+    not used (the S-clock kernel is evaluated flow-free), so arbitrary within-phase variable flow is exact;
     for ``D_m > 0`` the flow scales must be the (constant) per-phase magnitudes.
 
     Parameters
@@ -137,7 +144,8 @@ def single_cycle_echo_matrix(
         Longitudinal dispersivity (m).
     inj_flow_scale, ext_flow_scale : float
         Flow magnitudes ``|Q|`` (m^3/day) of the injection and extraction phases (only relevant when
-        ``molecular_diffusivity > 0``; ignored to within rounding for ``D_m = 0``).
+        ``molecular_diffusivity > 0``; ignored exactly for ``D_m = 0``, where the S-clock kernel is
+        evaluated flow-free).
     retardation_factor : float, optional
         Linear retardation ``R >= 1``. Default 1.
     molecular_diffusivity : float, optional

--- a/src/gwtransport/_radial_asr_reuse.py
+++ b/src/gwtransport/_radial_asr_reuse.py
@@ -107,7 +107,6 @@ def _airy_propagator_matrix(
     r_w: float,
     alpha_l: float,
     c_geo: float,
-    flow_scale: float,
     n_terms: int,
     tol: float,
 ) -> npt.NDArray[np.floating]:
@@ -120,16 +119,17 @@ def _airy_propagator_matrix(
     and every output row is assembled by prefix selection (``O(n_quad)`` Airy evaluations).
 
     The Sturm-Liouville source weight is ``w(r') = (2 c_geo r'/alpha_L) e^{-gauge_sign r'/alpha_L} dr'``
-    (``gauge_sign = +1`` injection / ``-1`` extraction); the flushed-volume clock is set by ``s =
-    flow_scale * p`` with ``a0 = flow_scale/(2 c_geo)`` so ``beta = 2 c_geo p/alpha_L`` is flow-magnitude
-    independent (the autonomy of the S-clock).
+    (``gauge_sign = +1`` injection / ``-1`` extraction); the ``D_m = 0`` Airy kernel depends on the Laplace
+    node only through ``beta = 2 c_geo p/alpha_L`` (the autonomy of the flushed-volume S-clock), so it is
+    evaluated directly in that flow-free canonical form (``s = 2 c_geo p``, ``a0 = 1``) -- no ``flow_scale``
+    round-trip, so ``P`` is exactly independent of the phase flow magnitude.
 
     Returns
     -------
     ndarray
         Propagator matrix ``P``, shape ``(n_quad, n_quad)``.
     """
-    a0 = flow_scale / (2.0 * c_geo)
+    a0 = 1.0
     gauge_sign = 1.0 if direction == _INJECTION else -1.0
     n = r_nodes.size
     # Split the Sturm-Liouville source weight (2 c_geo r'/alpha_L) e^{-gauge_sign r'/alpha_L} dr' into its
@@ -144,7 +144,7 @@ def _airy_propagator_matrix(
     below = r_nodes[None, :] < r_nodes[:, None]  # below[i, j] = r_j < r_i
 
     def f_hat(p: npt.NDArray[np.complexfloating]) -> npt.NDArray[np.complexfloating]:
-        s = (flow_scale * p).reshape(-1, 1)
+        s = (2.0 * c_geo * p).reshape(-1, 1)  # canonical flow-free S-clock: beta = 2 c_geo p / alpha_L
         grid_p = _resolvent_airy_pieces(s, r_nodes.reshape(1, -1), alpha_l, a0, gauge_sign)
         piece_w = _resolvent_airy_pieces(s, np.array([[r_w]]), alpha_l, a0, gauge_sign)
         ghat = np.empty((p.size, n, n), dtype=complex)
@@ -412,7 +412,7 @@ def cout_deviation(
     def propagate(field, direction, flow_scale, phase_volume, phase_time):
         if molecular_diffusivity == 0.0:  # Airy: flushed-volume clock, retardation rescales the clock
             tau = phase_volume / retardation_factor
-            key = ("airy", direction, round(tau, 9), round(flow_scale, 9))
+            key = ("airy", direction, round(tau, 9))  # matrix is flow-magnitude independent (S-clock autonomy)
             if key not in matrices:
                 matrices[key] = _airy_propagator_matrix(
                     direction,
@@ -422,7 +422,6 @@ def cout_deviation(
                     r_w=r_w,
                     alpha_l=alpha_l,
                     c_geo=c_geo,
-                    flow_scale=flow_scale,
                     n_terms=n_terms,
                     tol=tol,
                 )
@@ -465,8 +464,8 @@ def cout_deviation(
                     )
                 field = matrices[key] @ field
             continue
-        flow_scale = float(np.mean(np.abs(flow[sl])))
         phase_time = float(np.sum(dt_days[sl]))
+        flow_scale = phase_volume / phase_time  # dt-weighted mean |Q|: flow_scale * phase_time = flushed volume
         edges = np.concatenate(([0.0], np.cumsum(flushed[sl])))
         readout = {
             "c_geo": c_geo,

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -237,8 +237,10 @@ def _echo_operator(
     dt = dt_to_days(tedges)
     inj_vol = np.concatenate(([0.0], np.cumsum((flow * dt)[inj_mask])))  # 0 .. S_inj
     ext_vol = np.concatenate(([0.0], np.cumsum((-flow * dt)[ext_mask])))  # 0 .. T_end
-    inj_flow_scale = float(np.mean(flow[inj_mask])) if np.any(inj_mask) else 1.0
-    ext_flow_scale = float(np.mean(-flow[ext_mask])) if np.any(ext_mask) else 1.0
+    # dt-weighted mean |Q| per direction (total flushed volume / total pumping time): flow_scale * time =
+    # flushed volume, so the D_m>0 constant-|Q| kernel conserves volume and cout is rebinning-invariant.
+    inj_flow_scale = float(inj_vol[-1] / np.sum(dt[inj_mask])) if np.any(inj_mask) else 1.0
+    ext_flow_scale = float(ext_vol[-1] / np.sum(dt[ext_mask])) if np.any(ext_mask) else 1.0
     w_ens = np.zeros((int(np.sum(ext_mask)), int(np.sum(inj_mask))))
     for c_geo, w_i in zip(c_geos, weights, strict=True):
         w_ens += w_i * single_cycle_echo_matrix(
@@ -462,7 +464,10 @@ def infiltration_to_extraction(
     molecular_diffusivity : float, optional
         Molecular diffusivity ``D_m`` [m^2/day]. Default 0. ``D_m = 0`` uses the vectorized Airy branch;
         ``D_m > 0`` uses the log-derivative Riccati kernel -- exact to the de Hoog floor at any ``A_0/D_m``
-        with no precision cap, reducing continuously to the Airy branch as ``D_m -> 0``.
+        with no precision cap, reducing continuously to the Airy branch as ``D_m -> 0``. For ``D_m > 0`` each
+        one-signed pumping phase is advanced at its (constant) dt-weighted mean flow magnitude, so
+        within-phase variable flow is a constant-|Q| approximation whose error grows with the within-phase
+        flow variation; it is exact for constant-|Q| phases, and (at any flow schedule) for ``D_m = 0``.
     retardation_factor : float, optional
         Linear retardation ``R >= 1``. Default 1.
     weights : array-like, optional

--- a/tests/src/_radial_asr_gridfree_oracle.py
+++ b/tests/src/_radial_asr_gridfree_oracle.py
@@ -157,7 +157,6 @@ def _propagate(
     *,
     r_w: float,
     alpha_l: float,
-    flow_scale: float,
     c_geo: float,
 ) -> npt.NDArray[np.floating]:
     """Propagate a resident field by flushed-volume ``tau`` with the Airy interior Green's function.
@@ -165,9 +164,10 @@ def _propagate(
     ``f_resid(r_i) = L^{-1}_p[ sum_k Ghat(r_i, r_k; p) field_k src_measure_k ](tau)`` -- one de Hoog
     inversion per output node, with the source superposition folded into the transform (it is linear
     and commutes with the inversion). ``src_measure_k = w(r_k) dr_weights_k`` carries the
-    Sturm-Liouville weight; ``flow_scale`` cancels for ``D_m = 0`` (the autonomous S/T-clock). The
-    scaled Airy on the grid is evaluated ONCE per de Hoog node set (cached and reused across output
-    nodes), and each output node is assembled by prefix selection at ``r_i`` -- ``O(n_quad)`` Airy
+    Sturm-Liouville weight; the ``D_m = 0`` Airy kernel depends on the Laplace node only through
+    ``beta = 2 c_geo p/alpha_L`` (the autonomous S-clock), so it is evaluated flow-free (``s = 2 c_geo p``,
+    ``a0 = 1``). The scaled Airy on the grid is evaluated ONCE per de Hoog node set (cached and reused across
+    output nodes), and each output node is assembled by prefix selection at ``r_i`` -- ``O(n_quad)`` Airy
     evaluations rather than ``O(n_quad^2)``.
 
     Returns
@@ -175,7 +175,7 @@ def _propagate(
     ndarray
         Propagated resident deviation at each node, shape ``(n_quad,)``.
     """
-    a0 = flow_scale / (2.0 * c_geo)
+    a0 = 1.0
     gauge_sign = 1.0 if direction == "injection" else -1.0
     weighted = field * src_measure
     if not np.any(weighted != 0.0):
@@ -186,7 +186,7 @@ def _propagate(
     cache: dict[bytes, tuple] = {}
 
     def pieces(p: npt.NDArray[np.complexfloating]) -> tuple:
-        s = (flow_scale * p).reshape(-1, 1)
+        s = (2.0 * c_geo * p).reshape(-1, 1)  # canonical flow-free S-clock: beta = 2 c_geo p / alpha_L
         return (
             _resolvent_airy_pieces(s, r_grid, alpha_l, a0, gauge_sign),
             _resolvent_airy_pieces(s, np.array([[r_w]]), alpha_l, a0, gauge_sign),
@@ -399,7 +399,6 @@ def gridfree_cout_deviation(
                 phase_volume / retardation_factor,
                 r_w=r_w,
                 alpha_l=alpha_l,
-                flow_scale=flow_scale,
                 c_geo=c_geo,
             )
         return _propagate_diffusive(  # D_m > 0: wall-clock time, retardation rescales A_0, D_m
@@ -433,8 +432,8 @@ def gridfree_cout_deviation(
                     d_m_eff=molecular_diffusivity / retardation_factor,
                 )
             continue
-        flow_scale = float(np.mean(np.abs(flow[sl])))
         phase_time = float(np.sum(dt_days[sl]))
+        flow_scale = phase_volume / phase_time  # dt-weighted mean |Q|: flow_scale * phase_time = flushed volume
         edges = np.concatenate(([0.0], np.cumsum(phase_flushed)))
         if sign > 0:  # injection: propagate the buffer, then add the new injected resident profile
             field = propagate(field, "injection", flow_scale, phase_volume, phase_time)

--- a/tests/src/test_radial_asr_gridfree.py
+++ b/tests/src/test_radial_asr_gridfree.py
@@ -515,16 +515,16 @@ class TestReuseEngine:
         # sign / structural error is O(|col|) ~ 1e-2..1e-1, five orders of magnitude above the tolerance.
         flow, dt = np.array([100.0] * 4 + [-100.0] * 4), np.ones(8)
         r_nodes, _, dr = _field_grid(flow, dt, CG, 0.5, 0.5, 0.0, 60)
-        tau, flow_scale = 400.0, 100.0  # flushed-volume tau = phase_volume
+        tau = 400.0  # flushed-volume tau = phase_volume (the D_m=0 Airy kernel is flow-magnitude free)
         gauge = -1.0 if direction == "injection" else 1.0
         sl = (2.0 * CG * r_nodes / 0.5) * np.exp(gauge * r_nodes / 0.5) * dr
         pmat = _airy_propagator_matrix(
-            direction, tau, r_nodes, dr, r_w=0.5, alpha_l=0.5, c_geo=CG, flow_scale=flow_scale, n_terms=44, tol=1e-9
+            direction, tau, r_nodes, dr, r_w=0.5, alpha_l=0.5, c_geo=CG, n_terms=44, tol=1e-9
         )
         for j in (5, 30, 55):
             e = np.zeros(60)
             e[j] = 1.0
-            col = _propagate(e, r_nodes, sl, direction, tau, r_w=0.5, alpha_l=0.5, flow_scale=flow_scale, c_geo=CG)
+            col = _propagate(e, r_nodes, sl, direction, tau, r_w=0.5, alpha_l=0.5, c_geo=CG)
             np.testing.assert_allclose(pmat[:, j], col, rtol=1e-6, atol=5e-7)
 
     @pytest.mark.parametrize("direction", ["injection", "extraction"])
@@ -539,7 +539,7 @@ class TestReuseEngine:
         r_nodes, _, dr = _field_grid(flow, dt, c_geo, r_w, alpha_l, 0.0, 120)
         assert r_nodes.max() / alpha_l > 700.0  # the regime that overflowed before the fold
         signed = flow[flow > 0] if direction == "injection" else -flow[flow < 0]
-        tau, flow_scale = float(np.sum(signed)), float(np.mean(signed))
+        tau = float(np.sum(signed))  # flushed-volume tau = phase_volume
         pmat = _airy_propagator_matrix(
             direction,
             tau,
@@ -548,7 +548,6 @@ class TestReuseEngine:
             r_w=r_w,
             alpha_l=alpha_l,
             c_geo=c_geo,
-            flow_scale=flow_scale,
             n_terms=44,
             tol=1e-9,
         )
@@ -863,3 +862,179 @@ class TestRestDiffusion:
             cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.05, n_cells=600, n_sub=8, **GEOM
         )
         assert np.max(np.abs(gf[ext] - fv[ext])) < 3e-2  # FV first-order floor (the gridfree side is exact)
+
+
+def _tedges_from_dt(dt):
+    """DatetimeIndex bin edges (n+1) whose day-widths equal ``dt`` -- for the public ``radial_asr`` API."""
+    return pd.Timestamp("2020-01-01") + pd.to_timedelta(np.concatenate(([0.0], np.cumsum(dt))), unit="D")
+
+
+def _assemble(segments):
+    """Concatenate a list of ``(flow, dt, cin)`` phase segments into flat ``(flow, dt, cin)`` arrays."""
+    return tuple(np.concatenate(col) for col in zip(*segments, strict=True))
+
+
+def _i2e(segments, n_quad):
+    """Run the public ``infiltration_to_extraction`` on assembled phase segments (fixed ASR geometry)."""
+    flow, dt, cin = _assemble(segments)
+    tedges = _tedges_from_dt(dt)
+    return infiltration_to_extraction(
+        cin=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        pore_heights=10.0,
+        porosity=0.3,
+        well_radius=0.5,
+        longitudinal_dispersivity=0.5,
+        molecular_diffusivity=0.05,
+        n_quad=n_quad,
+    )
+
+
+def _rebinning_schedules(direction):
+    r"""Two binnings (A, B) of one physical Q(t): a tracer push, then a clean probe phase binned coarsely
+    (A: 2 bins where ``|Q|`` and ``dt`` covary, so ``mean(|Q|) != phase_volume/phase_time``) vs. finely
+    (B: the identical physical flow in uniform 1-day bins), then a final extraction read on 6 shared bins.
+
+    The probe (``injection`` or ``extraction``) is an intermediate phase, so its across-reversal propagator
+    hand-off carries the ``flow_scale`` defect. Returns ``(segments_A, segments_B)``; the last 6 bins are the
+    identical extraction readout in both.
+    """
+    read = [(np.full(6, -100.0), np.full(6, 2.0), np.zeros(6))]  # final extraction: read cout on 6 shared bins
+    if direction == "injection":
+        pre = [
+            (np.full(4, 100.0), np.ones(4), np.ones(4)),  # tracer push (cin deviation = 1)
+            (np.full(2, -100.0), np.ones(2), np.zeros(2)),  # partial extract -> a resident plume remains
+        ]
+        # probe: clean injection of 380 m^3 over 20 d. mean|Q| = 100 (A) / 19 (B); phase_volume/time = 19 both.
+        probe_a = [(np.array([190.0, 10.0]), np.array([1.0, 19.0]), np.zeros(2))]
+        probe_b = [(np.concatenate([[190.0], np.full(19, 10.0)]), np.ones(20), np.zeros(20))]
+        return pre + probe_a + read, pre + probe_b + read
+    # extraction probe: tracer push, then a clean extraction binned two ways (its residual is propagated
+    # inward by the convergent hand-off), then a clean injection separates it from the readout extraction.
+    pre = [(np.full(6, 100.0), np.ones(6), np.ones(6))]  # tracer push (cin deviation = 1)
+    # probe: clean extraction of 500 m^3 over 4 d. mean|Q| = 100 (A) / 125 (B); phase_volume/time = 125 both.
+    probe_a = [(np.array([-150.0, -50.0]), np.array([3.0, 1.0]), np.zeros(2))]
+    probe_b = [(np.array([-150.0, -150.0, -150.0, -50.0]), np.ones(4), np.zeros(4))]
+    mid = [(np.full(2, 100.0), np.ones(2), np.zeros(2))]  # clean injection separates the two extraction phases
+    return pre + probe_a + mid + read, pre + probe_b + mid + read
+
+
+class TestRebinningInvariance:
+    r"""Issue #333: two valid binnings of the *same physical* Q(t) must give identical ``cout``.
+
+    The per-phase advective clock must advance the plume by the flushed volume ``sum|Q| dt`` (the
+    dt-weighted mean ``flow_scale = phase_volume/phase_time``), not by the unweighted ``mean(|Q|) * sum(dt)``.
+    Any phase where ``|Q|`` and ``dt`` covary makes the two differ, so the two binnings expose the bug
+    (issue #333 confirmed baselines: ~0.95 rel for ``D_m > 0``, ~7e-5 for ``D_m = 0``; the per-test baselines
+    below vary with the schedule). Every uniform-bin schedule -- i.e. every other radial test -- is a
+    bit-exact no-op for the fix, which is why it went uncaught. All comparisons are on physically identical
+    extraction bins.
+    """
+
+    @pytest.mark.parametrize("direction", ["injection", "extraction"])
+    def test_rebinning_invariance_dm0(self, direction):
+        # D_m = 0 (Airy S-clock, vectorized -> fast). After the fix flow_scale is binning-invariant AND the
+        # kernel is evaluated flow-free, so the two binnings share bit-identical grids/matrices: A == B to the
+        # last bit (measured 0.0). Baseline round-trips a different flow_scale per binning (RAR-F2), leaving
+        # de-Hoog-amplified bit-noise ~2.6e-8 on this schedule.
+        seg_a, seg_b = _rebinning_schedules(direction)
+        fa, da, ca = _assemble(seg_a)
+        fb, db, cb = _assemble(seg_b)
+        cout_a = cout_deviation(cin_deviation=ca, flow=fa, dt_days=da, molecular_diffusivity=0.0, n_quad=64, **GEOM)
+        cout_b = cout_deviation(cin_deviation=cb, flow=fb, dt_days=db, molecular_diffusivity=0.0, n_quad=64, **GEOM)
+        # atol near machine precision: integer volumes give bit-identical tau/flow_scale, so A and B build the
+        # identical matrices; the ~2.6e-8 baseline fails this by ~5 orders.
+        np.testing.assert_allclose(cout_a[-6:], cout_b[-6:], rtol=0, atol=1e-13)
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(
+        ("direction", "r_fac"),
+        [("injection", 1.0), ("extraction", 1.0), ("injection", 2.0)],  # both hand-off directions + retardation
+    )
+    def test_rebinning_invariance_dm_positive(self, direction, r_fac):
+        # D_m > 0 (Riccati wall-clock) -- THE major regression (RAR-F1). Baseline mis-advects the probe phase
+        # by mean(|Q|)*sum(dt) instead of the flushed volume: ~0.95 rel between the two binnings. After the fix
+        # flow_scale = phase_volume/phase_time is binning-invariant, so both build the identical cached Riccati
+        # propagator and A == B bit-for-bit (measured 0.0). R>1 exercises the a0_eff = flow_scale/(2c_geo)/R
+        # coupling; the extraction probe exercises the convergent (Danckwerts) hand-off.
+        seg_a, seg_b = _rebinning_schedules(direction)
+        kw = {"molecular_diffusivity": 0.05, "retardation_factor": r_fac, "n_quad": 40, **GEOM}
+        fa, da, ca = _assemble(seg_a)
+        fb, db, cb = _assemble(seg_b)
+        cout_a = cout_deviation(cin_deviation=ca, flow=fa, dt_days=da, **kw)
+        cout_b = cout_deviation(cin_deviation=cb, flow=fb, dt_days=db, **kw)
+        np.testing.assert_allclose(cout_a[-6:], cout_b[-6:], rtol=0, atol=1e-13)
+
+    def test_dm0_flow_magnitude_invariance(self):
+        # RAR-F2 in isolation: for D_m = 0 the S-clock kernel is flow-magnitude free, so scaling all |Q| by a
+        # constant (with inverse-scaled dt -> fixed volume schedule) must leave cout unchanged, and with a
+        # different flow magnitude on each run this is independent of the RAR-F1 (dt-weighting) fix. Multi-cycle
+        # so the across-reversal Airy propagator hand-off (which carries the round-trip noise) is invoked -- a
+        # single inject/extract cycle never propagates. The scale factor is NON-power-of-two on purpose: a power
+        # of two makes the baseline round-trip cancel exactly (s=c*s, a0=c*a0 -> beta=s/a0 bit-identical),
+        # hiding the bug. Baseline: ~1e-8 de-Hoog-amplified flow_scale bit-noise; post-fix the kernel is
+        # evaluated flow-free so only ~1e-14 volume-ulp noise remains.
+        flow = np.array([100.0] * 4 + [-100.0] * 2 + [50.0] * 4 + [-100.0] * 6)  # 3 reversals -> propagator used
+        dt = np.ones(len(flow))
+        cin = np.where(flow > 0, 1.0, 0.0)  # tracer on injections
+        c = 1.7  # NON-power-of-two
+        ext = flow < 0
+        cout1 = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.0, n_quad=80, **GEOM)
+        cout2 = cout_deviation(
+            cin_deviation=cin, flow=flow * c, dt_days=dt / c, molecular_diffusivity=0.0, n_quad=80, **GEOM
+        )
+        np.testing.assert_allclose(cout1[ext], cout2[ext], rtol=0, atol=1e-11)
+
+    @pytest.mark.slow
+    def test_dm_engine_reduces_to_airy_limit(self):
+        # Physical-correctness ANCHOR that pins the flow_scale VALUE (not just self-consistency, which the
+        # rebinning tests already give): as D_m -> 0 the wall-clock Riccati engine must reduce to the
+        # volume-exact D_m=0 Airy engine on the non-uniform schedule. This holds ONLY if the Riccati clock
+        # advects exactly the flushed volume, i.e. flow_scale = phase_volume/phase_time. Baseline (mean|Q|)
+        # mis-advects -> ~0.97 gap; any wrong-but-binning-invariant scale (e.g. max|Q|, = 190 in both binnings)
+        # would also fail here while passing the A==B tests. Post-fix the gap is the first-order D_m truncation
+        # (~2e-3 at D_m=1e-3).
+        flow, dt, cin = _assemble(_rebinning_schedules("injection")[0])
+        ext = flow < 0
+        ref = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.0, n_quad=48, **GEOM)
+        approx = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=1e-3, n_quad=48, **GEOM)
+        scale = np.max(np.abs(ref[ext]))
+        assert np.max(np.abs(approx[ext] - ref[ext])) / scale < 8e-3  # first-order D_m limit; baseline ~0.97
+
+    @pytest.mark.slow
+    def test_nonuniform_dm_matches_fv_oracle(self):
+        # Independent cross-check: the fixed non-uniform D_m>0 engine matches the finite-volume oracle, which
+        # shares NO kernel code with the engine and is itself rebinning-invariant. This is the definitive guard
+        # against "engine and gridfree oracle silently agree on the wrong value" (both were fixed together).
+        # The floor is the constant-|Q| per-phase kernel approximation (~7%, ratio-independent) + slow-FV
+        # first-order convergence -- NOT "a few %". Baseline engine-vs-FV = 0.87 (sides with the wrong value);
+        # post-fix ~0.08.
+        flow, dt, cin = _assemble(_rebinning_schedules("injection")[0])
+        ext = flow < 0
+        eng = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.05, n_quad=64, **GEOM)
+        fv = fv_cout_deviation(
+            cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.05, n_cells=600, n_sub=8, **GEOM
+        )
+        scale = np.max(np.abs(fv[ext]))
+        assert np.max(np.abs(eng[ext] - fv[ext])) / scale < 0.15  # constant-|Q| kernel (~7%) + slow-FV floor
+
+    @pytest.mark.slow
+    def test_echo_operator_rebinning_invariance(self):
+        # The single-cycle D_m>0 public path uses the echo operator (radial_asr._echo_operator), whose
+        # inj/ext_flow_scale are the milder RAR-F1 site (volume corners exact, only the kernel A_0 shape is
+        # off). Non-uniform vs uniform injection of the same tracer -> identical cout after the fix (baseline
+        # ~2.6%). Exercises the public infiltration_to_extraction dispatch + tedges->dt conversion.
+        inj_a = (np.array([190.0, 10.0]), np.array([1.0, 19.0]), np.array([1.0, 1.0]))
+        inj_b = (np.concatenate([[190.0], np.full(19, 10.0)]), np.ones(20), np.ones(20))
+        ext = (np.full(6, -100.0), np.full(6, 2.0), np.zeros(6))
+        np.testing.assert_allclose(_i2e([inj_a, ext], 48)[-6:], _i2e([inj_b, ext], 48)[-6:], rtol=0, atol=1e-13)
+
+    @pytest.mark.slow
+    def test_public_multicycle_rebinning(self):
+        # The multi-cycle public path (infiltration_to_extraction -> _reuse_ensemble -> cout_deviation, plus
+        # the tedges->dt conversion and streamtube averaging) is rebinning-invariant. Complements the direct
+        # cout_deviation tests, which bypass the public wrapper. Baseline ~0.95; post-fix bit-identical.
+        seg_a, seg_b = _rebinning_schedules("injection")
+        np.testing.assert_allclose(_i2e(seg_a, 40)[-6:], _i2e(seg_b, 40)[-6:], rtol=0, atol=1e-13)


### PR DESCRIPTION
## Summary

Fixes #333. The `radial_asr` scalar engine's per-phase `flow_scale` used the **unweighted** bin-mean
`mean(|Q|)` as the constant-Q advective clock speed. The conserved quantity is the flushed volume
`Σ|Q|·dt = phase_volume`, so the plume was advected by `mean(|Q|)·Σdt` instead of `Σ|Q|·dt` — these differ
whenever `|Q|` and `dt` covary within a one-signed phase. Consequence: **two valid binnings of the identical
physical `Q(t)` gave different public `cout`** (rebinning invariance broken). Every existing radial test uses
uniform bins, where the two means coincide, so it went uncaught.

**Root-cause fix — dt-weighted `flow_scale = phase_volume / phase_time`** (RAR-F1), at the three scalar
sites: the reuse engine (`_radial_asr_reuse.cout_deviation`), the per-reversal gridfree oracle
(`_radial_asr_gridfree_oracle.gridfree_cout_deviation`), and the single-cycle echo operator
(`radial_asr._echo_operator`, per direction: total flushed volume / total pumping time). This makes
`flow_scale·phase_time = phase_volume` exactly, so `flow_scale` is a binning-invariant physical quantity.

**Canonical flow-free `D_m = 0` kernel** (RAR-F2): for `D_m = 0` the Airy S-clock kernel depends on the
Laplace node only through `beta = 2·c_geo·(R)·p/alpha_L` — flow-magnitude free. The code round-tripped
`flow_scale` through `s = flow_scale·p`, `a0 = flow_scale/(2·c_geo)`, leaving ~1-ulp bit-noise the de Hoog
QD stage amplified to ~4e-5 in `cout` (holding the `D_m=0` rebinning control 4–5 orders above the de Hoog
floor). It is now evaluated directly in the canonical form (`s = 2·c_geo·p`, `a0 = 1`) at all three sites the
`D_m=0` kernel is computed (`_airy_propagator_matrix`, `_fr_step_response`, oracle `_propagate`), matching
the form the `_radial_asr_compose` module docstring already documented.

**Nits:** dropped the now-redundant `flow_scale` from the Airy propagator cache key (RAC-F2); added the
constant-|Q|-per-phase qualifier to the public `molecular_diffusivity` doc (RAC-F3).

As a free consequence, the dt-weighted echo scales make `single_cycle_echo_matrix`'s
`total_time = S_inj/inj_flow_scale + T_end/ext_flow_scale` collapse to the true pumping time, fixing a latent
`D_m>0` molecular-reach under-sizing for non-uniform bins.

Out of scope: the same mechanism in the **drift** engine (`_radial_asr_drift_kernels.py`) is issue #310 /
RAD-F2, a separate code path — not touched here.

Reviewed by the physics-math, test, and leanness reviewers (plan and implementation); every finding and NIT
was folded in.

## Test plan

New `TestRebinningInvariance` in `tests/src/test_radial_asr_gridfree.py`. Each was confirmed to **fail on the
unchanged baseline and pass on the fix** (per the repo's regression-test discipline):

- `test_rebinning_invariance_dm0[injection|extraction]` — `D_m=0` rebinning A vs B → bit-identical
  (baseline ~7e-5 / 2.6e-8).
- `test_rebinning_invariance_dm_positive[injection|extraction|injection,R=2]` (slow) — the major regression;
  `D_m>0` rebinning → bit-identical (baseline ~0.95 rel).
- `test_dm0_flow_magnitude_invariance` — RAR-F2 in isolation: `D_m=0` cout invariant to a non-power-of-two
  flow-magnitude scaling at fixed volume schedule (baseline ~5e-6).
- `test_dm_engine_reduces_to_airy_limit` (slow) — physical-correctness anchor pinning the `flow_scale`
  *value*: the `D_m>0` engine reduces to the volume-exact `D_m=0` Airy engine as `D_m→0` (baseline ~0.97).
- `test_nonuniform_dm_matches_fv_oracle` (slow) — independent finite-volume cross-check (shares no kernel
  code), baseline engine-vs-FV 0.87 → ~0.08.
- `test_echo_operator_rebinning_invariance` (slow) — public single-cycle echo path (baseline ~2.6%).
- `test_public_multicycle_rebinning` (slow) — public `infiltration_to_extraction` multi-cycle path.

Existing tests updated for the `_airy_propagator_matrix` / `_propagate` signature change (dropped the dead
`flow_scale` argument): `test_airy_matrix_is_per_reversal_operator`, `test_airy_matrix_finite_at_high_peclet`.

Commands:
```bash
env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src/test_radial_asr_gridfree.py tests/src/test_radial_asr.py -n auto
env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src/test_radial_asr_gridfree.py -m slow -n 4
env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q ruff format . && ruff check .
uv tool run -q ty check .
```

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
