### PR TITLE
fix(diffusion_fast): cover and split interior zero-flow gaps in the banded C_F build

### DIFF
--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -118,6 +118,7 @@ def _pv_band_geometry(
     min_cin_flow: float,
     saturation_threshold: float,
     n_cin_bins: int,
+    stagnant_time_at_cout: npt.NDArray[np.floating],
 ) -> tuple[npt.NDArray[np.intp], npt.NDArray[np.intp]]:
     r"""Per-cout-row band bounds (lo, hi) in cin-bin columns for one streamtube (geometry only).
 
@@ -136,6 +137,12 @@ def _pv_band_geometry(
     genuine, non-negligible coefficient remains at column 0 (the warm-start tail of a wide bin with
     large ``tau`` -> large ``D_t``). Each row therefore additionally tests ``|x0| < U*2*sqrt(D_t0)``
     at edge 0 and, when non-saturated, drops its band lower bound to 0 so that tail is kept.
+
+    ``stagnant_time_at_cout`` is the interior zero-flow (stagnation) time accumulated before each
+    cout bin's upper edge [days]. During a pumped-off gap the moving-frame variance keeps growing
+    (``D_m * tau``) at frozen cumulative volume, so post-side columns before the gap carry a ``D_t``
+    larger than the front intercept plus the flowing slope bound; the gap-accumulated product
+    ``D_m * stagnant_time`` is added to the post-side intercept so those columns stay in the band.
 
     Returns
     -------
@@ -175,7 +182,10 @@ def _pv_band_geometry(
         molecular_diffusivity * np.maximum(t_cout_lo - tedges_days[np.minimum(center_post, n_cin_edges - 1)], 0.0)
         + disp
     )
-    a_post = np.maximum(a_post, a_pre)
+    # Interior stagnation: tau across a zero-flow gap grows without volume, so the flowing slope
+    # bound below misses D_m * (gap time) at post-side columns before the gap; add it to the
+    # intercept (conservative: all interior stagnant time before the row's upper edge).
+    a_post = np.maximum(a_post, a_pre) + molecular_diffusivity * stagnant_time_at_cout
     pre_x = 2.0 * u * np.sqrt(a_pre)
     if min_cin_flow > 0.0:
         b_max = longitudinal_dispersivity + molecular_diffusivity * r_vpv / (length * min_cin_flow)
@@ -296,8 +306,49 @@ def _pv_band_values(
     i_lo = i_edge[rows, lo_idx]
     i_hi = i_edge[rows + 1, hi_idx]
     dx = sw_hi - sw_lo
+    delta = i_hi - i_lo
+
+    # Stagnation (zero-flow gap) correction. The endpoint difference above integrates the exact
+    # 1-form dI = C_R dx + (dI/dD_t) dD_t along the bin; on flowing stretches dD_t/dx = D_s/v_s
+    # makes dI = C_F dx, but across a zero-flow gap x is frozen while tau (hence D_t) keeps
+    # growing, so a cout bin straddling a gap picks up a vertical int (dI/dD_t) dD_t that carries
+    # no extracted volume and does not belong in the flux-weighted bin average. Subtract, per
+    # (cout bin, zero-flow cin bin) overlap clipped to the bin's time span, the antiderivative
+    # jump at the gap's frozen breakthrough coordinate. Consecutive zero-flow bins telescope to
+    # the full gap jump; zero-length overlaps (grid-aligned cout edges) are skipped, keeping the
+    # aligned path bit-identical.
+    if molecular_diffusivity > 0.0:
+        gap_bins = np.nonzero((np.diff(v_cin) <= 0.0) & (np.diff(tedges_days) > 0.0))[0]
+        if gap_bins.size:
+            t_gap_lo, t_gap_hi = tedges_days[gap_bins], tedges_days[gap_bins + 1]
+            k_first = np.maximum(np.searchsorted(cout_tedges_days, t_gap_lo, side="right") - 1, 0)
+            k_last = np.minimum(np.searchsorted(cout_tedges_days, t_gap_hi, side="left") - 1, n_cout_bins - 1)
+            counts = np.maximum(k_last - k_first + 1, 0)
+            k_pair = np.repeat(k_first, counts) + (
+                np.arange(counts.sum()) - np.repeat(np.cumsum(counts) - counts, counts)
+            )
+            g_pair = np.repeat(np.arange(gap_bins.size), counts)
+            t_lo_pair = np.maximum(cout_tedges_days[k_pair], t_gap_lo[g_pair])
+            t_hi_pair = np.minimum(cout_tedges_days[k_pair + 1], t_gap_hi[g_pair])
+            keep = t_hi_pair > t_lo_pair
+            if np.any(keep):
+                k_pair, g_pair = k_pair[keep], g_pair[keep]
+                t_lo_pair, t_hi_pair = t_lo_pair[keep], t_hi_pair[keep]
+                cols = np.clip(col_start[k_pair][:, None] + band, 0, n_cin_edges - 1)
+                x_gap = (v_cin[gap_bins[g_pair], None] - v_cin[cols] - r_vpv) * length / r_vpv
+                disp_term = longitudinal_dispersivity * np.maximum(x_gap + length, 0.0)
+                t_c = tedges_days[cols]
+                dt_gap_lo = np.maximum(
+                    molecular_diffusivity * np.maximum(t_lo_pair[:, None] - t_c, 0.0) + disp_term, _DT_FLOOR
+                )
+                dt_gap_hi = np.maximum(
+                    molecular_diffusivity * np.maximum(t_hi_pair[:, None] - t_c, 0.0) + disp_term, _DT_FLOOR
+                )
+                jump = _breakthrough_antideriv(x_gap, dt_gap_hi) - _breakthrough_antideriv(x_gap, dt_gap_lo)
+                np.add.at(delta, k_pair, -jump)
+
     with np.errstate(divide="ignore", invalid="ignore"):
-        frac = np.where(dx > 0.0, (i_hi - i_lo) / dx, 0.0)
+        frac = np.where(dx > 0.0, delta / dx, 0.0)
 
     return frac[:, :-1] - frac[:, 1:]
 
@@ -388,6 +439,17 @@ def _closed_form_coeff_matrix(
     n_cout_bins = len(cout_tedges) - 1
     n_cin_bins = len(flow)
 
+    # Interior stagnation (zero-flow gap) time accumulated before each cout bin's upper edge, for
+    # the post-side band intercept (see _pv_band_geometry). The data-start plateau (including the
+    # 100-year warm-start pad when flow[0] == 0) is excluded: its columns share the data-start
+    # cumulative volume, so the per-row x0 tail check already covers them without forcing a
+    # record-wide band.
+    dv_bins = np.diff(cumulative_volume_at_cin)
+    stagnant_dt = np.where(dv_bins > 0.0, 0.0, np.diff(tedges_days))
+    stagnant_dt[: int(np.argmax(dv_bins > 0.0))] = 0.0
+    stagnant_cum = np.concatenate(([0.0], np.cumsum(stagnant_dt)))
+    stagnant_time_at_cout = np.interp(cout_tedges_days[1:], tedges_days, stagnant_cum)
+
     # PASS 1 (geometry): per-streamtube band bounds (lo, hi) in cin-bin columns; accumulate the
     # per-row union over streamtubes. union_lo / union_hi are the min / max bounds per cout row.
     union_lo = np.full(n_cout_bins, n_cin_bins - 1, dtype=np.intp)
@@ -410,6 +472,7 @@ def _closed_form_coeff_matrix(
             min_cin_flow=min_cin_flow,
             saturation_threshold=saturation_threshold,
             n_cin_bins=n_cin_bins,
+            stagnant_time_at_cout=stagnant_time_at_cout,
         )
         np.minimum(union_lo, lo, out=union_lo)
         np.maximum(union_hi, hi, out=union_hi)

--- a/tests/src/test_diffusion_fast.py
+++ b/tests/src/test_diffusion_fast.py
@@ -3187,3 +3187,94 @@ def test_leading_zero_flow_inverse_finite_and_matches_dense_reverse():
     both = interior & np.isfinite(cin_rec) & np.isfinite(cin_ref)
     assert np.sum(both) > 50
     assert_allclose(cin_rec[both], cin_ref[both], atol=1e-6, rtol=0.0)
+
+
+# =============================================================================
+# Interior zero-flow gap: band coverage and stagnation-straddle aggregation (#306)
+# =============================================================================
+
+
+def test_interior_zero_flow_gap_band_covers_gap_accumulated_diffusion():
+    """Interior zero-flow gap: the default band (U=7) reproduces the wide band (U=25).
+
+    During a pumped-off (zero-flow) gap, molecular diffusion keeps growing the moving-frame
+    variance ``D_t = D_m*tau + alpha_L*xi`` (``tau`` grows, ``xi`` frozen), so post-restart
+    cout bins carry non-saturated coefficients at pre-gap cin columns whose ``D_t`` includes
+    the full stagnation time. A post-side band extent sized from the dispersion slope and the
+    front intercept alone truncates those columns (errors up to ~5e-4 here, ~4.9e-3 in wider
+    scans); the record is long enough that the warm-start data-start tail check is saturated
+    and cannot mask the truncation. At any ``U >= ~6`` the dropped coefficients are exactly
+    zero, so the U=7 and U=25 builds must agree to machine precision.
+    """
+    n = 1200
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    flow[1000:1100] = 0.0
+    # Misaligned cout grid: same daily spacing, offset 6 h, so bins straddle the gap edges.
+    cout_tedges = tedges[:-1] + pd.Timedelta(hours=6)
+    tedges_days = tedges_to_days(tedges)
+    cout_days = tedges_to_days(cout_tedges, ref=tedges[0])
+    cumvol = cumulative_flow_volume(flow, dt_to_days(tedges))
+    flow_out = np.diff(np.interp(cout_days, tedges_days, cumvol)) / np.diff(cout_days)
+    cin = np.random.default_rng(42).random(n)
+    kwargs = {
+        "cin": cin,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([300.0]),
+        "streamline_length": 10.0,
+        "molecular_diffusivity": 0.1,
+        "longitudinal_dispersivity": 0.0,
+        "flow_out": flow_out,
+    }
+    cout_default = infiltration_to_extraction(**kwargs, saturation_threshold=7.0)
+    cout_wide = infiltration_to_extraction(**kwargs, saturation_threshold=25.0)
+    np.testing.assert_array_equal(np.isnan(cout_default), np.isnan(cout_wide))
+    valid = ~np.isnan(cout_default)
+    assert np.sum(valid) > 1000
+    assert_allclose(cout_default[valid], cout_wide[valid], atol=1e-13, rtol=0.0)
+
+
+@pytest.mark.parametrize(
+    ("d_m", "alpha_l", "pv"),
+    # (0.2, 0.1, 1500) is excluded: at that dispersion strength the 16-point quadrature reference
+    # itself carries a ~6e-12 resolution floor on this coarse grid even without a gap.
+    [(0.05, 0.1, 1000.0), (0.2, 0.0, 1500.0)],
+)
+def test_coarse_cout_straddling_flow_restart_matches_diffusion_quadrature(d_m, alpha_l, pv):
+    """Coarse cout bins straddling a zero-flow gap match the quadrature volume-weighted aggregate.
+
+    The banded ``C_F`` is a two-endpoint antiderivative difference ``(I(x_hi) - I(x_lo))/dx``,
+    exact whenever ``D_t`` follows the flow path (``dD_t/dx = D_s/v_s``). Across a stagnation
+    (zero-flow) interval, ``x`` is frozen while ``D_t`` keeps growing, so a coarse cout bin
+    straddling the gap must exclude the vertical ``int (dI/dD_t) dD_t`` jump -- no volume is
+    extracted during the gap, so it carries no weight in the flux-weighted bin average.
+    ``gwtransport.diffusion`` integrates in volume space and skips zero-``dV`` flow bins, so it
+    defines the aggregate exactly (a naive endpoint difference deviates by up to ~7e-3 here).
+    """
+    n = 60
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D")
+    flow = np.full(n, 100.0)
+    flow[20:30] = 0.0
+    # Coarse 4-day cout bins; bin [day 28, day 32) straddles the flow restart at day 30.
+    cout_tedges = tedges[::4]
+    tedges_days = tedges_to_days(tedges)
+    cout_days = tedges_to_days(cout_tedges, ref=tedges[0])
+    cumvol = cumulative_flow_volume(flow, dt_to_days(tedges))
+    flow_out = np.diff(np.interp(cout_days, tedges_days, cumvol)) / np.diff(cout_days)
+    cin = np.random.default_rng(7).random(n)
+    kwargs = {
+        "cin": cin,
+        "flow": flow,
+        "tedges": tedges,
+        "cout_tedges": cout_tedges,
+        "aquifer_pore_volumes": np.array([pv]),
+        "molecular_diffusivity": d_m,
+        "longitudinal_dispersivity": alpha_l,
+    }
+    cout_fast = infiltration_to_extraction(**kwargs, streamline_length=10.0, flow_out=flow_out)
+    cout_quad = diffusion_exact(**kwargs, streamline_length=np.array([10.0]))
+    both = np.isfinite(cout_fast) & np.isfinite(cout_quad)
+    assert np.sum(both) > 5
+    assert_allclose(cout_fast[both], cout_quad[both], atol=1e-12, rtol=0.0)


### PR DESCRIPTION
## Summary

Fixes the two certified `diffusion_fast` defects of #306, both in the coarse-cout / interior zero-flow-gap regime (the advertised machine-precision path — cout grid aligned with or finer than the flow grid, no gaps — is unchanged bit-for-bit):

- **DFA-F1 (zero-flow-gap band under-coverage)**: the post-side breakthrough-band extent in `_pv_band_geometry` was sized from the dispersion slope and the front `D_t` intercept only. Molecular diffusion accumulated across an interior pumped-off gap (`D_m * gap_time` at frozen cumulative volume) could leave genuinely unsaturated pre-gap columns outside the band at the default `saturation_threshold=7` (up to ~5e-4 in the regression config; the issue's wider scan found up to ~4.9e-3). The interior stagnant time accumulated before each cout bin's upper edge is now added to the post-side intercept. The data-start plateau (including the 100-year warm-start pad when `flow[0] == 0`) is deliberately excluded — its columns share the data-start volume and remain covered by the existing per-row `x0` tail check, so a leading plateau does not force a record-wide band.

- **DFA-F2 (stagnation-straddle vertical-path term)**: `C_F` per cout bin is the endpoint antiderivative difference `(I(x_hi) - I(x_lo)) / dx`, which integrates the exact 1-form `dI`. Across a zero-flow gap, `x` is frozen while `tau` (hence `D_t`) keeps growing, so a cout bin straddling a gap picked up a vertical `∫ (∂I/∂D_t) dD_t` term that carries no extracted volume and does not belong in the flux-weighted bin average (deviations up to ~6.6e-3 vs the `gwtransport.diffusion` quadrature, which integrates in volume space and skips zero-dV bins). `_pv_band_values` now subtracts the antiderivative jump over each (cout bin, zero-flow cin bin) time overlap; consecutive zero-flow bins telescope to the full gap jump, and zero-length overlaps (grid-aligned cout edges) are skipped so the aligned path stays bit-identical.

The reverse (Tikhonov) path picks up both fixes automatically through the shared operator build.

Remaining known cross-module deltas on coarse grids are **pre-existing and out of scope**: the concurrent-injection edge gating difference (parcels infiltrating during a cout bin — `gwtransport.diffusion` lumps them into the last pre-bin column) belongs to the #305 coarse-cout family, and `(D_m, alpha_L) = (0.2, 0.1)` on 4-day bins sits on a ~6e-12 resolution floor of the 16-point quadrature reference itself (present with no gap, on unchanged main).

## Test plan

Both regressions were run against unchanged `origin/main` first and **failed** there (discipline per CLAUDE.md):

- `test_interior_zero_flow_gap_band_covers_gap_accumulated_diffusion` — 1200-day record, 100-day interior gap, misaligned cout grid: default `U=7` vs `U=25` build agree to 1e-13 (baseline failed at ~3.7e-4).
- `test_coarse_cout_straddling_flow_restart_matches_diffusion_quadrature` — coarse 4-day cout bin straddling a flow restart, heat-regime `D_m`, vs the independent `gwtransport.diffusion` Gauss-Legendre oracle to 1e-12 (baseline failed at ~2.7e-3 / ~6.6e-3).

Verification beyond the new tests:

- `pytest tests/src/test_diffusion_fast.py tests/src/test_diffusion.py tests/src/test_diffusion_fast_fast.py` — 413 passed (includes the banded==dense bit-identity suite and the leading-zero-flow warm-start regressions).
- Adversarial scan (variable flow, two gaps, retardation R∈{1,2}, multi-PV, shifted/coarse grids): worst `U=7` vs `U=25` deviation 2.2e-16; straddle configs match the quadrature at ~1e-12.
- Bit-identity harness vs the pristine `origin/main` module: all no-gap forward configs (aligned/shifted/coarse/sub-bin grids, R∈{1,2}, zero-dispersion and dispersive) and the reverse path are bit-identical; gap configs on aligned grids are bit-identical as well.
- `ruff format`, `ruff check`, `ty check` clean on the changed source.

Closes #306

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.