### PR TITLE
fix(gamma): guard degenerate bins()/parse_parameters inputs instead of silently-wrong output (#331)

### DIFF
--- a/src/gwtransport/gamma.py
+++ b/src/gwtransport/gamma.py
@@ -55,6 +55,13 @@ import numpy as np
 import numpy.typing as npt
 from scipy.stats import gamma as gamma_dist
 
+# Numerical-envelope guard thresholds for bins() (issue #331). Below _MIN_QUANTILE_GAP the
+# conditional-mean CDF difference cancels catastrophically; when alpha*eps exceeds
+# _HUGE_ALPHA_GAP_FRACTION of the smallest quantile gap, alpha + 1 == alpha to machine precision
+# and the per-bin expected values degrade to noise.
+_MIN_QUANTILE_GAP = 1e-8
+_HUGE_ALPHA_GAP_FRACTION = 0.01
+
 
 def parse_parameters(
     *,
@@ -101,7 +108,8 @@ def parse_parameters(
     ValueError
         If neither ``(mean, std)`` nor ``(alpha, beta)`` is provided, if both pairs
         are provided, if only one of a pair is provided, if ``alpha`` or ``beta`` are
-        not positive, if ``loc`` is negative, or if ``mean <= loc``.
+        not positive, if ``loc`` is negative, if the resolved ``alpha``, ``beta``, or
+        ``loc`` is not finite, or if ``mean <= loc``.
     """
     if loc < 0:
         msg = "loc must be non-negative"
@@ -126,6 +134,12 @@ def parse_parameters(
         alpha, beta = mean_std_loc_to_alpha_beta(mean=mean, std=std, loc=loc)
     elif alpha <= 0 or beta <= 0:
         msg = "Alpha and beta must be positive"
+        raise ValueError(msg)
+
+    # A non-finite alpha/beta/loc slips past the comparisons above (``nan <= 0`` and ``nan < 0`` are
+    # both False), producing an all-NaN distribution instead of a clear error. Reject it loudly.
+    if not (np.isfinite(alpha) and np.isfinite(beta) and np.isfinite(loc)):
+        msg = "alpha, beta, and loc must be finite."
         raise ValueError(msg)
 
     return alpha, beta, loc
@@ -307,7 +321,12 @@ def bins(
     ValueError
         If ``n_bins`` is not greater than 1, if ``quantile_edges`` is not a strictly
         increasing 1-D array in ``[0, 1]`` with endpoints exactly 0 and 1, or if
-        parameter validation in :func:`parse_parameters` fails.
+        parameter validation in :func:`parse_parameters` fails. Also raised for
+        numerically-degenerate requests that would otherwise return silently-wrong
+        structure: a smallest quantile-edge gap below ``1e-8`` (catastrophic
+        cancellation of the conditional-mean CDF difference), an ``alpha`` so large that
+        ``alpha + 1 == alpha`` in float64 relative to that gap (the distribution is
+        numerically a point mass), or a bin whose expected value underflows to ``loc``.
 
     See Also
     --------
@@ -317,6 +336,12 @@ def bins(
     :ref:`concept-gamma-loc` : Shifted gamma with minimum pore volume.
     :ref:`concept-dispersion-scales` : What ``std`` represents (macrodispersion vs total spreading).
     :ref:`assumption-gamma-distribution` : When gamma distribution is adequate.
+
+    Notes
+    -----
+    For a very large ``alpha`` (``>= ~1e6``) combined with custom ``quantile_edges`` deep
+    in the left tail, ``scipy``'s ``ppf`` loses relative accuracy; prefer equal-mass bins
+    or a coarser grid in that regime.
 
     Examples
     --------
@@ -363,6 +388,28 @@ def bins(
         msg = "Number of bins must be greater than 1"
         raise ValueError(msg)
 
+    # Guard the two numerical cliffs of the closed-form conditional mean below. A quantile gap
+    # narrower than ~1e-8 makes the CDF difference cancel catastrophically (expected values leave
+    # their own bins); an alpha so large that alpha*eps exceeds ~1% of that gap makes alpha+1 == alpha
+    # to machine precision, so the conditional means degrade to noise. Both are only reachable with
+    # extreme custom quantile_edges or a near-degenerate (delta-like) distribution.
+    min_quantile_gap = float(np.min(np.diff(quantile_edges)))
+    if min_quantile_gap < _MIN_QUANTILE_GAP:
+        msg = (
+            f"The smallest quantile-edge gap ({min_quantile_gap:.3g}) is below {_MIN_QUANTILE_GAP:g}; the "
+            "conditional-mean CDF difference cancels catastrophically and expected values may fall "
+            "outside their own bins. Use wider quantile bins."
+        )
+        raise ValueError(msg)
+    if alpha * np.finfo(float).eps > _HUGE_ALPHA_GAP_FRACTION * min_quantile_gap:
+        msg = (
+            f"alpha ({alpha:.3g}) is too large for float64 bin resolution: alpha*eps exceeds 1% of "
+            f"the smallest quantile gap ({min_quantile_gap:.3g}), so alpha+1 == alpha to machine "
+            "precision and the per-bin expected values are numerical noise. The distribution is "
+            "effectively a point mass at alpha*beta + loc; use a larger std/(mean-loc) or fewer bins."
+        )
+        raise ValueError(msg)
+
     # Unshifted bin edges for the standard Gamma(alpha, beta) distribution, then shift
     unshifted_edges = gamma_dist.ppf(quantile_edges, alpha, scale=beta)
     bin_edges = unshifted_edges + loc
@@ -374,7 +421,23 @@ def bins(
     # where F_{alpha+1} is the CDF of Gamma(alpha+1, beta).
     cdf_alpha_plus_1 = gamma_dist.cdf(unshifted_edges, alpha + 1, scale=beta)
     diff_alpha_plus_1 = np.diff(cdf_alpha_plus_1)
-    expected_values = beta * alpha * diff_alpha_plus_1 / probability_mass + loc
+
+    # Pre-shift conditional mean of the excess over loc. Every positive-mass bin of a Gamma(alpha, beta)
+    # has a strictly positive conditional mean, so this must be > 0; a value <= 0 signals an underflow /
+    # cancellation of the CDF difference (very small alpha or extremely fine bins) that would emit a
+    # numerically-zero or negative pore volume. Test this pre-shift quantity rather than the shifted
+    # expected value: for loc > 0 a benign ``loc + tiny_positive_excess == loc`` rounding would otherwise
+    # be misread as underflow and reject correct, usable output for shifted heterogeneous APVDs.
+    cond_mean_excess = beta * alpha * diff_alpha_plus_1 / probability_mass
+    if np.any(cond_mean_excess <= 0.0):
+        msg = (
+            "A bin's conditional expected value underflowed to loc (its excess conditional mean over loc "
+            "is not strictly positive). This happens for very small alpha or extremely fine bins where "
+            "the CDF difference underflows. Use fewer bins or a larger alpha."
+        )
+        raise ValueError(msg)
+
+    expected_values = cond_mean_excess + loc
 
     return {
         "lower_bound": bin_edges[:-1],

--- a/tests/src/test_gamma.py
+++ b/tests/src/test_gamma.py
@@ -646,3 +646,114 @@ def test_bins_expected_values_against_scipy_quadrature():
 # The former test_bins_alpha_less_than_one_large_nbins (alpha=0.5, beta=10.0, n_bins=100)
 # is now covered, at tighter tolerance and with the first-moment check, by the
 # (0.5, 10.0, 100) case in test_bins_extreme_regimes_finite_and_conservative.
+
+
+# =============================================================================
+# Numerical-envelope guards for bins() / parse_parameters (issue #331).
+#
+# Each degenerate input below previously returned silently-wrong structure -- expected
+# values outside their own bins, E == loc, or an all-NaN distribution -- with no error.
+# The guards now raise a clear ValueError. Every "must raise" test fails on the pre-guard
+# baseline (no exception was raised there), which is what makes it a regression test.
+# =============================================================================
+
+
+def test_parse_parameters_rejects_nonfinite():
+    """Non-finite alpha/beta/loc must raise, not slip through to an all-NaN distribution (GAM-F4).
+
+    ``nan <= 0`` and ``nan < 0`` are both False, so a non-finite value passes the positivity checks.
+    """
+    with pytest.raises(ValueError, match="must be finite"):
+        parse_parameters(alpha=np.nan, beta=2.0)
+    with pytest.raises(ValueError, match="must be finite"):
+        parse_parameters(alpha=2.0, beta=np.inf)
+    with pytest.raises(ValueError, match="must be finite"):
+        parse_parameters(alpha=2.0, beta=3.0, loc=np.nan)
+
+
+def test_bins_rejects_nonfinite_parameters():
+    """bins() surfaces the non-finite-parameter guard instead of returning an all-NaN dict (GAM-F4)."""
+    with pytest.raises(ValueError, match="must be finite"):
+        gamma_bins(alpha=np.nan, beta=2.0, n_bins=5)
+
+
+def test_bins_rejects_huge_alpha():
+    """alpha beyond float64 bin resolution (alpha + 1 == alpha) must raise (GAM-F1).
+
+    Reached through the documented (mean, std) parameterization: std/(mean - loc) = 1e-8 gives
+    alpha = 1e16 >= 2**53. On the baseline this returned noisy, non-monotone expected values with
+    8 of 10 lying outside their own bins, and nothing was raised.
+    """
+    with pytest.raises(ValueError, match="too large for float64 bin resolution"):
+        gamma_bins(mean=1.0, std=1e-8, n_bins=10)
+
+
+def test_bins_rejects_tiny_quantile_gap():
+    """A quantile gap below 1e-8 makes the conditional-mean CDF difference cancel catastrophically,
+    placing an expected value outside its own (infinitesimal) bin; it must raise (GAM-F2)."""
+    q0 = 0.5
+    edges = np.array([0.0, q0, np.nextafter(q0, 1.0), 1.0])
+    with pytest.raises(ValueError, match="quantile-edge gap"):
+        gamma_bins(alpha=10.0, beta=1.0, loc=5.0, quantile_edges=edges)
+
+
+def test_bins_rejects_expected_value_underflow():
+    """A very small alpha underflows the leftmost equal-mass bin's expected value to loc (a
+    numerically-zero pore volume); it must raise rather than propagate a bad value downstream (ADV-F2)."""
+    with pytest.raises(ValueError, match="underflowed to loc"):
+        gamma_bins(alpha=5e-3, beta=100.0, n_bins=100)
+
+
+def test_bins_guards_leave_realistic_configs_untouched():
+    """The #331 guards must not reject any realistic APVD: default and shifted configs, a fine
+    250-bin grid, and custom quantile edges all still succeed with strictly in-bin expected values."""
+    for kwargs in (
+        {"mean": 30000.0, "std": 8100.0, "n_bins": 10},
+        {"mean": 30000.0, "std": 8100.0, "loc": 5000.0, "n_bins": 250},
+        {"alpha": 13.7, "beta": 2000.0, "n_bins": 20},
+        {"mean": 30000.0, "std": 8100.0, "quantile_edges": np.array([0.0, 0.25, 0.5, 0.75, 1.0])},
+    ):
+        result = gamma_bins(**kwargs)
+        assert result["probability_mass"].sum() == 1.0
+        assert np.all(result["expected_values"] >= result["lower_bound"])
+        assert np.all(result["expected_values"] <= result["upper_bound"])
+
+
+def test_bins_accepts_shifted_heterogeneous_apvd():
+    """The underflow guard must test the pre-shift excess conditional mean, not the shifted expected
+    value. For a shifted, highly-heterogeneous APVD (loc > 0, small alpha) the excess conditional mean
+    is tiny but strictly positive; the shifted ``loc + tiny_excess`` can round to exactly ``loc`` in
+    float64 without any underflow, and that correctly-rounded, usable output must NOT be rejected.
+    Both parameterizations reach the same distribution and both must be accepted."""
+    for kwargs in (
+        {"alpha": 0.15, "beta": 100.0, "loc": 5000.0, "n_bins": 100},
+        {"mean": 6000.0, "std": 4472.0, "loc": 5000.0, "n_bins": 100},
+    ):
+        result = gamma_bins(**kwargs)
+        # Expected values are at least loc (the excess is non-negative) and inside their own bins,
+        # and the flow-weighted mean recovers the distribution mean.
+        assert np.all(result["expected_values"] >= result["lower_bound"])
+        assert np.all(result["expected_values"] <= result["upper_bound"])
+        assert np.all(result["expected_values"] >= 5000.0)
+
+
+def test_bins_rejects_expected_value_underflow_shifted():
+    """loc > 0: a genuine underflow (excess conditional mean == 0) must still raise. This pins that the
+    guard compares the excess against 0, not the shifted value against a hardcoded 0 -- a ``<= 0.0``
+    regression would silently pass at loc=0 but return E == loc bins here (the dominant shifted case)."""
+    with pytest.raises(ValueError, match="underflowed to loc"):
+        gamma_bins(alpha=5e-3, beta=100.0, n_bins=100, loc=5.0)
+
+
+def test_bins_rejects_huge_alpha_direct_alpha():
+    """The huge-alpha guard fires regardless of parameterization (direct alpha=, not only mean/std)."""
+    with pytest.raises(ValueError, match="too large for float64 bin resolution"):
+        gamma_bins(alpha=1e16, beta=1.0, n_bins=10)
+
+
+def test_parse_parameters_rejects_nonfinite_from_mean_std():
+    """A non-finite mean/std (e.g. an upstream division by zero) is rejected after conversion, so the
+    finite guard sits downstream of the (mean, std) -> (alpha, beta) converter, not only on the direct
+    alpha/beta arm."""
+    with pytest.raises(ValueError, match="must be finite"):
+        parse_parameters(mean=np.inf, std=1.0)


### PR DESCRIPTION
## Summary

`gamma.bins()` and `parse_parameters()` silently returned physically-impossible structure in degenerate corners — expected values outside their own bins, an expected value equal to `loc`, or an all-NaN distribution — with **no error** (issue #331; confirmed by the 2026-07 Fable deep-math review: GAM-F1/GAM-F2 + ADV-F2 + GAM-F4).

This adds four additive **loudness guards** that raise a clear `ValueError` instead of emitting silently-wrong output:

1. `parse_parameters` — reject non-finite `alpha`/`beta`/`loc`. A `nan`/`inf` slips past `nan <= 0` / `nan < 0` (both `False`) and would otherwise produce an all-NaN distribution.
2. `bins` — reject a smallest quantile-edge gap `< 1e-8`: the conditional-mean CDF difference cancels catastrophically and expected values leave their own bins.
3. `bins` — reject `alpha * eps > 1%` of the smallest quantile gap: `alpha + 1 == alpha` to machine precision, so the per-bin expected values are numerical noise. The distribution is effectively a point mass at `alpha*beta + loc`.
4. `bins` — reject any bin whose **pre-shift excess conditional mean** `<= 0` (a positive-mass bin of a shifted gamma must have a conditional mean strictly above `loc`). Guarding the *pre-shift* excess (not the shifted `expected_value <= loc`) is deliberate: for `loc > 0` a benign `loc + tiny_positive_excess == loc` rounding is otherwise misread as an underflow and would reject **correct, usable** output for shifted, heterogeneous APVDs (caught in review; e.g. `bins(mean=6000, std=4472, loc=5000, n_bins=100)`).

All four are reachable only through near-degenerate configs. The default equal-mass path and every realistic APVD are unaffected — accepted-input output is **bit-identical** to `main` (verified). A `Notes` caveat documents `scipy` `ppf` accuracy loss for very large `alpha` with deep-left-tail custom quantile edges (GAM-F3).

Closes #331

## Test plan

New regression tests in `tests/src/test_gamma.py` (a "Numerical-envelope guards" section). Each "must raise" test **fails on the pre-guard baseline** (`DID NOT RAISE`); the shifted-APVD acceptance test **fails on the naive `expected_value <= loc` guard** (raises) and passes on the pre-shift-excess guard; and a further test pins that realistic configs (default, shifted, 250/1000-bin, custom quantile edges) are still accepted with strictly in-bin expected values.

- `env UV_PROJECT_ENVIRONMENT=.venv-claude uv run -q pytest tests/src/test_gamma.py` — **68 passed**
- gamma-consuming suites (advection, residence_time, fraction_explained, diffusion, deposition, logremoval, diffusion_fast) — **832 passed**, no regressions
- `ruff format` + `ruff check` clean; `ty check` clean
- accepted-input output verified **bit-identical** to `main` (a pure additive-guard change)

Reviewed by adversarial physics-math and test agents: the physics pass flagged and this PR fixes the `loc>0` guard-4 false positive (verified against a 60-digit `mpmath` oracle); the test pass confirmed each guard's regression test fails on the pre-fix baseline and is individually load-bearing.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
