### PR TITLE
fix(diffusion): remove zero-residence edge mask that broke mass conservation on coarse cout grids

### DIFF
--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -660,15 +660,11 @@ def _infiltration_to_extraction_coeff_matrix(
     n_cin_bins = len(flow)
     accumulated_coeff = np.zeros((n_cout_bins, n_cin_bins))
 
-    # Determine when infiltration has occurred: cout_tedge must be >= tedge (infiltration time)
-    isactive = cout_tedges.to_numpy()[:, None] >= tedges.to_numpy()[None, :]
-
     # Loop over each pore volume
     for i_pv in range(len(aquifer_pore_volumes)):
         r_vpv = retardation_factor * aquifer_pore_volumes[i_pv]
 
         delta_volume = cumulative_volume_at_cout_tedges[:, None] - cumulative_volume_at_cin_tedges[None, :] - r_vpv
-        delta_volume[~isactive] = np.nan
 
         step_widths = delta_volume / r_vpv * streamline_length[i_pv]
 
@@ -683,12 +679,7 @@ def _infiltration_to_extraction_coeff_matrix(
             streamline_len=streamline_length[i_pv],
         )
 
-        frac_start = frac[:, :-1]
-        frac_end = frac[:, 1:]
-        frac_end_filled = np.where(np.isnan(frac_end) & ~np.isnan(frac_start), 0.0, frac_end)
-        coeff = frac_start - frac_end_filled
-
-        accumulated_coeff += coeff
+        accumulated_coeff += frac[:, :-1] - frac[:, 1:]
 
     coeff_matrix_filled = np.nan_to_num(accumulated_coeff / len(aquifer_pore_volumes), nan=0.0)
 

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -6,6 +6,7 @@ import pytest
 from scipy import integrate, special
 
 from gwtransport import gamma as gamma_utils
+from gwtransport._time import tedges_to_days
 from gwtransport.advection import (
     extraction_to_infiltration as advection_e2i,
 )
@@ -2339,3 +2340,58 @@ def test_cout_tedges_unit_mismatch_matches_aligned():
 
     assert np.isfinite(mismatched).sum() == np.isfinite(aligned).sum() > 0
     np.testing.assert_array_equal(mismatched, aligned)
+
+
+@pytest.mark.parametrize("offset_days", range(10))
+def test_coarse_cout_grid_conserves_pulse_mass(offset_days):
+    """Coarse cout bins conserve pulse mass for every grid alignment.
+
+    Regression for the zero-residence edge mask in
+    ``_infiltration_to_extraction_coeff_matrix``: with cout bins (10 d) wider
+    than the residence time (RT = R * V_pore / Q = 5 d), the mask NaN-ed out
+    cells the causality-aware quadrature fills correctly, so depending on the
+    grid offset the pulse mass was silently deleted (ratio 0) or amplified
+    (ratio 5). The oracle is the exact column-sum invariant
+    ``integral Q c_out dt = integral Q c_in dt`` (Kreft & Zuber, 1978, Eq. 1),
+    checked against the input mass computed from first principles.
+    """
+    n_days = 60
+    flow_rate = 100.0
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    flow = np.full(n_days, flow_rate)
+    cin = np.zeros(n_days)
+    cin[20] = 1.0  # 1-day pulse => mass_in = Q * 1 * 1 day = 100
+    # 5 x 10-day bins, staying inside the 60-day flow record for every offset so the
+    # advection reference has no NaN bins; the breakthrough (days 25-26) is fully captured.
+    cout_tedges = pd.date_range(tedges[0] + pd.Timedelta(days=offset_days), periods=6, freq="10D")
+    kwargs = {
+        "cin": cin,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([500.0]),  # RT = 5 days
+        "streamline_length": np.array([100.0]),
+        "retardation_factor": 1.0,
+    }
+
+    dt_days = np.diff(tedges_to_days(cout_tedges))
+    mass_in = flow_rate * cin.sum() * 1.0  # Q * c * dt
+
+    # Pure-advection limit: mass conservation and exact agreement with the advection module.
+    cout = infiltration_to_extraction(molecular_diffusivity=0.0, longitudinal_dispersivity=0.0, **kwargs)
+    assert not np.any(np.isnan(cout))
+    np.testing.assert_allclose(np.sum(flow_rate * cout * dt_days), mass_in, rtol=1e-12)
+    cout_adv = advection_i2e(
+        cin=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=cout_tedges,
+        aquifer_pore_volumes=np.array([500.0]),
+        retardation_factor=1.0,
+    )
+    np.testing.assert_allclose(cout, cout_adv, rtol=1e-14, atol=1e-16)
+
+    # Dispersive regime: the Kreft-Zuber flux concentration keeps the invariant exact.
+    cout_disp = infiltration_to_extraction(molecular_diffusivity=0.02, longitudinal_dispersivity=1.0, **kwargs)
+    assert not np.any(np.isnan(cout_disp))
+    np.testing.assert_allclose(np.sum(flow_rate * cout_disp * dt_days), mass_in, rtol=1e-10)


### PR DESCRIPTION
## Summary

The dense diffusion module (the package's reference oracle) silently violated mass conservation when `cout_tedges` is coarser than the flow grid and an output bin is wider than a streamtube residence time `RT = R * V_pore / Q`. Root cause: the `isactive` zero-residence edge mask in `_infiltration_to_extraction_coeff_matrix` NaN-ed out cells that the causality-aware quadrature `_cfrac_mean_volume` fills correctly — its integration lower bound `max(V_lo, V_cin)` already enforces `frac = 0` before front arrival — and the ad-hoc `frac_end` NaN->0 patch compounded the error at bin boundaries. For a pulse with V=500, Q=100, R=1 (RT=5 d) on 10-day cout bins, 4/10 grid offsets deleted the whole pulse (mass ratio 0) and 1/10 amplified it 5x, while the sibling advection module stayed exact.

Fix: delete the mask and the dead NaN-fill patch; the final `np.nan_to_num` remains the sole NaN guard. Matched-grid results are bit-identical before and after (verified on 4 parameter combinations incl. R=1.7, two pore volumes, zero and nonzero D_m/alpha_L).

## Test plan

- New regression `test_coarse_cout_grid_conserves_pulse_mass`, parametrized over all 10 grid offsets of 10-day cout bins against a daily flow grid. Oracle is the exact column-sum invariant `integral Q c_out dt = integral Q c_in dt` (Kreft & Zuber, 1978, Eq. 1) computed from first principles, plus exact agreement with `advection.infiltration_to_extraction` in the D_m=alpha_L=0 limit, plus the mass invariant in the dispersive regime. Confirmed 8/10 parametrizations FAIL on unchanged origin/main (mass ratio 0 or 5, or mass placed in the wrong bin) and all pass with the fix.
- `pytest tests/src/test_diffusion.py`: 133 passed.
- `pytest tests/src/test_diffusion_fast.py tests/src/test_diffusion_fast_fast.py`: 287 passed.
- `ruff format`, `ruff check`, `ty check` clean on changed files.

Closes #305

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.