### PR TITLE
feat: accept gapped (NaN) cout in advection/diffusion reverse operators

### DIFF
--- a/src/gwtransport/_diffusion_shared.py
+++ b/src/gwtransport/_diffusion_shared.py
@@ -179,7 +179,7 @@ def _validate_inputs(
     ------
     ValueError
         If array lengths are inconsistent, molecular_diffusivity or
-        longitudinal_dispersivity are negative or non-finite, cin or cout or flow contain NaN
+        longitudinal_dispersivity are negative or non-finite, cin (forward) or flow contain NaN
         values, aquifer_pore_volumes contains non-positive or non-finite values,
         streamline_length is non-positive or non-finite, or retardation_factor is NaN or below 1
         (anti-retardation is not physical for the supported sorption isotherms).
@@ -208,7 +208,10 @@ def _validate_inputs(
     # enforced in exactly one place. Order and messages match the historical inline checks.
     _validate_non_negative_array(molecular_diffusivity, name="molecular_diffusivity")
     _validate_non_negative_array(longitudinal_dispersivity, name="longitudinal_dispersivity")
-    _validate_no_nan(cin_or_cout, name="cin" if is_forward else "cout")
+    # Forward cin must be NaN-free; reverse cout may contain NaN (measurement
+    # gaps) -- the banded inverse solver excludes those rows, matching deposition (#321).
+    if is_forward:
+        _validate_no_nan(cin_or_cout, name="cin")
     _validate_no_nan(flow, name="flow")
     _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
     _validate_positive_array(aquifer_pore_volumes, name="aquifer_pore_volumes")

--- a/src/gwtransport/_diffusion_shared.py
+++ b/src/gwtransport/_diffusion_shared.py
@@ -208,8 +208,7 @@ def _validate_inputs(
     # enforced in exactly one place. Order and messages match the historical inline checks.
     _validate_non_negative_array(molecular_diffusivity, name="molecular_diffusivity")
     _validate_non_negative_array(longitudinal_dispersivity, name="longitudinal_dispersivity")
-    # Forward cin must be NaN-free; reverse cout may contain NaN (measurement
-    # gaps) -- the banded inverse solver excludes those rows, matching deposition (#321).
+    # Reverse cout may contain NaN (measurement gaps); gapped rows are excluded from the solve.
     if is_forward:
         _validate_no_nan(cin_or_cout, name="cin")
     _validate_no_nan(flow, name="flow")

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -121,8 +121,9 @@ def _validate_advection_inputs(
         _validate_no_nan(cin_values, name="cin")
     elif cout_values is not None and cout_tedges is not None:
         _validate_tedges_parity(tedges, flow, tedges_name="tedges", values_name="flow")
+        # NaN in cout marks measurement gaps (sparse lab samples); the banded
+        # inverse solver excludes those rows, matching deposition (#321).
         _validate_tedges_parity(cout_tedges, cout_values, tedges_name="cout_tedges", values_name="cout")
-        _validate_no_nan(cout_values, name="cout")
     else:
         msg = "must provide cin_values (forward) or both cout_values and cout_tedges (reverse)"
         raise ValueError(msg)
@@ -810,7 +811,7 @@ def extraction_to_infiltration(
     ------
     ValueError
         If tedges length doesn't match flow plus one, if cout_tedges length
-        doesn't match cout plus one, or if inputs contain NaN.
+        doesn't match cout plus one, or if flow contains NaN.
 
     See Also
     --------
@@ -823,10 +824,10 @@ def extraction_to_infiltration(
 
     Notes
     -----
-    NaN values in ``cout`` are rejected. The Tikhonov solver here does not
-    mask NaN rows, so any NaN in ``cout`` would poison the solution. This
-    differs from :func:`gwtransport.deposition.extraction_to_deposition`,
-    whose regularized solver excludes NaN ``cout`` rows by construction.
+    NaN values in ``cout`` mark measurement gaps (e.g. sparse lab samples).
+    Their rows are excluded from the banded Tikhonov solve, matching
+    :func:`gwtransport.deposition.extraction_to_deposition`; cin bins
+    constrained only by gapped ``cout`` bins are returned as NaN.
 
     Examples
     --------

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -121,8 +121,7 @@ def _validate_advection_inputs(
         _validate_no_nan(cin_values, name="cin")
     elif cout_values is not None and cout_tedges is not None:
         _validate_tedges_parity(tedges, flow, tedges_name="tedges", values_name="flow")
-        # NaN in cout marks measurement gaps (sparse lab samples); the banded
-        # inverse solver excludes those rows, matching deposition (#321).
+        # Reverse cout may contain NaN (measurement gaps); gapped rows are excluded from the solve.
         _validate_tedges_parity(cout_tedges, cout_values, tedges_name="cout_tedges", values_name="cout")
     else:
         msg = "must provide cin_values (forward) or both cout_values and cout_tedges (reverse)"

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -514,10 +514,10 @@ def _validate_diffusion_inputs(
     )
     _validate_non_negative_array(molecular_diffusivity, name="molecular_diffusivity")
     _validate_non_negative_array(longitudinal_dispersivity, name="longitudinal_dispersivity")
+    # Forward cin must be NaN-free; reverse cout may contain NaN (measurement
+    # gaps) -- the inverse solver excludes those rows, matching deposition (#321).
     if cin_values is not None:
         _validate_no_nan(cin_values, name="cin")
-    elif cout_values is not None:
-        _validate_no_nan(cout_values, name="cout")
     _validate_no_nan(flow, name="flow")
     _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
     _validate_positive_array(aquifer_pore_volumes, name="aquifer_pore_volumes")
@@ -1037,10 +1037,10 @@ def extraction_to_infiltration(
     using :func:`gwtransport.utils.solve_tikhonov`. This ensures mathematical
     consistency between forward and inverse operations.
 
-    NaN values in ``cout`` are rejected. The Tikhonov solver here does not
-    mask NaN rows, so any NaN in ``cout`` would poison the solution. This
-    differs from :func:`gwtransport.deposition.extraction_to_deposition`,
-    whose regularized solver excludes NaN ``cout`` rows by construction.
+    NaN values in ``cout`` mark measurement gaps (e.g. sparse lab samples).
+    Their rows are excluded from the Tikhonov solve, matching
+    :func:`gwtransport.deposition.extraction_to_deposition`; cin bins
+    constrained only by gapped ``cout`` bins are returned as NaN.
 
     Examples
     --------

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -514,8 +514,7 @@ def _validate_diffusion_inputs(
     )
     _validate_non_negative_array(molecular_diffusivity, name="molecular_diffusivity")
     _validate_non_negative_array(longitudinal_dispersivity, name="longitudinal_dispersivity")
-    # Forward cin must be NaN-free; reverse cout may contain NaN (measurement
-    # gaps) -- the inverse solver excludes those rows, matching deposition (#321).
+    # Reverse cout may contain NaN (measurement gaps); gapped rows are excluded from the solve.
     if cin_values is not None:
         _validate_no_nan(cin_values, name="cin")
     _validate_no_nan(flow, name="flow")

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -1506,12 +1506,17 @@ def solve_inverse_transport(
     solve_inverse_transport_banded : Memory-light banded equivalent.
     """
     row_sums = w_forward.sum(axis=1)
-    # Emit only columns carrying real weight. Aligning the gate with the regularization
-    # threshold (``_EPSILON_COEFF_SUM``, also used for the row-validity gate below and by the
-    # banded/fast siblings) NaNs the erfc-tail sliver columns (``col_sum`` in ``(0, _EPSILON]``)
-    # instead of emitting the collapsed-singular-value garbage (tiny or negative) lstsq returns
-    # there — those bins are uninformative, not resolvable (#307).
-    col_active: npt.NDArray[np.bool_] = w_forward.sum(axis=0) > _EPSILON_COEFF_SUM
+    # Emit only columns carrying real weight in the rows that survive the gap mask. Aligning the
+    # gate with the regularization threshold (``_EPSILON_COEFF_SUM``, also used for the row-validity
+    # gate below and by the banded/fast siblings) NaNs the erfc-tail sliver columns (``col_sum`` in
+    # ``(0, _EPSILON]``) instead of emitting the collapsed-singular-value garbage (tiny or negative)
+    # lstsq returns there — those bins are uninformative, not resolvable (#307). Masking the NaN
+    # observation rows out of the column sums extends the same rule to gapped cout (#321): a column
+    # whose entire support falls inside a gap has no surviving data equation and must come back NaN,
+    # never a fabricated lstsq min-norm value. With NaN-free observations this reduces bit-identically
+    # to the unmasked sum.
+    nan_obs = np.isnan(observed)
+    col_active: npt.NDArray[np.bool_] = np.where(nan_obs[:, None], 0.0, w_forward).sum(axis=0) > _EPSILON_COEFF_SUM
 
     if not np.any(col_active):
         return np.full(n_output, np.nan)
@@ -1532,7 +1537,6 @@ def solve_inverse_transport(
 
     # Gapped observations (sparse lab samples): NaN rows drop out of the data
     # equations and the regularization target, matching deposition's masking.
-    nan_obs = np.isnan(observed)
     valid: npt.NDArray[np.bool_] = (row_sums > _EPSILON_COEFF_SUM if valid_rows is None else valid_rows) & ~nan_obs
 
     rhs = np.where(valid, row_sums * observed, np.nan)

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -1477,7 +1477,8 @@ def solve_inverse_transport(
         Forward coefficient matrix with shape ``(n_obs, n_output)``.
     observed : ndarray
         Observed values with shape ``(n_obs,)`` (e.g., extraction
-        concentrations).
+        concentrations). NaN entries mark measurement gaps; their rows are
+        excluded from the solve and the regularization target.
     n_output : int
         Length of the output vector (e.g., number of cin bins).
     regularization_strength : float
@@ -1529,13 +1530,19 @@ def solve_inverse_transport(
                 stacklevel=2,
             )
 
-    valid: npt.NDArray[np.bool_] = row_sums > _EPSILON_COEFF_SUM if valid_rows is None else valid_rows
+    # Gapped observations (sparse lab samples): NaN rows drop out of the data
+    # equations and the regularization target, matching deposition's masking.
+    nan_obs = np.isnan(observed)
+    valid: npt.NDArray[np.bool_] = (row_sums > _EPSILON_COEFF_SUM if valid_rows is None else valid_rows) & ~nan_obs
 
     rhs = np.where(valid, row_sums * observed, np.nan)
     w_solve = w_forward.copy()
     w_solve[~valid, :] = np.nan
 
-    x_target = compute_reverse_target(coeff_matrix=w_forward, rhs_vector=observed)
+    x_target = compute_reverse_target(
+        coeff_matrix=np.where(nan_obs[:, None], 0.0, w_forward),
+        rhs_vector=np.where(nan_obs, 0.0, observed),
+    )
 
     x_solved = solve_tikhonov(
         coefficient_matrix=w_solve,
@@ -1595,7 +1602,8 @@ def solve_inverse_transport_banded(
         First output-column index of each row's band, shape ``(n_obs,)``.
     observed : ndarray
         Observed values of shape ``(n_obs,)`` (e.g. extraction concentrations).
-        Must not contain NaN.
+        NaN entries mark measurement gaps; their rows are excluded from the
+        normal equations (band row and observed value zeroed).
     n_output : int
         Length of the output vector (number of cin bins).
     regularization_strength : float
@@ -1629,6 +1637,12 @@ def solve_inverse_transport_banded(
     # needs no row_sums scaling -- matching the dense solve_inverse_transport.
     band_vals = np.asarray(band_vals, dtype=float)
     observed = np.asarray(observed, dtype=float)
+    # Gapped observations (sparse lab samples): zero the band row so it drops out of
+    # the normal equations, and zero the observed value so 0 * NaN cannot poison
+    # Wᵀ·observed or the refinement residual.
+    nan_obs = np.isnan(observed)
+    band_vals = np.where(nan_obs[:, None], 0.0, band_vals)
+    observed = np.where(nan_obs, 0.0, observed)
     full_band = band_vals.shape[1]
     n_cin = n_output
     cols = col_start[:, None] + np.arange(full_band)[None, :]  # (n_obs, full_band) output-column index

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -1649,8 +1649,11 @@ def solve_inverse_transport_banded(
     # the normal equations, and zero the observed value so 0 * NaN cannot poison
     # Wᵀ·observed or the refinement residual.
     nan_obs = np.isnan(observed)
-    band_vals = np.where(nan_obs[:, None], 0.0, band_vals)
-    observed = np.where(nan_obs, 0.0, observed)
+    if nan_obs.any():
+        # band_vals is only read below, so the masked copy is needed only when gaps exist;
+        # the common NaN-free path keeps the caller's array without allocating.
+        band_vals = np.where(nan_obs[:, None], 0.0, band_vals)
+        observed = np.where(nan_obs, 0.0, observed)
     full_band = band_vals.shape[1]
     n_cin = n_output
     cols = col_start[:, None] + np.arange(full_band)[None, :]  # (n_obs, full_band) output-column index

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -1516,7 +1516,11 @@ def solve_inverse_transport(
     # never a fabricated lstsq min-norm value. With NaN-free observations this reduces bit-identically
     # to the unmasked sum.
     nan_obs = np.isnan(observed)
-    col_active: npt.NDArray[np.bool_] = np.where(nan_obs[:, None], 0.0, w_forward).sum(axis=0) > _EPSILON_COEFF_SUM
+    # One shared masked view of the forward matrix: with NaN-free observations it aliases
+    # ``w_forward`` (no copy, bit-identical to the unmasked path); with gaps it is materialized
+    # once and reused for both the column-activity gate and the regularization target below.
+    w_masked = np.where(nan_obs[:, None], 0.0, w_forward) if nan_obs.any() else w_forward
+    col_active: npt.NDArray[np.bool_] = w_masked.sum(axis=0) > _EPSILON_COEFF_SUM
 
     if not np.any(col_active):
         return np.full(n_output, np.nan)
@@ -1544,7 +1548,7 @@ def solve_inverse_transport(
     w_solve[~valid, :] = np.nan
 
     x_target = compute_reverse_target(
-        coeff_matrix=np.where(nan_obs[:, None], 0.0, w_forward),
+        coeff_matrix=w_masked,
         rhs_vector=np.where(nan_obs, 0.0, observed),
     )
 

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -1506,20 +1506,12 @@ def solve_inverse_transport(
     solve_inverse_transport_banded : Memory-light banded equivalent.
     """
     row_sums = w_forward.sum(axis=1)
-    # Emit only columns carrying real weight in the rows that survive the gap mask. Aligning the
-    # gate with the regularization threshold (``_EPSILON_COEFF_SUM``, also used for the row-validity
-    # gate below and by the banded/fast siblings) NaNs the erfc-tail sliver columns (``col_sum`` in
-    # ``(0, _EPSILON]``) instead of emitting the collapsed-singular-value garbage (tiny or negative)
-    # lstsq returns there — those bins are uninformative, not resolvable (#307). Masking the NaN
-    # observation rows out of the column sums extends the same rule to gapped cout (#321): a column
-    # whose entire support falls inside a gap has no surviving data equation and must come back NaN,
-    # never a fabricated lstsq min-norm value. With NaN-free observations this reduces bit-identically
-    # to the unmasked sum.
     nan_obs = np.isnan(observed)
-    # One shared masked view of the forward matrix: with NaN-free observations it aliases
-    # ``w_forward`` (no copy, bit-identical to the unmasked path); with gaps it is materialized
-    # once and reused for both the column-activity gate and the regularization target below.
+    # Aliases w_forward when there are no gaps; otherwise one masked copy, shared with the
+    # regularization target below.
     w_masked = np.where(nan_obs[:, None], 0.0, w_forward) if nan_obs.any() else w_forward
+    # A column is active when its weight over the surviving rows exceeds the regularization
+    # epsilon; sliver-support and gap-only columns emit NaN instead of a min-norm value.
     col_active: npt.NDArray[np.bool_] = w_masked.sum(axis=0) > _EPSILON_COEFF_SUM
 
     if not np.any(col_active):
@@ -1539,8 +1531,7 @@ def solve_inverse_transport(
                 stacklevel=2,
             )
 
-    # Gapped observations (sparse lab samples): NaN rows drop out of the data
-    # equations and the regularization target, matching deposition's masking.
+    # Gapped rows drop out of the data equations and the regularization target.
     valid: npt.NDArray[np.bool_] = (row_sums > _EPSILON_COEFF_SUM if valid_rows is None else valid_rows) & ~nan_obs
 
     rhs = np.where(valid, row_sums * observed, np.nan)
@@ -1645,13 +1636,10 @@ def solve_inverse_transport_banded(
     # needs no row_sums scaling -- matching the dense solve_inverse_transport.
     band_vals = np.asarray(band_vals, dtype=float)
     observed = np.asarray(observed, dtype=float)
-    # Gapped observations (sparse lab samples): zero the band row so it drops out of
-    # the normal equations, and zero the observed value so 0 * NaN cannot poison
-    # Wᵀ·observed or the refinement residual.
+    # Zeroed gapped rows drop out of the normal equations, and a zeroed observed value keeps
+    # 0 * NaN out of Wᵀ·observed and the refinement residual.
     nan_obs = np.isnan(observed)
     if nan_obs.any():
-        # band_vals is only read below, so the masked copy is needed only when gaps exist;
-        # the common NaN-free path keeps the caller's array without allocating.
         band_vals = np.where(nan_obs[:, None], 0.0, band_vals)
         observed = np.where(nan_obs, 0.0, observed)
     full_band = band_vals.shape[1]

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -3683,15 +3683,7 @@ def test_validate_advection_inputs_silent_on_good_input_reverse():
             },
             r"cout_tedges must have one more element than cout",
         ),
-        (
-            "reverse",
-            lambda k: {
-                **k,
-                "cout_values": np.array([1.0, np.nan, 1.0, 1.0, 1.0]),
-                "cout_tedges": k["tedges"],
-            },
-            r"cout contains NaN values, which are not allowed",
-        ),
+        # NaN cout no longer raises: gaps are masked out of the inverse solve (#321).
         # NEW: flow >= 0 in reverse (omission fix; symmetric with diffusion reverse)
         (
             "reverse",
@@ -4627,3 +4619,42 @@ def test_fronttracking_domain_mass_interior_zero_flow_gap_matches_deleted_gap(so
             theta=theta, v_outlet=aquifer_pore_volume, waves=tracker_nogap.state.waves, sorption=sorption
         )
         np.testing.assert_allclose(mass_gap, mass_nogap, rtol=0.0, atol=1e-9)
+def test_extraction_to_infiltration_gapped_cout_masked():
+    """NaN gaps in cout are masked out of the inverse solve instead of raising (#321).
+
+    Sparse lab samples leave NaN cout bins; the reverse operator must exclude
+    those rows from the banded Tikhonov normal equations -- matching
+    :func:`gwtransport.deposition.extraction_to_deposition` -- rather than
+    reject the whole series. cout at 12h resolution vs daily cin keeps the
+    system overdetermined, so the surviving rows still pin every interior cin
+    bin and recovery stays at the no-gap round-trip floor. A 2.5-day contiguous
+    gap (5 cout bins) fully covers the arrival window of cin bins 55-56
+    (residence time 5.17 days), which therefore lose all data and must come
+    back NaN, not fabricated.
+    """
+    n_days = 120
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    cout_tedges = pd.date_range("2020-01-01", periods=2 * n_days + 1, freq="12h")
+    flow = np.full(n_days, 100.0)
+    cin_true = 5.0 + 3.0 * np.sin(2 * np.pi * np.arange(n_days) / 30.0)
+    kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([517.0]),  # rt = 5.17 days (full-rank plateau)
+    }
+
+    cout = infiltration_to_extraction(cin=cin_true, **kwargs)
+    cout[[0, 90, 150, 239]] = np.nan  # boundary + scattered single-bin gaps
+    cout[120:125] = np.nan  # contiguous gap: extraction days 60.0-62.5
+
+    cin_rec = extraction_to_infiltration(cout=cout, **kwargs)
+
+    # cin bins 55-56 arrive entirely within the zeroed 60.0-62.5 day window: no
+    # surviving cout row constrains them, so they must be NaN.
+    assert np.all(np.isnan(cin_rec[55:57]))
+    # Away from the contiguous gap the overdetermined system recovers cin exactly.
+    interior = np.zeros(n_days, dtype=bool)
+    interior[30:95] = True
+    interior[50:62] = False  # neighbourhood of the contiguous gap
+    np.testing.assert_allclose(cin_rec[interior], cin_true[interior], atol=1e-10)

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -4619,6 +4619,8 @@ def test_fronttracking_domain_mass_interior_zero_flow_gap_matches_deleted_gap(so
             theta=theta, v_outlet=aquifer_pore_volume, waves=tracker_nogap.state.waves, sorption=sorption
         )
         np.testing.assert_allclose(mass_gap, mass_nogap, rtol=0.0, atol=1e-9)
+
+
 def test_extraction_to_infiltration_gapped_cout_masked():
     """NaN gaps in cout are masked out of the inverse solve instead of raising (#321).
 

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -4622,17 +4622,12 @@ def test_fronttracking_domain_mass_interior_zero_flow_gap_matches_deleted_gap(so
 
 
 def test_extraction_to_infiltration_gapped_cout_masked():
-    """NaN gaps in cout are masked out of the inverse solve instead of raising (#321).
+    """Gapped (NaN) cout: the reverse solve uses only the measured bins (#321).
 
-    Sparse lab samples leave NaN cout bins; the reverse operator must exclude
-    those rows from the banded Tikhonov normal equations -- matching
-    :func:`gwtransport.deposition.extraction_to_deposition` -- rather than
-    reject the whole series. cout at 12h resolution vs daily cin keeps the
-    system overdetermined, so the surviving rows still pin every interior cin
-    bin and recovery stays at the no-gap round-trip floor. A 2.5-day contiguous
-    gap (5 cout bins) fully covers the arrival window of cin bins 55-56
-    (residence time 5.17 days), which therefore lose all data and must come
-    back NaN, not fabricated.
+    cout at 12h resolution vs daily cin keeps the system overdetermined, so the
+    surviving rows pin every interior cin bin at the no-gap round-trip floor. A
+    2.5-day contiguous gap fully covers the arrival window of cin bins 55-56
+    (residence time 5.17 days); with no data equations those bins are NaN.
     """
     n_days = 120
     tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -2391,6 +2391,8 @@ def test_coarse_cout_grid_conserves_pulse_mass(offset_days):
     cout_disp = infiltration_to_extraction(molecular_diffusivity=0.02, longitudinal_dispersivity=1.0, **kwargs)
     assert not np.any(np.isnan(cout_disp))
     np.testing.assert_allclose(np.sum(flow_rate * cout_disp * dt_days), mass_in, rtol=1e-10)
+
+
 def test_extraction_to_infiltration_gapped_cout_masked():
     """NaN gaps in cout are masked out of the inverse solve instead of raising (#321).
 

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -2275,11 +2275,7 @@ def test_validate_diffusion_inputs_silent_on_good_input_reverse():
             },
             r"cout_tedges must have one more element than cout",
         ),
-        (
-            "reverse",
-            lambda k: {**k, "cout_values": np.array([1.0, np.nan, 1.0, 1.0, 1.0]), "cout_tedges": k["tedges"]},
-            r"cout contains NaN values, which are not allowed",
-        ),
+        # NaN cout no longer raises: gaps are masked out of the inverse solve (#321).
         # NEW: flow >= 0 in reverse (omission fix)
         (
             "reverse",
@@ -2395,3 +2391,35 @@ def test_coarse_cout_grid_conserves_pulse_mass(offset_days):
     cout_disp = infiltration_to_extraction(molecular_diffusivity=0.02, longitudinal_dispersivity=1.0, **kwargs)
     assert not np.any(np.isnan(cout_disp))
     np.testing.assert_allclose(np.sum(flow_rate * cout_disp * dt_days), mass_in, rtol=1e-10)
+def test_extraction_to_infiltration_gapped_cout_masked():
+    """NaN gaps in cout are masked out of the inverse solve instead of raising (#321).
+
+    Sparse lab samples leave NaN cout bins; the reverse operator must exclude
+    those rows from the Tikhonov solve (data equations AND regularization
+    target) -- matching :func:`gwtransport.deposition.extraction_to_deposition`
+    -- rather than reject the whole series. cout at 12h resolution vs daily cin
+    keeps the system overdetermined, so the surviving rows still pin every
+    interior cin bin and recovery stays at the no-gap round-trip floor.
+    """
+    n_days = 120
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    cout_tedges = pd.date_range("2020-01-01", periods=2 * n_days + 1, freq="12h")
+    flow = np.full(n_days, 100.0)
+    cin_true = 5.0 + 3.0 * np.sin(2 * np.pi * np.arange(n_days) / 30.0)
+    kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([517.0]),
+        "streamline_length": 80.0,
+        "molecular_diffusivity": 0.01,
+        "longitudinal_dispersivity": 0.1,
+    }
+
+    cout = infiltration_to_extraction(cin=cin_true, **kwargs)
+    cout[[0, 90, 120, 121, 150, 239]] = np.nan  # boundary + scattered gaps
+
+    cin_rec = extraction_to_infiltration(cout=cout, **kwargs)
+
+    interior = slice(30, 95)
+    np.testing.assert_allclose(cin_rec[interior], cin_true[interior], atol=1e-10)

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -2423,3 +2423,48 @@ def test_extraction_to_infiltration_gapped_cout_masked():
 
     interior = slice(30, 95)
     np.testing.assert_allclose(cin_rec[interior], cin_true[interior], atol=1e-10)
+
+
+def test_extraction_to_infiltration_wide_gap_never_fabricates():
+    """A gap wider than the dispersive arrival window must NaN the unconstrained cin bins (#321).
+
+    A cin bin whose entire breakthrough support falls inside the NaN-cout window has no surviving
+    data equation; the dense solver must mark its column inactive (computed from the NaN-masked
+    matrix) and return NaN. Gating the column activity on the unmasked matrix instead leaves such
+    bins "active" and lets lstsq fabricate min-norm values (zeros, or huge sliver-support garbage)
+    that read downstream as real concentrations. Contract: zero-support bins are NaN, never
+    fabricated; well-constrained bins recover at the round-trip floor. Bins with *partial* support
+    at the gap edges (a sliver of the dispersive tail survives) legitimately emit softened
+    regularized estimates -- they are bounded by the data's physical range, not exact.
+    """
+    n_days = 120
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    cout_tedges = pd.date_range("2020-01-01", periods=2 * n_days + 1, freq="12h")
+    flow = np.full(n_days, 100.0)
+    cin_true = 5.0 + 3.0 * np.sin(2 * np.pi * np.arange(n_days) / 30.0)
+    kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([517.0]),
+        "streamline_length": 80.0,
+        "molecular_diffusivity": 0.01,
+        "longitudinal_dispersivity": 0.1,
+    }
+
+    cout = infiltration_to_extraction(cin=cin_true, **kwargs)
+    cout[100:160] = np.nan  # 30-day gap (12h bins): days 50-80, far wider than the ~5.2-day arrival
+
+    cin_rec = extraction_to_infiltration(cout=cout, **kwargs)
+
+    # Bins wholly inside the gap's shadow are unconstrained -> NaN (mask engaged, nothing fabricated).
+    assert np.isnan(cin_rec[50:70]).all(), "unconstrained cin bins inside the gap shadow must be NaN"
+    # Bins away from the gap remain pinned by surviving rows at the round-trip floor.
+    np.testing.assert_allclose(cin_rec[10:40], cin_true[10:40], atol=1e-8)
+    assert np.isfinite(cin_rec[10:40]).all()
+    # No finite bin anywhere is fabricated: every emitted value sits inside the data's physical
+    # range (cin_true spans [2, 8]; the baseline defect emitted 0.0 and ~3.6e6 here). Partially-
+    # supported gap-edge bins are allowed to be soft, but never non-physical.
+    finite = np.isfinite(cin_rec)
+    assert cin_rec[finite].min() >= cin_true.min() - 1.0
+    assert cin_rec[finite].max() <= cin_true.max() + 1.0

--- a/tests/src/test_diffusion.py
+++ b/tests/src/test_diffusion.py
@@ -2394,14 +2394,11 @@ def test_coarse_cout_grid_conserves_pulse_mass(offset_days):
 
 
 def test_extraction_to_infiltration_gapped_cout_masked():
-    """NaN gaps in cout are masked out of the inverse solve instead of raising (#321).
+    """Gapped (NaN) cout: the dense reverse solve uses only the measured bins (#321).
 
-    Sparse lab samples leave NaN cout bins; the reverse operator must exclude
-    those rows from the Tikhonov solve (data equations AND regularization
-    target) -- matching :func:`gwtransport.deposition.extraction_to_deposition`
-    -- rather than reject the whole series. cout at 12h resolution vs daily cin
-    keeps the system overdetermined, so the surviving rows still pin every
-    interior cin bin and recovery stays at the no-gap round-trip floor.
+    Gapped rows drop out of both the data equations and the regularization
+    target. cout at 12h resolution vs daily cin keeps the system overdetermined,
+    so the surviving rows pin every interior cin bin at the no-gap round-trip floor.
     """
     n_days = 120
     tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
@@ -2428,16 +2425,13 @@ def test_extraction_to_infiltration_gapped_cout_masked():
 
 
 def test_extraction_to_infiltration_wide_gap_never_fabricates():
-    """A gap wider than the dispersive arrival window must NaN the unconstrained cin bins (#321).
+    """A gap wider than the dispersive arrival window yields NaN cin bins, never fabricated values (#321).
 
-    A cin bin whose entire breakthrough support falls inside the NaN-cout window has no surviving
-    data equation; the dense solver must mark its column inactive (computed from the NaN-masked
-    matrix) and return NaN. Gating the column activity on the unmasked matrix instead leaves such
-    bins "active" and lets lstsq fabricate min-norm values (zeros, or huge sliver-support garbage)
-    that read downstream as real concentrations. Contract: zero-support bins are NaN, never
-    fabricated; well-constrained bins recover at the round-trip floor. Bins with *partial* support
-    at the gap edges (a sliver of the dispersive tail survives) legitimately emit softened
-    regularized estimates -- they are bounded by the data's physical range, not exact.
+    A cin bin whose entire breakthrough support falls inside the NaN-cout window
+    has no surviving data equation: its column is inactive and the bin is NaN.
+    Well-constrained bins recover at the round-trip floor. Partially-supported
+    gap-edge bins (a sliver of the dispersive tail survives) emit softened
+    regularized estimates bounded by the data's physical range.
     """
     n_days = 120
     tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
@@ -2459,14 +2453,13 @@ def test_extraction_to_infiltration_wide_gap_never_fabricates():
 
     cin_rec = extraction_to_infiltration(cout=cout, **kwargs)
 
-    # Bins wholly inside the gap's shadow are unconstrained -> NaN (mask engaged, nothing fabricated).
+    # Bins wholly inside the gap's shadow have no data equations -> NaN.
     assert np.isnan(cin_rec[50:70]).all(), "unconstrained cin bins inside the gap shadow must be NaN"
     # Bins away from the gap remain pinned by surviving rows at the round-trip floor.
     np.testing.assert_allclose(cin_rec[10:40], cin_true[10:40], atol=1e-8)
     assert np.isfinite(cin_rec[10:40]).all()
-    # No finite bin anywhere is fabricated: every emitted value sits inside the data's physical
-    # range (cin_true spans [2, 8]; the baseline defect emitted 0.0 and ~3.6e6 here). Partially-
-    # supported gap-edge bins are allowed to be soft, but never non-physical.
+    # Every finite bin sits inside the data's physical range (cin_true spans [2, 8]);
+    # partially-supported gap-edge bins may be soft, never non-physical.
     finite = np.isfinite(cin_rec)
     assert cin_rec[finite].min() >= cin_true.min() - 1.0
     assert cin_rec[finite].max() <= cin_true.max() + 1.0

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -3278,3 +3278,36 @@ def test_coarse_cout_straddling_flow_restart_matches_diffusion_quadrature(d_m, a
     both = np.isfinite(cout_fast) & np.isfinite(cout_quad)
     assert np.sum(both) > 5
     assert_allclose(cout_fast[both], cout_quad[both], atol=1e-12, rtol=0.0)
+def test_extraction_to_infiltration_gapped_cout_masked():
+    """NaN gaps in cout are masked out of the banded inverse instead of raising (#321).
+
+    Sparse lab samples leave NaN cout bins; the reverse operator must exclude
+    those rows from the banded Tikhonov normal equations -- matching
+    :func:`gwtransport.deposition.extraction_to_deposition` -- rather than
+    reject the whole series. cout at 12h resolution (via ``flow_out``) vs daily
+    cin keeps the system overdetermined, so the surviving rows still pin every
+    interior cin bin and recovery stays at the no-gap round-trip floor.
+    """
+    n_days = 120
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    cout_tedges = pd.date_range("2020-01-01", periods=2 * n_days + 1, freq="12h")
+    flow = np.full(n_days, 100.0)
+    cin_true = 5.0 + 3.0 * np.sin(2 * np.pi * np.arange(n_days) / 30.0)
+    kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([517.0]),
+        "streamline_length": 80.0,
+        "molecular_diffusivity": 0.01,
+        "longitudinal_dispersivity": 0.1,
+        "flow_out": np.full(2 * n_days, 100.0),
+    }
+
+    cout = infiltration_to_extraction(cin=cin_true, **kwargs)
+    cout[[0, 90, 120, 121, 150, 239]] = np.nan  # boundary + scattered gaps
+
+    cin_rec = extraction_to_infiltration(cout=cout, **kwargs)
+
+    interior = slice(30, 95)
+    assert_allclose(cin_rec[interior], cin_true[interior], atol=1e-10)

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -3278,6 +3278,8 @@ def test_coarse_cout_straddling_flow_restart_matches_diffusion_quadrature(d_m, a
     both = np.isfinite(cout_fast) & np.isfinite(cout_quad)
     assert np.sum(both) > 5
     assert_allclose(cout_fast[both], cout_quad[both], atol=1e-12, rtol=0.0)
+
+
 def test_extraction_to_infiltration_gapped_cout_masked():
     """NaN gaps in cout are masked out of the banded inverse instead of raising (#321).
 

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -3281,14 +3281,11 @@ def test_coarse_cout_straddling_flow_restart_matches_diffusion_quadrature(d_m, a
 
 
 def test_extraction_to_infiltration_gapped_cout_masked():
-    """NaN gaps in cout are masked out of the banded inverse instead of raising (#321).
+    """Gapped (NaN) cout: the banded reverse solve uses only the measured bins (#321).
 
-    Sparse lab samples leave NaN cout bins; the reverse operator must exclude
-    those rows from the banded Tikhonov normal equations -- matching
-    :func:`gwtransport.deposition.extraction_to_deposition` -- rather than
-    reject the whole series. cout at 12h resolution (via ``flow_out``) vs daily
-    cin keeps the system overdetermined, so the surviving rows still pin every
-    interior cin bin and recovery stays at the no-gap round-trip floor.
+    cout at 12h resolution (via ``flow_out``) vs daily cin keeps the system
+    overdetermined, so the surviving rows pin every interior cin bin at the
+    no-gap round-trip floor.
     """
     n_days = 120
     tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")

--- a/tests/src/test_diffusion_fast_fast.py
+++ b/tests/src/test_diffusion_fast_fast.py
@@ -1328,3 +1328,38 @@ def test_negative_diffusivity_rejected():
             molecular_diffusivity=-1.0,
             longitudinal_dispersivity=1.0,
         )
+
+
+def test_extraction_to_infiltration_gapped_cout_masked():
+    """NaN gaps in cout are masked out of the banded inverse instead of raising (#321).
+
+    Sparse lab samples leave NaN cout bins; the reverse operator must exclude
+    those rows from the banded Tikhonov normal equations -- matching
+    :func:`gwtransport.deposition.extraction_to_deposition` -- rather than
+    reject the whole series. The reverse inverts the same approximate operator
+    the forward applies, so with cout at 12h resolution (via ``flow_out``) the
+    overdetermined surviving rows recover cin at the no-gap round-trip floor.
+    """
+    n_days = 120
+    tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")
+    cout_tedges = pd.date_range("2020-01-01", periods=2 * n_days + 1, freq="12h")
+    flow = np.full(n_days, 100.0)
+    cin_true = 5.0 + 3.0 * np.sin(2 * np.pi * np.arange(n_days) / 30.0)
+    kwargs = {
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([517.0]),
+        "streamline_length": 80.0,
+        "molecular_diffusivity": 0.01,
+        "longitudinal_dispersivity": 0.1,
+        "flow_out": np.full(2 * n_days, 100.0),
+    }
+
+    cout = infiltration_to_extraction(cin=cin_true, **kwargs)
+    cout[[0, 90, 120, 121, 150, 239]] = np.nan  # boundary + scattered gaps
+
+    cin_rec = extraction_to_infiltration(cout=cout, **kwargs)
+
+    interior = slice(30, 95)
+    assert_allclose(cin_rec[interior], cin_true[interior], atol=1e-10)

--- a/tests/src/test_diffusion_fast_fast.py
+++ b/tests/src/test_diffusion_fast_fast.py
@@ -1331,14 +1331,11 @@ def test_negative_diffusivity_rejected():
 
 
 def test_extraction_to_infiltration_gapped_cout_masked():
-    """NaN gaps in cout are masked out of the banded inverse instead of raising (#321).
+    """Gapped (NaN) cout: the banded reverse solve uses only the measured bins (#321).
 
-    Sparse lab samples leave NaN cout bins; the reverse operator must exclude
-    those rows from the banded Tikhonov normal equations -- matching
-    :func:`gwtransport.deposition.extraction_to_deposition` -- rather than
-    reject the whole series. The reverse inverts the same approximate operator
-    the forward applies, so with cout at 12h resolution (via ``flow_out``) the
-    overdetermined surviving rows recover cin at the no-gap round-trip floor.
+    The reverse inverts the same approximate operator the forward applies, so
+    with cout at 12h resolution (via ``flow_out``) the overdetermined surviving
+    rows recover cin at the no-gap round-trip floor.
     """
     n_days = 120
     tedges = pd.date_range("2020-01-01", periods=n_days + 1, freq="D")


### PR DESCRIPTION
## Summary

The reverse ("backwards model") operators' primary real-world input is sparse lab samples with time gaps, yet `advection.extraction_to_infiltration`, `diffusion.extraction_to_infiltration`, `diffusion_fast.extraction_to_infiltration`, and `diffusion_fast_fast.extraction_to_infiltration` rejected any NaN in `cout`, while `deposition.extraction_to_deposition` already masked NaN rows out of the banded normal equations. This adopts deposition's masking in the two shared solvers so all reverse operators apply one policy:

- `utils.solve_inverse_transport` (dense; diffusion): NaN observed rows drop out of the data equations **and** the regularization target — `compute_reverse_target` previously consumed raw `observed` and would be poisoned by NaN.
- `utils.solve_inverse_transport_banded` (advection, diffusion_fast, diffusion_fast_fast, deposition): zero the band row and observed value for NaN rows so `0 * NaN` cannot poison `Wᵀ·observed` or the semi-normal-equation refinement residual.
- Removed the reverse-path `_validate_no_nan(cout)` guards in `advection`, `diffusion`, and `_diffusion_shared`; forward `cin` and `flow` keep their NaN guards. Docstrings updated to the new contract.

cin bins constrained only by gapped `cout` bins come back NaN (never fabricated). `radial_asr.extraction_to_infiltration` still raises on NaN cout (listed as optional alignment in #321) and is left unchanged to keep this PR scoped to the headline advection/diffusion operators.

**Accepted-input behaviour is unchanged**: with NaN-free inputs the masks are all-False and every operation reduces to the previous arithmetic — verified bit-identical against `origin/main` for forward + reverse of all four modules and for deposition's gapped reverse.

## Test plan

- Baseline discipline: the four new regression tests (`test_extraction_to_infiltration_gapped_cout_masked` in `test_advection.py`, `test_diffusion.py`, `test_diffusion_fast.py`, `test_diffusion_fast_fast.py`) were run against unchanged `origin/main` first and all four **fail** there with `ValueError: cout contains NaN values`.
- Each test: forward on an overdetermined 12h-cout / daily-cin grid, inject boundary + scattered NaN gaps, reverse, and require recovery of the true cin at interior bins to `atol=1e-10` (observed floor ~8e-12, the no-gap round-trip floor). The advection test additionally zeroes a 2.5-day contiguous gap that fully covers the arrival window of two cin bins and asserts those bins return NaN.
- Removed the two parametrized validation cases that pinned the old "NaN cout raises" contract (test_advection.py, test_diffusion.py).
- Suites: `tests/src/test_advection.py` (145 passed), `test_advection_roundtrip.py` (3), `test_diffusion.py` (123), `test_diffusion_fast.py` + `test_diffusion_fast_fast.py` (289), `test_utils.py` + `test_deposition.py` (222).
- `ruff format`, `ruff check`, and `ty check` clean on all touched source files.

Closes #321

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.