### PR TITLE
fix(fronttracking): render DSW fan in breakthrough plot; clamp outlet crossings to wave lifetime; c_fan_tail apex in legacy fan integral

### DIFF
--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -273,7 +273,9 @@ def identify_outlet_segments(
             # whose c follows the self-similar profile and asymptotes to the
             # fan's tail concentration.
             theta_cross = wave.outlet_crossing_theta(v_outlet)
-            if theta_cross is None:
+            if theta_cross is None or theta_cross >= wave.theta_deactivation:
+                # The extrapolated crossing postdates the wave's death (a
+                # collision handed the front to a successor): spurious.
                 continue
             if theta_cross <= theta_start:
                 # Outlet already inside the fan at theta_start.
@@ -301,7 +303,7 @@ def identify_outlet_segments(
                 tail_speed = wave.tail_speed()
                 if tail_speed > EPSILON_VELOCITY:
                     theta_cross = wave.theta_start + (v_outlet - wave.v_start) / tail_speed
-                    if theta_start < theta_cross <= theta_end:
+                    if theta_start < theta_cross <= theta_end and theta_cross < wave.theta_deactivation:
                         outlet_events.append({
                             "theta": theta_cross,
                             "wave": wave,
@@ -310,11 +312,15 @@ def identify_outlet_segments(
                         })
                 continue
 
-            # Head crossing
+            # Head crossing. Crossings past the wave's death are extrapolation
+            # artifacts (the fan was handed to a successor, e.g. a
+            # DecayingShockWave, whose own crossing covers the outlet): clamp
+            # every crossing to ``theta_cross < theta_deactivation``, per
+            # ``was_active_at`` semantics.
             head_speed = wave.head_speed()
             if head_speed > EPSILON_VELOCITY and wave.v_start < v_outlet:
                 theta_cross = wave.theta_start + (v_outlet - wave.v_start) / head_speed
-                if theta_start <= theta_cross <= theta_end:
+                if theta_start <= theta_cross <= theta_end and theta_cross < wave.theta_deactivation:
                     outlet_events.append({
                         "theta": theta_cross,
                         "wave": wave,
@@ -326,7 +332,7 @@ def identify_outlet_segments(
             tail_speed = wave.tail_speed()
             if tail_speed > EPSILON_VELOCITY and wave.v_start < v_outlet:
                 theta_cross = wave.theta_start + (v_outlet - wave.v_start) / tail_speed
-                if theta_start <= theta_cross <= theta_end:
+                if theta_start <= theta_cross <= theta_end and theta_cross < wave.theta_deactivation:
                     outlet_events.append({
                         "theta": theta_cross,
                         "wave": wave,
@@ -570,7 +576,8 @@ def integrate_fan_exact(
     c_apex : float, optional
         Concentration on the constant side at the fan apex. For
         ``RarefactionWave`` this is ``raref.c_tail``; for
-        ``DecayingShockWave`` (decay_side='left') this is ``wave.c_fixed``.
+        ``DecayingShockWave`` (decay_side='left') this is ``wave.c_fan_tail``
+        (the plateau the outlet holds once the fan's far edge sweeps by).
         For ``c_apex > 0`` the fan formula extrapolates past the physical
         fan range; the integration is clamped at ``θ_tail`` (where
         ``c(θ_tail) = c_apex``) and the constant-c_apex region beyond
@@ -841,9 +848,14 @@ def compute_bin_averaged_concentration_exact(
                     c_mid = concentration_at_point(v_outlet, 0.5 * (seg_a + seg_b), waves, sorption)
                     total += c_mid * d
             elif seg["type"] == "decaying_fan":
+                # After the shock passes the outlet, the outlet sits inside the
+                # fan; once the fan's far edge (c = c_fan_tail) sweeps by, the
+                # concentration holds the c_fan_tail plateau (the reader's fan
+                # clamp) — NOT c_fixed, which is the state on the shock's other
+                # side and never reaches the outlet post-crossing.
                 w = seg["wave"]
                 total += integrate_fan_exact(
-                    w.theta_origin, w.v_origin, v_outlet, seg_a, seg_b, sorption, c_apex=w.c_fixed
+                    w.theta_origin, w.v_origin, v_outlet, seg_a, seg_b, sorption, c_apex=w.c_fan_tail
                 )
         c_avg[i] = total / dtheta_bin
     return c_avg

--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -262,13 +262,12 @@ def identify_outlet_segments(
     active_rarefactions_at_start: list[RarefactionWave | DecayingShockWave] = []
 
     for wave in waves:
-        # Retrospective filter: ``identify_outlet_segments`` is called over
-        # arbitrary [theta_start, theta_end] windows (e.g., plotting after the
-        # simulation ends). ``is_active`` is the wave's *current* (end-of-sim)
-        # state and skips waves that legitimately crossed v_outlet during the
-        # window but were later deactivated by a collision. Skip only if the
-        # wave's lifetime ended before the window started.
-        if wave.theta_deactivation <= theta_start:
+        # Lifetime filter, matching ``Wave.was_active_at``: skip waves that were never
+        # activated (``is_active=False`` with no recorded deactivation) or whose lifetime
+        # ended before the window starts. ``is_active`` alone is the end-of-simulation
+        # state and would also skip waves deactivated after an in-window crossing.
+        never_active = not wave.is_active and wave.theta_deactivation == float("inf")
+        if never_active or wave.theta_deactivation <= theta_start:
             continue
 
         if isinstance(wave, DecayingShockWave):

--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -248,6 +248,11 @@ def identify_outlet_segments(
     4. Handling rarefaction and decaying-fan profiles with θ-varying concentration.
 
     The segments completely partition the interval [theta_start, theta_end].
+
+    Every crossing is clamped to ``theta_cross < theta_deactivation``
+    (matching ``was_active_at`` semantics): a crossing extrapolated past a
+    wave's deactivation is an artifact — after a collision the front belongs
+    to the successor wave, whose own crossing covers the outlet.
     """
     # Find all waves that cross outlet in this θ-range
     outlet_events: list[dict] = []
@@ -274,8 +279,7 @@ def identify_outlet_segments(
             # fan's tail concentration.
             theta_cross = wave.outlet_crossing_theta(v_outlet)
             if theta_cross is None or theta_cross >= wave.theta_deactivation:
-                # The extrapolated crossing postdates the wave's death (a
-                # collision handed the front to a successor): spurious.
+                # Crossings at or after deactivation are spurious extrapolations.
                 continue
             if theta_cross <= theta_start:
                 # Outlet already inside the fan at theta_start.
@@ -312,11 +316,7 @@ def identify_outlet_segments(
                         })
                 continue
 
-            # Head crossing. Crossings past the wave's death are extrapolation
-            # artifacts (the fan was handed to a successor, e.g. a
-            # DecayingShockWave, whose own crossing covers the outlet): clamp
-            # every crossing to ``theta_cross < theta_deactivation``, per
-            # ``was_active_at`` semantics.
+            # Head crossing
             head_speed = wave.head_speed()
             if head_speed > EPSILON_VELOCITY and wave.v_start < v_outlet:
                 theta_cross = wave.theta_start + (v_outlet - wave.v_start) / head_speed
@@ -848,11 +848,7 @@ def compute_bin_averaged_concentration_exact(
                     c_mid = concentration_at_point(v_outlet, 0.5 * (seg_a + seg_b), waves, sorption)
                     total += c_mid * d
             elif seg["type"] == "decaying_fan":
-                # After the shock passes the outlet, the outlet sits inside the
-                # fan; once the fan's far edge (c = c_fan_tail) sweeps by, the
-                # concentration holds the c_fan_tail plateau (the reader's fan
-                # clamp) — NOT c_fixed, which is the state on the shock's other
-                # side and never reaches the outlet post-crossing.
+                # Outlet is inside the fan; past the fan's far edge c holds the c_fan_tail plateau.
                 w = seg["wave"]
                 total += integrate_fan_exact(
                     w.theta_origin, w.v_origin, v_outlet, seg_a, seg_b, sorption, c_apex=w.c_fan_tail

--- a/src/gwtransport/fronttracking/plot.py
+++ b/src/gwtransport/fronttracking/plot.py
@@ -21,7 +21,11 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from gwtransport._time import tedges_to_days
-from gwtransport.fronttracking.output import compute_breakthrough_curve, identify_outlet_segments
+from gwtransport.fronttracking.output import (
+    compute_breakthrough_curve,
+    concentration_at_point,
+    identify_outlet_segments,
+)
 from gwtransport.fronttracking.solver import FrontTrackerState
 from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
 from gwtransport.utils import step_plot_coords
@@ -423,6 +427,17 @@ def plot_breakthrough_curve(
                     c_raref[j] = c_fallback
 
             ax.plot(t_raref, c_raref, "b-", linewidth=2, label="Outlet concentration" if i == 0 else "")
+        elif segment["type"] == "decaying_fan":
+            # DecayingShockWave fan at the outlet: self-similar decay toward the
+            # fan-tail plateau. The face-sweep reader handles both the fan
+            # interior and the c_fan_tail plateau beyond the fan's edge.
+            t_fan = np.linspace(t_seg_start, t_seg_end, n_rarefaction_points)
+            theta_fan = state.theta_at_t_array(t_fan)
+            c_fan = np.array([
+                concentration_at_point(state.v_outlet, float(theta_j), state.waves, state.sorption)
+                for theta_j in theta_fan
+            ])
+            ax.plot(t_fan, c_fan, "b-", linewidth=2, label="Outlet concentration" if i == 0 else "")
 
     if t_first_arrival is not None and np.isfinite(t_first_arrival):
         ax.axvline(

--- a/src/gwtransport/fronttracking/plot.py
+++ b/src/gwtransport/fronttracking/plot.py
@@ -428,9 +428,8 @@ def plot_breakthrough_curve(
 
             ax.plot(t_raref, c_raref, "b-", linewidth=2, label="Outlet concentration" if i == 0 else "")
         elif segment["type"] == "decaying_fan":
-            # DecayingShockWave fan at the outlet: self-similar decay toward the
-            # fan-tail plateau. The face-sweep reader handles both the fan
-            # interior and the c_fan_tail plateau beyond the fan's edge.
+            # DecayingShockWave fan at the outlet: sample the reader, which covers
+            # both the fan interior and the c_fan_tail plateau beyond its edge.
             t_fan = np.linspace(t_seg_start, t_seg_end, n_rarefaction_points)
             theta_fan = state.theta_at_t_array(t_fan)
             c_fan = np.array([

--- a/tests/src/test_front_tracking_output.py
+++ b/tests/src/test_front_tracking_output.py
@@ -277,6 +277,140 @@ class TestIdentifyOutletSegments:
         # Should have 3 segments: [0, 1000] c=0, [1000, 1500] c=5, [1500, 2000] c=10.
         assert len(segments) == 3
 
+    def test_shock_deactivated_before_crossing_yields_no_segment(self):
+        """A shock deactivated mid-window never reaches the outlet -- no spurious crossing (issue #311).
+
+        The shock would cross v_outlet at θ_cross by straight-line extrapolation, but it was
+        deactivated (collision) at θ_deac < θ_cross, with θ_deac inside the query window so the
+        retrospective ``theta_deactivation <= theta_start`` filter does not remove it. The segment
+        list must not schedule the extrapolated crossing: the whole window stays at the downstream
+        state c=0, consistent with ``was_active_at`` and with ``concentration_at_point``. Today
+        this is guarded by ``find_outlet_crossing``'s ``is_active`` check; this test pins the
+        behavior so that guard cannot be removed without a ``theta_deactivation`` clamp.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        shock = ShockWave(theta_start=0.0, v_start=0.0, c_left=10.0, c_right=0.0, sorption=sorption, is_active=True)
+        v_outlet = 300.0
+        assert shock.speed is not None
+        theta_cross = v_outlet / shock.speed
+        shock.deactivate(0.5 * theta_cross)  # collision kills the wave halfway to the outlet
+        theta_end = 2.0 * theta_cross
+
+        segments = identify_outlet_segments(
+            theta_start=0.0, theta_end=theta_end, v_outlet=v_outlet, waves=[shock], sorption=sorption
+        )
+
+        # Independent check: the reader (which honors was_active_at) sees c=0 at the outlet
+        # for the entire window.
+        for theta_q in [0.25 * theta_cross, theta_cross, 1.5 * theta_cross]:
+            assert concentration_at_point(v_outlet, theta_q, [shock], sorption) == 0.0
+
+        assert all(seg["type"] == "constant" for seg in segments)
+        np.testing.assert_allclose([seg["concentration"] for seg in segments], 0.0)
+
+    def test_deactivated_rarefaction_does_not_mask_decaying_fan(self):
+        """A rarefaction consumed by a DSW must not schedule its extrapolated head crossing (issue #311).
+
+        Canonical Freundlich n=2 pulse: leading shock + trailing rarefaction merge into a
+        DecayingShockWave at θ≈525 (both parents deactivated). The dead rarefaction's head would
+        cross v_outlet=100 at θ≈1191 by extrapolation; scheduling it swallows the true structure:
+        constant c=0 until the DSW crossing at θ=3525, then the decaying fan. The reader
+        (``concentration_at_point``, post-#316 face sweep) is the independent oracle for the
+        pre-arrival plateau.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        n = 40
+        cin = np.array([0.0, 10.0, 10.0, 0.0] + [0.0] * (n - 4))
+        flow = np.full(n, 100.0)
+        tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+        tracker = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=100.0, sorption=sorption)
+        tracker.run()
+        state = tracker.state
+        waves = state.waves
+
+        raref = next(w for w in waves if isinstance(w, RarefactionWave))
+        dsw = next(w for w in waves if isinstance(w, DecayingShockWave))
+        assert not raref.is_active
+        theta_cross = dsw.outlet_crossing_theta(state.v_outlet)
+        assert theta_cross is not None
+        assert raref.theta_deactivation < theta_cross < state.theta_edges[-1]
+
+        segments = identify_outlet_segments(
+            theta_start=0.0,
+            theta_end=float(state.theta_edges[-1]),
+            v_outlet=state.v_outlet,
+            waves=waves,
+            sorption=sorption,
+        )
+
+        # No segment may come from the deactivated rarefaction.
+        assert not any(seg["type"] == "rarefaction" for seg in segments)
+        # The true structure: constant 0 up to the DSW crossing, then the decaying fan.
+        fan_segments = [seg for seg in segments if seg["type"] == "decaying_fan"]
+        assert len(fan_segments) == 1
+        np.testing.assert_allclose(fan_segments[0]["theta_start"], theta_cross, rtol=1e-12)
+        pre = [seg for seg in segments if seg["theta_end"] <= theta_cross + 1e-9]
+        assert pre, "expected a pre-arrival constant segment"
+        assert all(seg["type"] == "constant" for seg in pre)
+        np.testing.assert_allclose([seg["concentration"] for seg in pre], 0.0)
+
+
+class TestLegacyDecayingFanBinAverage:
+    """Legacy outlet-segment integration of a DSW fan clamps at c_fan_tail, not c_fixed (issue #311).
+
+    Hand-constructed Freundlich ``n=2``, ``c_fixed=0`` DecayingShockWave (closed-form trajectory,
+    same collision IC as the hand-derived wave test: apex at (V=0, θ=1000), K=1000/27) with a
+    nonzero fan-tail plateau ``c_fan_tail=0.5``. After the shock crosses the outlet the outlet
+    sits inside the fan; once the fan's far edge (c=c_fan_tail) passes, the concentration holds
+    the c_fan_tail plateau -- exactly what the post-#316 reader returns. The independent oracle is
+    the closed-form fan profile: with ``a = ρ_b·k_f/n_por = 50``, ``R(c) = 1 + (a/2)/√c``, the fan
+    at the outlet obeys ``R(c) = (θ-θ_origin)/Δv`` so ``c(θ) = (a/2)²/(r-1)²`` down to c_fan_tail,
+    and ``∫ c dθ = (a/2)²·Δv·[-(r-1)^{-1}]`` in closed form. ``c_apex=c_fixed=0`` instead
+    extrapolates the fan below the plateau and undercounts by ~10%.
+    """
+
+    def test_bin_average_matches_closed_form_plateau_oracle(self):
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        a_half = 0.5 * sorption.bulk_density * sorption.k_f / sorption.porosity  # 25.0
+        theta_origin, v_origin = 1000.0, 0.0
+        c_fan_tail = 0.5
+        wave = DecayingShockWave(
+            theta_start=1500.0,
+            v_start=1000.0 / 27.0,
+            c_decay_initial=4.0,
+            c_fixed=0.0,
+            c_fan_tail=c_fan_tail,
+            decay_side="left",
+            v_origin=v_origin,
+            theta_origin=theta_origin,
+            sorption=sorption,
+        )
+        v_outlet = 2000.0 / 27.0
+        delta_v = v_outlet - v_origin
+        theta_cross = wave.outlet_crossing_theta(v_outlet)
+        assert theta_cross is not None
+        np.testing.assert_allclose(theta_cross, 79000.0 / 27.0, rtol=1e-12)  # c_decay=1 at crossing
+
+        theta_a, theta_b = 2000.0, 4500.0
+        # Wave still valid at theta_b: c_decay(theta_b) > c_fan_tail.
+        c_decay_end = wave.c_decay_at_theta(theta_b)
+        assert c_decay_end is not None
+        assert c_decay_end > c_fan_tail
+
+        # Closed-form oracle. Fan: c(θ) = a_half²/(r-1)² with r = (θ-θ_origin)/Δv, valid until
+        # c = c_fan_tail at r_tail = 1 + a_half/√c_fan_tail; plateau c_fan_tail beyond.
+        r_cross = (theta_cross - theta_origin) / delta_v
+        r_tail = 1.0 + a_half / np.sqrt(c_fan_tail)
+        theta_tail = theta_origin + delta_v * r_tail
+        assert theta_cross < theta_tail < theta_b
+        fan_mass = a_half**2 * delta_v * (1.0 / (r_cross - 1.0) - 1.0 / (r_tail - 1.0))
+        plateau_mass = c_fan_tail * (theta_b - theta_tail)
+        # Pre-arrival: downstream of the shock the outlet sees c_fixed = 0.
+        expected_avg = (fan_mass + plateau_mass) / (theta_b - theta_a)
+
+        c_avg = compute_bin_averaged_concentration_exact(np.array([theta_a, theta_b]), v_outlet, [wave], sorption)
+        np.testing.assert_allclose(c_avg, [expected_avg], rtol=1e-12)
+
 
 class TestIntegrateRarefactionExact:
     """Test exact analytical integration of rarefaction (θ-based)."""

--- a/tests/src/test_front_tracking_output.py
+++ b/tests/src/test_front_tracking_output.py
@@ -351,6 +351,38 @@ class TestIdentifyOutletSegments:
         assert all(seg["type"] == "constant" for seg in pre)
         np.testing.assert_allclose([seg["concentration"] for seg in pre], 0.0)
 
+    def test_never_active_wave_contributes_no_segments(self):
+        """A never-active wave (``is_active=False``, no recorded deactivation) is invisible (#311).
+
+        ``Wave.was_active_at`` defines that state as never active at any theta;
+        the segment reader honors the same lifetime contract, so the output
+        equals the empty-wave-list background.
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        wave = DecayingShockWave(
+            theta_start=1500.0,
+            v_start=1000.0 / 27.0,
+            c_decay_initial=4.0,
+            c_fixed=0.0,
+            c_fan_tail=0.5,
+            decay_side="left",
+            v_origin=0.0,
+            theta_origin=1000.0,
+            sorption=sorption,
+            is_active=False,
+        )
+        v_outlet = 2000.0 / 27.0
+        theta_cross = wave.outlet_crossing_theta(v_outlet)
+        assert theta_cross is not None
+        assert not wave.was_active_at(theta_cross)
+        segments = identify_outlet_segments(
+            theta_start=2000.0, theta_end=4500.0, v_outlet=v_outlet, waves=[wave], sorption=sorption
+        )
+        background = identify_outlet_segments(
+            theta_start=2000.0, theta_end=4500.0, v_outlet=v_outlet, waves=[], sorption=sorption
+        )
+        assert segments == background
+
 
 class TestLegacyDecayingFanBinAverage:
     """Legacy outlet-segment integration of a DSW fan clamps at c_fan_tail, not c_fixed (#311).

--- a/tests/src/test_front_tracking_output.py
+++ b/tests/src/test_front_tracking_output.py
@@ -278,15 +278,13 @@ class TestIdentifyOutletSegments:
         assert len(segments) == 3
 
     def test_shock_deactivated_before_crossing_yields_no_segment(self):
-        """A shock deactivated mid-window never reaches the outlet -- no spurious crossing (issue #311).
+        """A shock deactivated mid-window never reaches the outlet -- no spurious crossing (#311).
 
-        The shock would cross v_outlet at θ_cross by straight-line extrapolation, but it was
+        The shock's straight-line extrapolation crosses v_outlet at θ_cross, but the wave is
         deactivated (collision) at θ_deac < θ_cross, with θ_deac inside the query window so the
         retrospective ``theta_deactivation <= theta_start`` filter does not remove it. The segment
         list must not schedule the extrapolated crossing: the whole window stays at the downstream
-        state c=0, consistent with ``was_active_at`` and with ``concentration_at_point``. Today
-        this is guarded by ``find_outlet_crossing``'s ``is_active`` check; this test pins the
-        behavior so that guard cannot be removed without a ``theta_deactivation`` clamp.
+        state c=0, consistent with ``was_active_at`` and with ``concentration_at_point``.
         """
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
         shock = ShockWave(theta_start=0.0, v_start=0.0, c_left=10.0, c_right=0.0, sorption=sorption, is_active=True)
@@ -309,14 +307,13 @@ class TestIdentifyOutletSegments:
         np.testing.assert_allclose([seg["concentration"] for seg in segments], 0.0)
 
     def test_deactivated_rarefaction_does_not_mask_decaying_fan(self):
-        """A rarefaction consumed by a DSW must not schedule its extrapolated head crossing (issue #311).
+        """A rarefaction consumed by a DSW must not schedule its extrapolated head crossing (#311).
 
         Canonical Freundlich n=2 pulse: leading shock + trailing rarefaction merge into a
-        DecayingShockWave at θ≈525 (both parents deactivated). The dead rarefaction's head would
-        cross v_outlet=100 at θ≈1191 by extrapolation; scheduling it swallows the true structure:
-        constant c=0 until the DSW crossing at θ=3525, then the decaying fan. The reader
-        (``concentration_at_point``, post-#316 face sweep) is the independent oracle for the
-        pre-arrival plateau.
+        DecayingShockWave at θ≈525 (both parents deactivated). The dead rarefaction's head
+        extrapolates to a crossing of v_outlet=100 at θ≈1191; the segment list must instead
+        show constant c=0 until the DSW crossing at θ=3525, then the decaying fan.
+        ``concentration_at_point`` is the independent oracle for the pre-arrival plateau.
         """
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
         n = 40
@@ -356,17 +353,15 @@ class TestIdentifyOutletSegments:
 
 
 class TestLegacyDecayingFanBinAverage:
-    """Legacy outlet-segment integration of a DSW fan clamps at c_fan_tail, not c_fixed (issue #311).
+    """Legacy outlet-segment integration of a DSW fan clamps at c_fan_tail, not c_fixed (#311).
 
     Hand-constructed Freundlich ``n=2``, ``c_fixed=0`` DecayingShockWave (closed-form trajectory,
-    same collision IC as the hand-derived wave test: apex at (V=0, θ=1000), K=1000/27) with a
-    nonzero fan-tail plateau ``c_fan_tail=0.5``. After the shock crosses the outlet the outlet
-    sits inside the fan; once the fan's far edge (c=c_fan_tail) passes, the concentration holds
-    the c_fan_tail plateau -- exactly what the post-#316 reader returns. The independent oracle is
-    the closed-form fan profile: with ``a = ρ_b·k_f/n_por = 50``, ``R(c) = 1 + (a/2)/√c``, the fan
-    at the outlet obeys ``R(c) = (θ-θ_origin)/Δv`` so ``c(θ) = (a/2)²/(r-1)²`` down to c_fan_tail,
-    and ``∫ c dθ = (a/2)²·Δv·[-(r-1)^{-1}]`` in closed form. ``c_apex=c_fixed=0`` instead
-    extrapolates the fan below the plateau and undercounts by ~10%.
+    apex at (V=0, θ=1000), K=1000/27) with a nonzero fan-tail plateau ``c_fan_tail=0.5``. After
+    the shock crosses the outlet the outlet sits inside the fan; once the fan's far edge
+    (c=c_fan_tail) passes, the concentration holds the c_fan_tail plateau. The independent oracle
+    is the closed-form fan profile: with ``a = ρ_b·k_f/n_por = 50``, ``R(c) = 1 + (a/2)/√c``, the
+    fan at the outlet obeys ``R(c) = (θ-θ_origin)/Δv`` so ``c(θ) = (a/2)²/(r-1)²`` down to
+    c_fan_tail, and ``∫ c dθ = (a/2)²·Δv·[-(r-1)^{-1}]`` in closed form.
     """
 
     def test_bin_average_matches_closed_form_plateau_oracle(self):

--- a/tests/src/test_fronttracking_plot.py
+++ b/tests/src/test_fronttracking_plot.py
@@ -14,6 +14,7 @@ import pytest
 from matplotlib.figure import Figure
 
 from gwtransport.fronttracking.math import FreundlichSorption
+from gwtransport.fronttracking.output import concentration_at_point
 from gwtransport.fronttracking.plot import (
     plot_breakthrough_curve,
     plot_front_tracking_summary,
@@ -24,7 +25,7 @@ from gwtransport.fronttracking.plot import (
 )
 from gwtransport.fronttracking.solver import FrontTracker
 from gwtransport.fronttracking.validation import verify_physics
-from gwtransport.fronttracking.waves import CharacteristicWave, RarefactionWave, ShockWave
+from gwtransport.fronttracking.waves import CharacteristicWave, DecayingShockWave, RarefactionWave, ShockWave
 
 plt.switch_backend("Agg")
 
@@ -123,6 +124,47 @@ class TestPlotBreakthroughCurveData:
         assert np.any(np.isclose(all_y, 0.0, atol=1e-10)), (
             f"breakthrough plot is missing the spin-up (c=0) segment; y-values seen: {all_y}"
         )
+
+        plt.close(fig)
+
+    def test_plotted_breakthrough_renders_decaying_fan(self):
+        """The exact-segment plot renders a DecayingShockWave's fan at the outlet (issue #311).
+
+        Canonical Freundlich n=2 pulse whose DSW crosses v_outlet=100 at θ=3525 (t=35.25 d,
+        constant flow 100 m³/d): after arrival the outlet concentration follows the DSW's
+        self-similar fan profile. The rendered breakthrough lines must contain samples strictly
+        inside the fan interval whose y-values equal ``concentration_at_point`` (the post-#316
+        reader) at the same t. Before the fix the ``decaying_fan`` segment was silently skipped
+        (and a deactivated rarefaction's extrapolated crossing plotted its c_start=10 fallback).
+        """
+        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
+        n = 40
+        cin = np.array([0.0, 10.0, 10.0, 0.0] + [0.0] * (n - 4))
+        flow = np.full(n, 100.0)
+        tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+        tracker = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=100.0, sorption=sorption)
+        tracker.run()
+        state = tracker.state
+
+        dsw = next(w for w in state.waves if isinstance(w, DecayingShockWave))
+        theta_cross = dsw.outlet_crossing_theta(state.v_outlet)
+        assert theta_cross is not None
+        t_cross = state.t_at_theta(theta_cross)
+        t_end = float((state.tedges[-1] - state.tedges[0]) / pd.Timedelta(days=1))
+        assert t_cross < t_end
+
+        fig, ax = plt.subplots()
+        plot_breakthrough_curve(state, ax=ax)
+
+        xy = np.concatenate([np.column_stack([ln.get_xdata(), ln.get_ydata()]).astype(float) for ln in ax.get_lines()])
+        inside = xy[(xy[:, 0] > t_cross + 1e-6) & (xy[:, 0] < t_end - 1e-6)]
+        assert len(inside) >= 5, "no rendered samples inside the decaying-fan interval"
+        expected = np.array([
+            concentration_at_point(state.v_outlet, float(state.theta_at_t(t)), state.waves, state.sorption)
+            for t in inside[:, 0]
+        ])
+        assert np.all(expected > 0.0)  # the fan interval carries nonzero concentration
+        np.testing.assert_allclose(inside[:, 1], expected, rtol=1e-9)
 
         plt.close(fig)
 

--- a/tests/src/test_fronttracking_plot.py
+++ b/tests/src/test_fronttracking_plot.py
@@ -128,14 +128,12 @@ class TestPlotBreakthroughCurveData:
         plt.close(fig)
 
     def test_plotted_breakthrough_renders_decaying_fan(self):
-        """The exact-segment plot renders a DecayingShockWave's fan at the outlet (issue #311).
+        """The exact-segment plot renders a DecayingShockWave's fan at the outlet (#311).
 
         Canonical Freundlich n=2 pulse whose DSW crosses v_outlet=100 at θ=3525 (t=35.25 d,
         constant flow 100 m³/d): after arrival the outlet concentration follows the DSW's
         self-similar fan profile. The rendered breakthrough lines must contain samples strictly
-        inside the fan interval whose y-values equal ``concentration_at_point`` (the post-#316
-        reader) at the same t. Before the fix the ``decaying_fan`` segment was silently skipped
-        (and a deactivated rarefaction's extrapolated crossing plotted its c_start=10 fallback).
+        inside the fan interval whose y-values equal ``concentration_at_point`` at the same t.
         """
         sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
         n = 40


### PR DESCRIPTION
## Summary

Fixes the three surviving display/legacy-path DecayingShockWave defects from #311 (the conservation-form `cout` path fixed by #316 is untouched):

- **Plot drops the DSW fan (A):** `plot_breakthrough_curve` only rendered `"constant"` and `"rarefaction"` segments, silently skipping the `"decaying_fan"` segments `identify_outlet_segments` emits. Added a branch that samples the post-#316 face-sweep reader (`concentration_at_point`) over the segment, which handles both the self-similar fan interior and the `c_fan_tail` plateau beyond the fan's edge.
- **Spurious extrapolated crossings (B):** `identify_outlet_segments` scheduled rarefaction head/tail and DSW outlet crossings by pure extrapolation, ignoring `theta_deactivation`. On the canonical Freundlich n=2 pulse, the rarefaction consumed by the DSW at θ≈525 still emitted a head crossing at θ≈1191 whose segment swallowed the true `constant → decaying_fan` structure (and plotted its c=10 fallback). Every inline-computed crossing is now clamped to `theta_cross < wave.theta_deactivation`, per `was_active_at` semantics. `ShockWave`/`CharacteristicWave` crossings were already guarded by `find_outlet_crossing`'s `is_active` check — the issue's shock sub-claim did **not** reproduce on baseline; a test pins that guard instead.
- **Legacy fan integral apex (C):** the legacy outlet-segment integration passed `c_apex=w.c_fixed` to `integrate_fan_exact`. After the shock passes the outlet, the outlet sits inside the fan and holds the `c_fan_tail` plateau once the fan's far edge sweeps by (exactly the reader's fan clamp); `c_fixed` lives on the shock's other side and never reaches the outlet post-crossing. Confirmed against a from-scratch closed-form Freundlich n=2 oracle (`∫c dθ = (a/2)²·Δv·[-(r-1)⁻¹]` + plateau term): baseline undercounts by ~10% when `c_fan_tail > c_fixed`. Canonical `c_fan_tail = c_fixed = 0` fans are numerically unchanged.

## Test plan

- New regression tests, all verified to FAIL on unchanged `origin/main` before the fix:
  - `test_fronttracking_plot.py::TestPlotBreakthroughCurveData::test_plotted_breakthrough_renders_decaying_fan` — rendered samples inside the fan interval must equal the reader (baseline: plotted 10.0 fallback).
  - `test_front_tracking_output.py::TestIdentifyOutletSegments::test_deactivated_rarefaction_does_not_mask_decaying_fan` — solver-built pulse; no segment from the dead rarefaction, one `decaying_fan` starting at the DSW crossing, c=0 before.
  - `test_front_tracking_output.py::TestLegacyDecayingFanBinAverage` — hand-built closed-form DSW (`c_fan_tail=0.5`, `c_fixed=0`) vs independent closed-form fan+plateau oracle, `rtol=1e-12`.
- Guard test (passes on baseline and after): `test_shock_deactivated_before_crossing_yields_no_segment` pins the existing `is_active` guard for shock crossings.
- Full targeted suites green: all 14 `tests/src/test_front_tracking*` / `test_fronttracking_plot` files (520 passed, 2 skipped).
- `ruff format`, `ruff check`, `ty check` clean on changed files.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.

Closes #311
