### PR TITLE
fix(radial_asr): surface drift-path de Hoog breakdowns, dt-weight the phase clock, direction-gauge the Airy IC

### DIFF
--- a/src/gwtransport/_radial_asr_drift_kernels.py
+++ b/src/gwtransport/_radial_asr_drift_kernels.py
@@ -444,7 +444,7 @@ def _block_solutions(
         b13 = beta ** (1.0 / 3.0)
         zeta = b13 * r_far + beta ** (-2.0 / 3.0) / (4.0 * alpha_l * alpha_l)
         aie, aipe, _, _ = airye(zeta)
-        l0 = 1.0 / (2.0 * alpha_l) + b13 * (aipe / aie)
+        l0 = sigma_a / (2.0 * alpha_l) + b13 * (aipe / aie)
     else:
         astar = alpha_l * abs(a0) / d_m
         kappa = np.sqrt(retardation_factor * s / d_m)
@@ -803,10 +803,10 @@ def block_cout_deviation(
     floor *for constant-per-phase flow* (the public API dispatches ``v_d = 0`` to the scalar path for the
     bit-for-bit guarantee).
 
-    Within-phase variable flow is **approximate**: each phase is clocked in wall-clock time at its mean
-    magnitude ``a0 = mean(|flow[phase]|)`` (the drift breaks the flushed-volume-clock autonomy the scalar
-    ``D_m = 0`` path exploits for exact variable flow, and matches the scalar ``D_m > 0`` path's same mean-
-    flow approximation). It is exact for piecewise-constant flow. At ``v_d = 0`` it is additionally exact
+    Within-phase variable flow is **approximate**: each phase is clocked in wall-clock time at its
+    dt-weighted mean magnitude ``a0 = sum(|flow| dt) / sum(dt)`` -- the flushed volume over the phase
+    duration (the drift breaks the flushed-volume-clock autonomy the scalar ``D_m = 0`` path exploits
+    for exact variable flow, and matches the scalar ``D_m > 0`` path's same mean-flow approximation). It is exact for piecewise-constant flow. At ``v_d = 0`` it is additionally exact
     for constant ``cin`` over a phase at any flow profile (the resident profile then depends only on the
     total injected volume), leaving only the *variable cin AND variable flow* cin-placement error (bins at
     time corners rather than exact volume edges). Under drift no such exactness survives for any
@@ -873,12 +873,15 @@ def block_cout_deviation(
         return cout_empty[:, 0] if vector_input else cout_empty
     while phases[-1][0] == 0:  # trailing rest phases cannot affect any output; don't propagate or guard them
         phases.pop()
-    # Each pumping phase is clocked at its mean magnitude, so its A_0 = mean(|flow[phase]|)/(2 c_geo); the
+    # Each pumping phase is clocked at its dt-weighted mean magnitude (flushed volume / duration), so its
+    # A_0 = sum(|flow[phase]| dt)/sum(dt)/(2 c_geo); the
     # stagnation radius r_s = |A_0|/|v_d| is smallest for the weakest phase, so size the grid cap on that
     # (worst-case). Interior rest phases translate the plume by v_d t/R; the grid provisions for their
     # total shift. Leading rests act on an empty field and trailing rests are dropped above, so neither
     # counts -- idle padding must not inflate the envelope guard or dilute the radial resolution.
-    a0_min = min(float(np.mean(np.abs(flow[sl]))) for _, sl in pumping) / (2.0 * c_geo)
+    a0_min = min(float(np.sum(np.abs(flow[sl]) * dt_days[sl]) / np.sum(dt_days[sl])) for _, sl in pumping) / (
+        2.0 * c_geo
+    )
     nz = np.flatnonzero(flow != 0.0)
     interior = slice(nz[0], nz[-1] + 1)
     rest_time = float(np.sum(dt_days[interior][flow[interior] == 0.0]))
@@ -945,7 +948,7 @@ def block_cout_deviation(
                     n_modes=n_modes,
                 )
             continue
-        a0 = float(np.mean(np.abs(flow[sl]))) / (2.0 * c_geo)
+        a0 = float(np.sum(np.abs(flow[sl]) * dt_days[sl])) / (t_phase * 2.0 * c_geo)
         if sign > 0:  # injection: propagate the buffer, then add the freshly injected resident profile
             if np.any(field):
                 field = propagate(field, a0, _INJECTION, t_phase)

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -395,6 +395,11 @@ def _block_ensemble(
         elsewhere.
     """
     v_d = regional_flux / porosity
+    # block_cout_deviation returns NaN on injection / rest bins by contract (structural, expected). Only the
+    # extraction bins are accumulated, so those structural NaNs are dropped without a blanket nan_to_num --
+    # a genuine NaN on an EXTRACTION bin (a de Hoog breakdown) then propagates and surfaces instead of
+    # silently reading as the background (mirrors _reuse_ensemble).
+    ext_mask = flow < 0.0
     acc = np.zeros(np.shape(cin_deviation))
     for c_geo, w_i in zip(c_geos, weights, strict=True):
         m = (
@@ -402,21 +407,20 @@ def _block_ensemble(
             if n_modes is not None
             else _auto_n_modes(flow, dt_days, c_geo, well_radius, longitudinal_dispersivity, v_d, retardation_factor)
         )
-        acc += w_i * np.nan_to_num(
-            block_cout_deviation(
-                cin_deviation=cin_deviation,
-                flow=flow,
-                dt_days=dt_days,
-                c_geo=c_geo,
-                r_w=well_radius,
-                alpha_l=longitudinal_dispersivity,
-                v_d=v_d,
-                molecular_diffusivity=molecular_diffusivity,
-                retardation_factor=retardation_factor,
-                n_modes=m,
-                n_quad=n_quad,
-            )
+        dev = block_cout_deviation(
+            cin_deviation=cin_deviation,
+            flow=flow,
+            dt_days=dt_days,
+            c_geo=c_geo,
+            r_w=well_radius,
+            alpha_l=longitudinal_dispersivity,
+            v_d=v_d,
+            molecular_diffusivity=molecular_diffusivity,
+            retardation_factor=retardation_factor,
+            n_modes=m,
+            n_quad=n_quad,
         )
+        acc[ext_mask] += w_i * dev[ext_mask]
     return acc / np.sum(weights)
 
 

--- a/tests/src/test_radial_asr_drift.py
+++ b/tests/src/test_radial_asr_drift.py
@@ -22,12 +22,19 @@ import pandas as pd
 import pytest
 from _radial_asr_drift_fv_oracle import fv2d_cout_deviation  # ty: ignore[unresolved-import]  # tests/src on path
 from _radial_asr_drift_kernels_check import real_space_coupling, real_space_face  # ty: ignore[unresolved-import]
+from scipy.special import airye
 
 from gwtransport._radial_asr_dehoog import dehoog_inverse
-from gwtransport._radial_asr_drift_kernels import _face_matrices, block_coupling_matrices, block_cout_deviation
+from gwtransport._radial_asr_drift_kernels import (
+    _block_solutions,
+    _face_matrices,
+    block_coupling_matrices,
+    block_cout_deviation,
+)
 from gwtransport._radial_asr_reuse import cout_deviation
 from gwtransport.radial_asr import (
     _auto_n_modes,
+    _block_ensemble,
     extraction_to_infiltration,
     gamma_extraction_to_infiltration,
     gamma_infiltration_to_extraction,
@@ -983,3 +990,108 @@ def test_drift_loss_matches_fv_oracle():
     fv_loss = (fv_re(220) * (1 / 140) - fv_re(140) * (1 / 220)) / (1 / 140 - 1 / 220)
     assert abs(block_loss - fv_loss) < 0.05 * abs(fv_loss) + 1e-3
     assert block_loss > 0.0  # drift always reduces recovery
+
+
+# --- issue #310 regressions -----------------------------------------------------------------------
+def test_extraction_bin_nan_surfaces_not_background(monkeypatch):
+    """A genuine breakdown NaN on an EXTRACTION bin must surface through the drift ensemble instead of
+    silently reading as the background. block_cout_deviation returns NaN on injection / rest bins by
+    contract (structural, dropped), but an extraction-bin NaN is the de Hoog inverter's deliberate
+    breakdown signal (an overflowed kernel column is NOT masked); a blanket nan_to_num would erase it
+    and the public API would report cout == background for a failed inversion (issue #310)."""
+    flow = np.array([_Q] * 3 + [-_Q] * 4)
+    n = len(flow)
+    ext = flow < 0
+    poisoned = 4  # an extraction bin
+
+    def fake_block(cin_deviation, **_kwargs):
+        out = np.full(np.shape(cin_deviation), np.nan)
+        out[ext] = 0.25
+        out[poisoned] = np.nan  # a genuine de Hoog breakdown on one extraction bin
+        return out
+
+    monkeypatch.setattr("gwtransport.radial_asr.block_cout_deviation", fake_block)
+    tedges = pd.date_range("2024-01-01", periods=n + 1, freq="D")
+    background = 7.0
+    cout = infiltration_to_extraction(
+        cin=np.where(flow > 0, 1.0 + background, background),
+        flow=flow,
+        tedges=tedges,
+        cout_tedges=tedges,
+        pore_heights=_B,
+        porosity=_POROSITY,
+        well_radius=_R_W,
+        longitudinal_dispersivity=_ALPHA_L,
+        regional_flux=0.05,
+        background=background,
+        n_modes=2,
+        n_quad=16,
+    )
+    healthy = ext & (np.arange(n) != poisoned)
+    np.testing.assert_allclose(cout[healthy], background + 0.25)
+    assert np.isnan(cout[poisoned])  # NOT background: the failure must not masquerade as physics
+    # the (n, k) column-batch path (reverse operator build) must propagate the NaN row too
+    dev = _block_ensemble(
+        np.zeros((n, 2)),
+        flow=flow,
+        dt_days=np.ones(n),
+        c_geos=np.array([_C_GEO]),
+        porosity=_POROSITY,
+        well_radius=_R_W,
+        longitudinal_dispersivity=_ALPHA_L,
+        molecular_diffusivity=0.0,
+        retardation_factor=1.0,
+        regional_flux=0.05,
+        n_modes=2,
+        weights=np.array([1.0]),
+        n_quad=16,
+    )
+    assert np.isnan(dev[poisoned]).all()
+    np.testing.assert_allclose(dev[healthy], 0.25)
+    np.testing.assert_array_equal(dev[~ext], 0.0)  # structural inj/rest NaNs are dropped, not propagated
+
+
+def test_nonuniform_dt_within_phase_is_volume_clocked():
+    """Constant cin at v_d = 0: the block engine must match the volume-exact scalar engine even when dt
+    varies within a pumping phase. The phase clock is the dt-weighted mean |Q| (flushed volume over the
+    phase duration, matching the scalar reuse engine's flow_scale = phase_volume / phase_time); the
+    unweighted bin mean would clock this phase at 200 instead of 150 m^3/day (issue #310)."""
+    flow = np.concatenate([[100.0, 300.0], np.full(8, -150.0)])
+    dt = np.concatenate([[1.5, 0.5], np.ones(8)])
+    cin = np.where(flow > 0, 1.0, 0.0)
+    ext = flow < 0
+    kw = {"dt_days": dt, "c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_quad": 80, "n_terms": 40, "tol": 1e-11}
+    scalar = cout_deviation(cin_deviation=cin, flow=flow, **kw)
+    block = block_cout_deviation(cin_deviation=cin, flow=flow, v_d=0.0, n_modes=2, **kw)
+    np.testing.assert_allclose(block[ext], scalar[ext], atol=1e-6)
+
+
+def test_dm0_extraction_recessive_ic_carries_direction_gauge():
+    """The D_m = 0 recessive-Airy IC must carry the phase-direction gauge. At v_d = 0, m = 0 the radial
+    ODE is exactly ``c'' - (sigma/alpha_L) c' - (R s / (alpha_L A0)) r c = 0`` (sigma = -1 for
+    extraction), whose decaying solution is ``c = exp(sigma r / (2 alpha_L)) Ai(zeta)``, so
+    ``L = sigma/(2 alpha_L) + beta^{1/3} Ai'/Ai``. Hardcoding the injection gauge (+1) hands the
+    extraction Riccati a non-solution; over a short (stagnation-clipped) grid the inward attractor
+    cannot wash the O(1/alpha_L) error out before r_w (issue #310)."""
+    alpha_l, a0, r_w, r_far = 0.5, 20.0, 0.5, 1.5
+    s = np.array([0.1 + 0.0j])
+    r_nodes = np.linspace(0.6, 1.4, 5)
+    sol = _block_solutions(
+        s,
+        r_nodes,
+        r_w,
+        alpha_l=alpha_l,
+        a0=a0,
+        v_d=0.0,
+        d_m=0.0,
+        retardation_factor=1.0,
+        n_modes=0,
+        direction="extraction",
+        r_far=r_far,
+    )
+    beta = float(s[0].real) / (alpha_l * a0)
+    b13 = beta ** (1.0 / 3.0)
+    zeta = b13 * r_w + beta ** (-2.0 / 3.0) / (4.0 * alpha_l**2)
+    aie, aipe, _, _ = airye(zeta)
+    l_exact = -1.0 / (2.0 * alpha_l) + b13 * (aipe / aie)
+    np.testing.assert_allclose(sol["Lm_w"][0, 0, 0], l_exact, rtol=1e-5)


### PR DESCRIPTION
## Summary

Fixes the three defects of issue #310 in the regional-drift path (`regional_flux != 0`, from never-reviewed PR #290):

- **RAD-F1 (silent corruption)**: `_block_ensemble` accumulated `w_i * np.nan_to_num(block_cout_deviation(...))`, erasing the de Hoog inverter's deliberate breakdown NaN (`_radial_asr_dehoog.py` leaves an overflowed column as NaN precisely so a real failure cannot masquerade as a physical zero). A failed extraction-bin inversion therefore silently read as `cout == background` — in the forward path and in the reverse-operator column batch. Now mirrors the already-fixed scalar `_reuse_ensemble`: only extraction bins are accumulated, so the structural injection/rest NaNs are dropped while a genuine extraction-bin NaN propagates and surfaces.
- **RAD-F2 (non-uniform-dt clock error)**: the per-phase advective clock used the unweighted bin-mean flow, so the front scaled as `mean(|Q|) * sum(dt)` instead of the conserved flushed volume `sum(|Q| dt)` — a first-order error for non-uniform dt within a phase (existing tests only used uniform dt). Each phase (and the stagnation-envelope `a0_min`) is now clocked at the dt-weighted mean magnitude, matching the scalar engine's `flow_scale = phase_volume / phase_time`. Uniform-dt schedules are unchanged.
- **RAD-F3 (D_m = 0 IC gauge)**: at `v_d = 0, m = 0, D_m = 0` the radial ODE is exactly `c'' - (sigma/alpha_L) c' - (R s/(alpha_L A0)) r c = 0`, whose decaying solution is `c = exp(sigma r/(2 alpha_L)) Ai(zeta)`; the recessive-Airy IC hardcoded the injection gauge `+1/(2 alpha_L)` for both directions. It now carries `sigma_a` (−1 for extraction).

The default path (`regional_flux == 0`) is untouched.

## Test plan

Three regression tests added to `tests/src/test_radial_asr_drift.py`; each was confirmed to FAIL on unchanged `origin/main` before the fix and pass after:

- `test_extraction_bin_nan_surfaces_not_background`: baseline returned `cout == background` (7.0) at a poisoned extraction bin; now NaN surfaces, healthy bins and the (n, k) batch path are unchanged, structural inj/rest NaNs still read 0.
- `test_nonuniform_dt_within_phase_is_volume_clocked`: constant-cin, non-uniform-dt injection phase vs the volume-exact scalar engine — baseline mismatched by up to 2x relative (phase clocked at 200 instead of 150 m³/day); now agrees to the de Hoog floor (atol 1e-6).
- `test_dm0_extraction_recessive_ic_carries_direction_gauge`: independent closed-form oracle `L(r_w) = -1/(2 alpha_L) + beta^{1/3} Ai'/Ai` — baseline off by ~95% relative; now matches to rtol 1e-5.

Also run: the 17 targeted existing drift tests covering the changed paths (scalar reductions, U=0 dispatch, ensembles, batching, auto-n_modes, round trip, cache eviction, degenerate schedules) — all pass; `ruff format`/`ruff check` and `ty check` clean on the changed files.

Closes #310

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.