### PR TITLE
feat(arrival): estimators for first-arrival, time-to-threshold, peak, and time-to-peak

### DIFF
--- a/docs/source/api/modules.rst
+++ b/docs/source/api/modules.rst
@@ -14,6 +14,14 @@ advection
    :undoc-members:
    :show-inheritance:
 
+arrival
+=======
+
+.. automodule:: gwtransport.arrival
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 deposition
 ==========
 

--- a/src/gwtransport/arrival.py
+++ b/src/gwtransport/arrival.py
@@ -1,0 +1,175 @@
+"""
+Arrival metrics for extraction-concentration breakthrough curves.
+
+This module reduces a modeled or observed extraction-concentration series (``cout``)
+to the arrival metrics an operator asks for during a contamination event:
+
+- :func:`first_arrival` -- earliest time the concentration rises above a detection level.
+- :func:`time_to_threshold` -- first time the concentration crosses a given threshold
+  (e.g. a regulatory limit).
+- :func:`peak_concentration` -- maximum concentration of the series.
+- :func:`time_to_peak` -- time at which the maximum occurs.
+
+Bin-edge convention
+-------------------
+``cout`` follows the package-wide bin-edge pattern: ``n`` values that are flow-weighted
+bin averages, constant over the intervals ``[tedges[i], tedges[i+1])`` defined by the
+``n + 1`` edges in ``tedges``. For crossing-time estimates each bin average is attributed
+to its bin center, and the crossing time is linearly interpolated between the two bin
+centers that straddle the level -- it is not snapped to a bin edge. When the level is
+already exceeded in the first bin, or the bin preceding the crossing holds NaN, no
+straddling pair exists; the left edge of the exceeding bin is returned because under the
+piecewise-constant convention the concentration is above the level throughout that bin.
+
+This file is part of gwtransport which is released under AGPL-3.0 license.
+See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
+"""
+
+import numpy as np
+import numpy.typing as npt
+import pandas as pd
+from pandas.api.typing import NaTType
+
+from gwtransport._validation import _validate_tedges_parity
+
+
+def _crossing_time(*, cout: npt.ArrayLike, tedges: pd.DatetimeIndex, level: float) -> pd.Timestamp | NaTType:
+    """Interpolate the first time ``cout`` rises strictly above ``level``.
+
+    Parameters
+    ----------
+    cout : array-like
+        Concentration series, constant per bin (n values). NaN entries are treated
+        as not exceeding ``level``.
+    tedges : DatetimeIndex
+        Time bin edges (n+1 edges for n values).
+    level : float
+        Level to cross.
+
+    Returns
+    -------
+    Timestamp
+        Crossing time; ``pd.NaT`` if ``cout`` never exceeds ``level``.
+    """
+    cout = np.asarray(cout, dtype=float)
+    _validate_tedges_parity(tedges, cout, tedges_name="tedges", values_name="cout")
+
+    above = cout > level  # NaN compares False
+    if not above.any():
+        return pd.NaT
+    i = int(np.argmax(above))
+    if i == 0 or not np.isfinite(cout[i - 1]):
+        # No straddling pair to interpolate between; the whole bin i is above level.
+        return tedges[i]
+    centers = tedges[:-1] + (tedges[1:] - tedges[:-1]) / 2
+    frac = (level - cout[i - 1]) / (cout[i] - cout[i - 1])
+    return centers[i - 1] + frac * (centers[i] - centers[i - 1])
+
+
+def first_arrival(*, cout: npt.ArrayLike, tedges: pd.DatetimeIndex, level: float = 0.0) -> pd.Timestamp | NaTType:
+    """Earliest time the concentration rises strictly above a detection level.
+
+    The crossing time is linearly interpolated between the centers of the bin that
+    first exceeds ``level`` and the preceding bin (see module docstring for the
+    bin-center attribution and its edge cases).
+
+    Parameters
+    ----------
+    cout : array-like
+        Concentration of the extracted water, constant per bin (n values).
+        NaN entries are treated as not exceeding ``level``.
+    tedges : DatetimeIndex
+        Time bin edges (n+1 edges for n values).
+    level : float, optional
+        Detection level (same units as ``cout``). Default 0.0.
+
+    Returns
+    -------
+    Timestamp
+        First-arrival time; ``pd.NaT`` if ``cout`` never exceeds ``level``.
+
+    See Also
+    --------
+    time_to_threshold : Same crossing estimate for a regulatory threshold.
+    time_to_peak : Time at which the maximum concentration occurs.
+    """
+    return _crossing_time(cout=cout, tedges=tedges, level=level)
+
+
+def time_to_threshold(*, cout: npt.ArrayLike, tedges: pd.DatetimeIndex, threshold: float) -> pd.Timestamp | NaTType:
+    """First time the concentration rises strictly above a threshold.
+
+    The crossing time is linearly interpolated between the centers of the bin that
+    first exceeds ``threshold`` and the preceding bin (see module docstring for the
+    bin-center attribution and its edge cases).
+
+    Parameters
+    ----------
+    cout : array-like
+        Concentration of the extracted water, constant per bin (n values).
+        NaN entries are treated as not exceeding ``threshold``.
+    tedges : DatetimeIndex
+        Time bin edges (n+1 edges for n values).
+    threshold : float
+        Threshold concentration (same units as ``cout``), e.g. a regulatory limit.
+
+    Returns
+    -------
+    Timestamp
+        Threshold-crossing time; ``pd.NaT`` if ``cout`` never exceeds ``threshold``.
+
+    See Also
+    --------
+    first_arrival : Same crossing estimate for a small detection level.
+    peak_concentration : Maximum concentration of the series.
+    """
+    return _crossing_time(cout=cout, tedges=tedges, level=threshold)
+
+
+def peak_concentration(*, cout: npt.ArrayLike) -> float:
+    """Maximum concentration of the series, ignoring NaN.
+
+    Parameters
+    ----------
+    cout : array-like
+        Concentration of the extracted water, constant per bin (n values).
+
+    Returns
+    -------
+    float
+        Maximum of ``cout``.
+
+    See Also
+    --------
+    time_to_peak : Time at which the maximum occurs.
+    """
+    return float(np.nanmax(np.asarray(cout, dtype=float)))
+
+
+def time_to_peak(*, cout: npt.ArrayLike, tedges: pd.DatetimeIndex) -> pd.Timestamp:
+    """Time at which the maximum concentration occurs, ignoring NaN.
+
+    The peak is attributed to the center of the bin holding the first occurrence
+    of the maximum, consistent with ``cout`` being a flow-weighted bin average.
+
+    Parameters
+    ----------
+    cout : array-like
+        Concentration of the extracted water, constant per bin (n values).
+    tedges : DatetimeIndex
+        Time bin edges (n+1 edges for n values).
+
+    Returns
+    -------
+    Timestamp
+        Bin-center timestamp of the maximum of ``cout``.
+
+    See Also
+    --------
+    peak_concentration : Maximum concentration of the series.
+    first_arrival : Earliest time the concentration exceeds a detection level.
+    """
+    cout = np.asarray(cout, dtype=float)
+    _validate_tedges_parity(tedges, cout, tedges_name="tedges", values_name="cout")
+    i = int(np.nanargmax(cout))
+    return tedges[i] + (tedges[i + 1] - tedges[i]) / 2

--- a/tests/src/test_arrival.py
+++ b/tests/src/test_arrival.py
@@ -1,0 +1,95 @@
+"""Tests for :mod:`gwtransport.arrival` against hand-derived crossing times.
+
+All expected timestamps are derived by hand from the bin-center attribution:
+bin centers of daily bins starting 2020-01-01 fall at 12:00 of each day, and a
+linear interpolation between two straddling centers is computed analytically.
+"""
+
+import importlib
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gwtransport.arrival import first_arrival, peak_concentration, time_to_peak, time_to_threshold
+
+TEDGES_DAILY = pd.date_range("2020-01-01", periods=5, freq="D")  # 4 daily bins
+RAMP = np.array([0.0, 0.0, 2.0, 4.0])  # centers: 01-01 12:00, 01-02 12:00, 01-03 12:00, 01-04 12:00
+
+
+def test_module_importable_from_package():
+    arrival = importlib.import_module("gwtransport.arrival")
+
+    assert callable(arrival.first_arrival)
+
+
+def test_peak_concentration_is_max():
+    np.testing.assert_allclose(peak_concentration(cout=RAMP), 4.0)
+
+
+def test_peak_concentration_ignores_nan():
+    np.testing.assert_allclose(peak_concentration(cout=[np.nan, 5.0, 2.0]), 5.0)
+
+
+def test_time_to_peak_is_last_bin_center():
+    # Maximum (4.0) sits in the last daily bin [2020-01-04, 2020-01-05) -> center 2020-01-04 12:00.
+    assert time_to_peak(cout=RAMP, tedges=TEDGES_DAILY) == pd.Timestamp("2020-01-04 12:00:00")
+
+
+def test_time_to_peak_ignores_nan():
+    tedges = pd.date_range("2020-01-01", periods=4, freq="D")
+    assert time_to_peak(cout=[np.nan, 5.0, 2.0], tedges=tedges) == pd.Timestamp("2020-01-02 12:00:00")
+
+
+def test_time_to_threshold_interpolates_within_bin():
+    # Straddling centers: 2020-01-02 12:00 (cout=0) and 2020-01-03 12:00 (cout=2).
+    # threshold=1 -> fraction (1-0)/(2-0) = 1/2 of the 24 h center spacing -> 2020-01-03 00:00.
+    crossing = time_to_threshold(cout=RAMP, tedges=TEDGES_DAILY, threshold=1.0)
+    np.testing.assert_allclose(crossing.value, pd.Timestamp("2020-01-03 00:00:00").value)
+
+
+def test_time_to_threshold_uneven_bins():
+    # Bin widths 1, 2, 4, 8 days -> centers 01-01 12:00, 01-03 00:00, 01-06 00:00, 01-12 00:00.
+    tedges = pd.DatetimeIndex(["2020-01-01", "2020-01-02", "2020-01-04", "2020-01-08", "2020-01-16"])
+    cout = [0.0, 1.0, 4.0, 2.0]
+    # First bin above threshold=2 is bin 2; fraction (2-1)/(4-1) = 1/3 of the 3-day
+    # spacing between centers 01-03 and 01-06 -> 2020-01-04 00:00.
+    crossing = time_to_threshold(cout=cout, tedges=tedges, threshold=2.0)
+    np.testing.assert_allclose(crossing.value, pd.Timestamp("2020-01-04 00:00:00").value)
+
+
+def test_first_arrival_default_level_zero():
+    # First bin strictly above 0 is bin 2; interpolation between (0, 2) at level 0
+    # lands on the previous bin center, 2020-01-02 12:00.
+    arrival_time = first_arrival(cout=RAMP, tedges=TEDGES_DAILY)
+    np.testing.assert_allclose(arrival_time.value, pd.Timestamp("2020-01-02 12:00:00").value)
+
+
+def test_first_arrival_matches_time_to_threshold():
+    # Both share one crossing path: identical results for identical levels.
+    assert first_arrival(cout=RAMP, tedges=TEDGES_DAILY, level=1.0) == time_to_threshold(
+        cout=RAMP, tedges=TEDGES_DAILY, threshold=1.0
+    )
+
+
+def test_crossing_never_exceeded_returns_nat():
+    assert time_to_threshold(cout=RAMP, tedges=TEDGES_DAILY, threshold=10.0) is pd.NaT
+    assert first_arrival(cout=RAMP, tedges=TEDGES_DAILY, level=4.0) is pd.NaT  # strict: 4 > 4 is False
+
+
+def test_crossing_in_first_bin_returns_left_edge():
+    # cout is above the level throughout the first bin -> earliest time in the record.
+    assert time_to_threshold(cout=[3.0, 4.0, 5.0, 6.0], tedges=TEDGES_DAILY, threshold=1.0) == TEDGES_DAILY[0]
+
+
+def test_crossing_after_nan_returns_left_edge_of_exceeding_bin():
+    # NaN in the preceding bin: no straddling pair, bin 2 is above throughout -> its left edge.
+    crossing = time_to_threshold(cout=[0.0, np.nan, 2.0, 4.0], tedges=TEDGES_DAILY, threshold=1.0)
+    assert crossing == TEDGES_DAILY[2]
+
+
+def test_tedges_parity_validated():
+    with pytest.raises(ValueError, match="tedges must have one more element than cout"):
+        time_to_threshold(cout=RAMP, tedges=TEDGES_DAILY[:-1], threshold=1.0)
+    with pytest.raises(ValueError, match="tedges must have one more element than cout"):
+        time_to_peak(cout=RAMP, tedges=TEDGES_DAILY[:-1])


### PR DESCRIPTION
## Summary

Adds `src/gwtransport/arrival.py`, closing the gap between the README promise ("Forecast contaminant arrival times") and the API: no public function turned a `cout` breakthrough series into arrival metrics.

Four keyword-only functions operating on `cout` (n flow-weighted bin averages) + `tedges` (n+1 `DatetimeIndex` edges):

- `first_arrival(*, cout, tedges, level=0.0)` — earliest time `cout` rises strictly above a detection level.
- `time_to_threshold(*, cout, tedges, threshold)` — first crossing of a user threshold (e.g. regulatory limit).
- `peak_concentration(*, cout)` — maximum of the series (NaN-ignoring).
- `time_to_peak(*, cout, tedges)` — bin-center timestamp of the maximum.

`first_arrival` and `time_to_threshold` share one crossing helper (one-path rule): each bin average is attributed to its bin center and the crossing time is linearly interpolated between the two straddling centers, not snapped to a bin edge. When no straddling pair exists (level already exceeded in the first bin, or NaN in the preceding bin), the left edge of the exceeding bin is returned, since under the piecewise-constant convention the concentration is above the level throughout that bin. Never-crossed returns `pd.NaT`. Bin-edge parity is validated via the shared `_validation` atom. The module is added to the Sphinx API listing.

Closes #320

## Test plan

- `tests/src/test_arrival.py` (13 tests) against hand-derived values: ramp `cout=[0,0,2,4]` over 4 daily bins — `time_to_threshold(threshold=1)` equals the analytically interpolated `2020-01-03 00:00` (assert_allclose on ns values), `peak_concentration==4`, `time_to_peak==` last bin center, `first_arrival(level=0)==` interpolated 0→2 crossing; uneven-bin-width interpolation (1/2/4/8-day bins, 1/3-fraction crossing); NaT when never exceeded (incl. strict-inequality boundary); first-bin and NaN-predecessor edge cases; NaN-ignoring peak; parity `ValueError`; importability from `gwtransport`.
- `pytest tests/src/test_arrival.py tests/src/test_validation.py` — 46 passed.
- `ruff format` / `ruff check` clean; `ty check src/gwtransport/arrival.py` clean.

## Contributor License Agreement

- [ ] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.