### PR TITLE
fix(fronttracking): make interior zero-flow (pump-off) bins transport-invisible

### DIFF
--- a/src/gwtransport/fronttracking/math.py
+++ b/src/gwtransport/fronttracking/math.py
@@ -1249,7 +1249,8 @@ def compute_first_front_arrival_theta(
     -------
     theta_first_arrival : float
         Cumulative-flow θ at which ``c_first`` is fully present at the outlet
-        [m³]. Returns ``np.inf`` only if ``cin`` is identically zero.
+        [m³]. Returns ``np.inf`` only if no water-carrying (positive θ-width)
+        bin has nonzero ``cin``.
 
     Examples
     --------
@@ -1262,7 +1263,9 @@ def compute_first_front_arrival_theta(
     >>> bool(np.isclose(theta_first, 100.0 + 500.0 * 2.0))  # θ_emit + V·R
     True
     """
-    nonzero_indices = np.where(cin > 0)[0]
+    # Zero-flow (pump-off) bins have zero θ-width and emit no wave (the solver
+    # skips them), so they cannot be the first arrival either.
+    nonzero_indices = np.where((cin > 0) & (np.diff(theta_edges) > 0))[0]
     if len(nonzero_indices) == 0:
         return float(np.inf)
 

--- a/src/gwtransport/fronttracking/solver.py
+++ b/src/gwtransport/fronttracking/solver.py
@@ -289,6 +289,13 @@ class FrontTracker:
         theta_edges = self.state.theta_edges
 
         for i in range(len(self.state.cin)):
+            # A zero-flow (pump-off) bin carries no water: its θ-interval has zero
+            # width, so it is transport-invisible. Skipping it carries the inlet
+            # step through the gap (effective transition c_before_gap → c_after_gap)
+            # instead of emitting coincident spurious waves at the degenerate θ.
+            if theta_edges[i + 1] <= theta_edges[i]:
+                continue
+
             c_new = float(self.state.cin[i])
 
             if abs(c_new - c_prev) > EPSILON_CONCENTRATION:

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -27,7 +27,9 @@ from gwtransport.advection_utils import (
 from gwtransport.advection_utils import (
     _resolve_spinup_mask as _banded_mask,
 )
-from gwtransport.fronttracking.math import ConstantRetardation
+from gwtransport.fronttracking.math import ConstantRetardation, FreundlichSorption, LangmuirSorption
+from gwtransport.fronttracking.output import compute_domain_mass
+from gwtransport.fronttracking.solver import FrontTracker
 from gwtransport.utils import (
     compute_time_edges,
     cumulative_flow_volume,
@@ -4520,3 +4522,108 @@ def test_extraction_to_infiltration_negative_pore_volume_raises():
             cout_tedges=tedges,
             aquifer_pore_volumes=np.array([-300.0]),
         )
+
+
+# Issue #309: an interior zero-flow (pump-off) bin must be transport-invisible.
+# Oracle: physically deleting the zero-flow bins from the record leaves the
+# θ-history (cumulative flow) of every water-carrying bin unchanged, and the
+# front-tracking transport depends on θ only — so cout of the water-carrying
+# bins must match the gap-free run bin-for-bin.
+_PUMP_OFF_SORPTION_KWARGS = [
+    pytest.param({"retardation_factor": 2.0}, id="constant-retardation"),
+    pytest.param(
+        {"freundlich_k": 0.01, "freundlich_n": 2.0, "bulk_density": 1500.0, "porosity": 0.3},
+        id="freundlich",
+    ),
+    pytest.param(
+        {"langmuir_s_max": 1.0, "langmuir_k_l": 1.0, "bulk_density": 1500.0, "porosity": 0.3},
+        id="langmuir",
+    ),
+]
+
+
+@pytest.mark.parametrize("c_gap", [5.0, 0.0], ids=["nonzero-gap-cin", "zero-gap-cin"])
+@pytest.mark.parametrize("sorption_kwargs", _PUMP_OFF_SORPTION_KWARGS)
+def test_nonlinear_sorption_interior_zero_flow_gap_matches_deleted_gap(sorption_kwargs, c_gap):
+    """Interior pump-off bins (flow=0) must not alter cout of the water-carrying bins."""
+    n = 40
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    gap = slice(20, 24)
+    flow[gap] = 0.0
+    cin = np.full(n, 8.0)
+    cin[gap] = c_gap
+    cin[24:] = 3.0
+
+    keep = np.ones(n, dtype=bool)
+    keep[gap] = False
+    tedges_nogap = pd.date_range("2020-01-01", periods=int(keep.sum()) + 1, freq="D")
+
+    cout_gap, _ = infiltration_to_extraction_nonlinear_sorption(
+        cin=cin,
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        aquifer_pore_volumes=[200.0],
+        **sorption_kwargs,
+    )
+    cout_nogap, _ = infiltration_to_extraction_nonlinear_sorption(
+        cin=cin[keep],
+        flow=flow[keep],
+        tedges=tedges_nogap,
+        cout_tedges=tedges_nogap,
+        aquifer_pore_volumes=[200.0],
+        **sorption_kwargs,
+    )
+
+    # The kept bins of the gap run cover exactly the same θ-intervals as the
+    # gap-free run, so the flow-weighted bin averages must agree to roundoff.
+    np.testing.assert_allclose(cout_gap[keep], cout_nogap, rtol=0.0, atol=1e-12)
+
+
+@pytest.mark.parametrize("c_gap", [5.0, 0.0], ids=["nonzero-gap-cin", "zero-gap-cin"])
+@pytest.mark.parametrize(
+    "sorption",
+    [
+        pytest.param(ConstantRetardation(retardation_factor=2.0), id="constant-retardation"),
+        pytest.param(FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3), id="freundlich"),
+        pytest.param(LangmuirSorption(s_max=1.0, k_l=1.0, bulk_density=1500.0, porosity=0.3), id="langmuir"),
+    ],
+)
+def test_fronttracking_domain_mass_interior_zero_flow_gap_matches_deleted_gap(sorption, c_gap):
+    """Stored mass in the domain must be identical with and without the pump-off gap."""
+    n = 40
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    gap = slice(20, 24)
+    flow[gap] = 0.0
+    cin = np.full(n, 8.0)
+    cin[gap] = c_gap
+    cin[24:] = 3.0
+
+    keep = np.ones(n, dtype=bool)
+    keep[gap] = False
+    tedges_nogap = pd.date_range("2020-01-01", periods=int(keep.sum()) + 1, freq="D")
+
+    aquifer_pore_volume = 200.0
+    tracker_gap = FrontTracker(
+        cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=aquifer_pore_volume, sorption=sorption
+    )
+    tracker_gap.run()
+    tracker_nogap = FrontTracker(
+        cin=cin[keep],
+        flow=flow[keep],
+        tedges=tedges_nogap,
+        aquifer_pore_volume=aquifer_pore_volume,
+        sorption=sorption,
+    )
+    tracker_nogap.run()
+
+    for theta in [500.0, 1500.0, 2100.0, 3000.0, 3600.0]:
+        mass_gap = compute_domain_mass(
+            theta=theta, v_outlet=aquifer_pore_volume, waves=tracker_gap.state.waves, sorption=sorption
+        )
+        mass_nogap = compute_domain_mass(
+            theta=theta, v_outlet=aquifer_pore_volume, waves=tracker_nogap.state.waves, sorption=sorption
+        )
+        np.testing.assert_allclose(mass_gap, mass_nogap, rtol=0.0, atol=1e-9)


### PR DESCRIPTION
## Summary

`infiltration_to_extraction_nonlinear_sorption` silently returned wrong `cout` when the flow record contained an interior zero-flow (pump-off) bin across which `cin` changes. A zero-flow bin carries no water, so its θ-interval has zero width (`theta_edges[i] == theta_edges[i+1]`), yet `FrontTracker._initialize_inlet_waves` still emitted a wave for the step into and out of the gap — two coincident spurious fronts at the degenerate θ. The resulting face made `compute_domain_mass` over-count stored mass: ConstantRetardation mis-attributed mass between the bins straddling the gap (an outlet bin read `c_pre + c_post`), and Freundlich/Langmuir either fabricated nonzero pre-breakthrough concentration or tripped the unresolved-interaction `RuntimeError`.

Fix (at the source, in the solver):

- `FrontTracker._initialize_inlet_waves` now skips bins with zero θ-width, carrying the inlet step through the gap so the effective transition is `c_before_gap → c_after_gap`.
- `compute_first_front_arrival_theta` excludes the same zero-width bins, so consumers see the identical collapsed inlet history (docstring updated accordingly).

Positive-flow inputs never hit the new branch: output is bit-identical to `main` for records without zero-flow bins (verified for ConstantRetardation, Freundlich n=2, Langmuir, incl. `theta_first_arrival`).

## Test plan

- New regression tests in `tests/src/test_advection.py` (delete-gap oracle, independent of the implementation): a 40-day record with `flow[20:24] = 0` must reproduce, bin-for-bin (`atol=1e-12`), the same record with the zero-flow bins physically removed — transport depends on θ only. Parametrized over all three sorption models × two `cin` patterns (distinct nonzero `c_pre`/`c_gap`/`c_post`, and `c_gap = 0` with nonzero distinct neighbours). A second test asserts `compute_domain_mass` equality between the gap and no-gap trackers at several θ.
- Baseline (`origin/main`): all 12 parametrizations fail — wrong `cout` (max error 0.7–3.0 concentration units) or `RuntimeError` from the unresolved-interaction tripwire. With the fix: all pass.
- Full targeted suites pass: `tests/src/test_advection.py`, `test_advection_roundtrip.py`, all `test_front_tracking_*.py`, `test_fronttracking_plot.py`, `test_percolation.py` (736 passed, 2 skipped).
- `ruff format`, `ruff check`, and `ty check` clean on the changed files.

Closes #309

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.