### PR TITLE
perf(advection): raise _WEIGHT_BUILD_BLOCK to 1_000_000

### DIFF
--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -18,9 +18,9 @@ from gwtransport.utils import cumulative_flow_volume
 
 # Target number of (streamtube x cout-bin) pairs per tile in the banded weight build. The
 # per-tile working set is O(_WEIGHT_BUILD_BLOCK x band), so peak memory is bounded
-# independent of record length; chosen to keep the build under ~30 MB while spanning most
+# independent of record length; chosen to keep the build under ~300 MB while spanning most
 # records in one or a few tiles. See _infiltration_to_extraction_weights.
-_WEIGHT_BUILD_BLOCK = 100_000
+_WEIGHT_BUILD_BLOCK = 1_000_000
 
 
 def _infiltration_to_extraction_weights(


### PR DESCRIPTION
## Summary

Raises the banded weight-build tiling constant `_WEIGHT_BUILD_BLOCK` in `src/gwtransport/advection_utils.py` from `100_000` to `1_000_000`, and updates the adjacent comment (~30 MB -> ~300 MB). The per-tile working set is O(`_WEIGHT_BUILD_BLOCK` x band), so this raises the bounded peak-memory ceiling of the weight build from roughly 30 MB to roughly 300 MB, letting most real records fit in one or a few tiles and cutting Python-level tiling iterations. The change is numerically inert: tiling granularity never affects the computed weights.

Closes #267

## Test plan

- `pytest tests/src/test_advection.py -q` — 145 passed (includes the tiling-equivalence test that monkeypatches `_WEIGHT_BUILD_BLOCK` directly, so it is independent of the default value).
- Sanity check of intended effect: on a 4000-bin record with 250 pore volumes, the old constant builds the weights in 10 tiles (block=400), the new constant in 1 tile (block=4000); `_infiltration_to_extraction_weights` outputs are byte-identical (`np.testing.assert_array_equal`) between the two constants.
- `ruff format --check` / `ruff check` clean; `ty check src/gwtransport/advection_utils.py` clean.

## Contributor License Agreement

- [ ] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.