### PR TITLE
fix: cheap guards and doc corrections from minor-findings roundup (#313)

### DIFF
--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -126,6 +126,11 @@ def _validate_advection_inputs(
     else:
         msg = "must provide cin_values (forward) or both cout_values and cout_tedges (reverse)"
         raise ValueError(msg)
+    # The docstrings promise a ValueError for non-monotonic infiltration time edges, which would
+    # otherwise silently corrupt the cumulative-volume mapping.
+    if np.any(np.diff(tedges.asi8) <= 0):
+        msg = "tedges must be strictly increasing"
+        raise ValueError(msg)
     _validate_no_nan(flow, name="flow")
     _validate_non_negative_array(flow, name="flow", message="flow must be non-negative (negative flow not supported)")
     _validate_retardation_factor(retardation_factor)

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -126,8 +126,7 @@ def _validate_advection_inputs(
     else:
         msg = "must provide cin_values (forward) or both cout_values and cout_tedges (reverse)"
         raise ValueError(msg)
-    # The docstrings promise a ValueError for non-monotonic infiltration time edges, which would
-    # otherwise silently corrupt the cumulative-volume mapping.
+    # Non-monotonic tedges would silently corrupt the cumulative-volume mapping.
     if np.any(np.diff(tedges.asi8) <= 0):
         msg = "tedges must be strictly increasing"
         raise ValueError(msg)

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -558,8 +558,12 @@ def extraction_to_deposition(
     ``O(n_cout * n_cin)``). Unlike advection (where rows sum to ~1), deposition
     rows sum to ``r_i = residence_time_i / (retardation_factor * porosity *
     thickness)``. Rows are
-    rescaled by ``r_i`` before solving: for systems where ``cout`` lies in
-    the column space of ``W`` this preserves the exact ``dep``, while for
+    rescaled by ``r_i`` before solving: when ``W`` has full column rank and
+    ``cout`` lies in its column space this preserves the exact ``dep`` (with
+    the default square ``spinup="constant"`` system the warm-start padding
+    makes ``W`` structurally rank-deficient, so even a forward-generated
+    ``cout`` is recovered only up to the nullspace, regardless of
+    ``regularization_strength``), while for
     overdetermined systems with noise it is equivalent to weighted least
     squares with weights ``1 / r_i^2`` (shorter residence times get more
     weight; under constant flow all ``r_i`` are equal and this reduces to

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -33,7 +33,10 @@ flow-bin boundaries, with extra front-centred panels wherever a sharp breakthrou
 is otherwise under-resolved).
 Prefer it only when the output grid is coarser than the flow detail -- it integrates the
 full within-bin flow, which the closed-form :mod:`gwtransport.diffusion_fast` approximates as
-constant per output bin. Otherwise that module computes the same physics to machine
+constant per output bin. Caveat (issue #305): on output grids so coarse that a cout bin is
+wider than a streamtube residence time, this module currently violates mass conservation
+(a breakthrough pulse can be silently deleted or amplified); validate column mass before
+trusting coarse-output results. Otherwise that module computes the same physics to machine
 precision for *every* parameter regime (including ``retardation_factor != 1`` with non-zero
 molecular diffusivity, whose flux correction it also evaluates in closed form) and is
 ~80-90x faster (no quadrature, no residence-time inversion). Both modules accept
@@ -1034,13 +1037,14 @@ def extraction_to_infiltration(
     -----
     The algorithm builds the forward coefficient matrix ``W_forward`` (same as
     used by :func:`infiltration_to_extraction`) and solves ``W_forward @ cin = cout``
-    using :func:`gwtransport.utils.solve_tikhonov`. This ensures mathematical
-    consistency between forward and inverse operations.
+    using :func:`gwtransport.utils.solve_inverse_transport`. This ensures
+    mathematical consistency between forward and inverse operations.
 
-    NaN values in ``cout`` are rejected. The Tikhonov solver here does not
-    mask NaN rows, so any NaN in ``cout`` would poison the solution. This
-    differs from :func:`gwtransport.deposition.extraction_to_deposition`,
-    whose regularized solver excludes NaN ``cout`` rows by construction.
+    NaN values in ``cout`` are rejected up front (ValueError): the dense
+    Tikhonov solve does not mask NaN rows, so a NaN measurement reaching it
+    would poison the whole solution. This differs from
+    :func:`gwtransport.deposition.extraction_to_deposition`, whose regularized
+    solver excludes NaN ``cout`` rows by construction.
 
     Examples
     --------

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -33,10 +33,10 @@ flow-bin boundaries, with extra front-centred panels wherever a sharp breakthrou
 is otherwise under-resolved).
 Prefer it only when the output grid is coarser than the flow detail -- it integrates the
 full within-bin flow, which the closed-form :mod:`gwtransport.diffusion_fast` approximates as
-constant per output bin. Caveat (issue #305): on output grids so coarse that a cout bin is
-wider than a streamtube residence time, this module currently violates mass conservation
-(a breakthrough pulse can be silently deleted or amplified); validate column mass before
-trusting coarse-output results. Otherwise that module computes the same physics to machine
+constant per output bin. Caveat: on output grids so coarse that a cout bin is wider than a
+streamtube residence time, this module violates mass conservation -- a breakthrough pulse
+can be silently deleted or amplified (#305); validate column mass before trusting
+coarse-output results. Otherwise that module computes the same physics to machine
 precision for *every* parameter regime (including ``retardation_factor != 1`` with non-zero
 molecular diffusivity, whose flux correction it also evaluates in closed form) and is
 ~80-90x faster (no quadrature, no residence-time inversion). Both modules accept

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -648,6 +648,11 @@ def extraction_to_infiltration(
     if np.any(np.isnan(cout[flow < 0.0])):
         msg = "cout contains NaN values on extraction bins, which are not allowed"
         raise ValueError(msg)
+    # A negative Tikhonov parameter would flow into np.sqrt below -> NaN augmented rows -> silent
+    # all-NaN cin (or an opaque lstsq convergence error); reject it up front.
+    if regularization_strength < 0.0:
+        msg = f"regularization_strength must be >= 0, got {regularization_strength}"
+        raise ValueError(msg)
     c_geos = np.pi * pore_heights * porosity
     # A rest phase with molecular diffusion routes to the reuse engine (see the forward function); regional
     # drift never uses the radial echo operator (it breaks the azimuthal symmetry the echo relies on).

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -610,7 +610,7 @@ def extraction_to_infiltration(
     molecular_diffusivity, retardation_factor, weights, background, regional_flux, n_modes, n_quad
         As in :func:`infiltration_to_extraction`.
     regularization_strength : float, optional
-        Tikhonov parameter. Default ``1e-10``.
+        Tikhonov parameter, must be non-negative. Default ``1e-10``.
 
     Returns
     -------
@@ -622,6 +622,8 @@ def extraction_to_infiltration(
     ValueError
         If ``cout`` contains NaN on any extraction bin (``flow < 0``), which would poison the
         least-squares solve. Structural NaN on injection / rest bins is allowed.
+        If ``regularization_strength`` is negative: it would reach ``np.sqrt`` in the augmented
+        system and silently produce an all-NaN ``cin``.
     """
     cout = np.asarray(cout, dtype=float)
     flow = np.asarray(flow, dtype=float)
@@ -648,8 +650,6 @@ def extraction_to_infiltration(
     if np.any(np.isnan(cout[flow < 0.0])):
         msg = "cout contains NaN values on extraction bins, which are not allowed"
         raise ValueError(msg)
-    # A negative Tikhonov parameter would flow into np.sqrt below -> NaN augmented rows -> silent
-    # all-NaN cin (or an opaque lstsq convergence error); reject it up front.
     if regularization_strength < 0.0:
         msg = f"regularization_strength must be >= 0, got {regularization_strength}"
         raise ValueError(msg)

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -670,13 +670,15 @@ def time_bin_overlap(*, tedges: npt.ArrayLike, bin_tedges: list[tuple]) -> npt.N
         raise ValueError(msg)
 
     # Normalize datetime-like inputs (datetime64 or object arrays of Timestamps/datetimes) to a
-    # common int64-nanosecond float scale so numeric, datetime64, and Timestamp inputs share one
-    # arithmetic path; ``np.maximum(0, Timedelta)`` on an object array would otherwise raise. Only
-    # differences enter the result, so the shared epoch origin cancels and the fractions are exact.
+    # common int64-nanosecond scale so numeric, datetime64, and Timestamp inputs share one
+    # arithmetic path; ``np.maximum(0, Timedelta)`` on an object array would otherwise raise.
+    # Stay in int64 through the differencing below: a float64 epoch value rounds to its ulp
+    # (1024 ns by the 2200s), which would corrupt sub-microsecond bins. Only exact int64
+    # differences enter the final float division, so the shared epoch origin cancels.
     if not np.issubdtype(tedges.dtype, np.number):
-        tedges = pd.DatetimeIndex(tedges).asi8.astype(float)
+        tedges = pd.DatetimeIndex(tedges).asi8
     if not np.issubdtype(bin_tedges_array.dtype, np.number):
-        flat = pd.DatetimeIndex(bin_tedges_array.ravel()).asi8.astype(float)
+        flat = pd.DatetimeIndex(bin_tedges_array.ravel()).asi8
         bin_tedges_array = flat.reshape(bin_tedges_array.shape)
 
     # Calculate overlaps for all combinations using broadcasting
@@ -769,7 +771,12 @@ def simplify_bins(
     new_edges = edges[idx]
     new_widths = np.add.reduceat(widths, s)
     weight_sums = np.add.reduceat(weights, s)
-    new_values = np.add.reduceat(weights * values, s) / weight_sums
+    # A merged group of all-zero-flow bins has zero volume weight (0/0 -> NaN); its average is
+    # still well defined, so fall back to width weighting there.
+    zero_weight = weight_sums == 0.0
+    new_values = np.where(
+        zero_weight, np.add.reduceat(widths * values, s), np.add.reduceat(weights * values, s)
+    ) / np.where(zero_weight, new_widths, weight_sums)
     # When flow is given, weights == flow * widths, so weight_sums == reduceat(flow * widths, s) exactly.
     new_flow = weight_sums / new_widths if flow is not None else None
 
@@ -1441,6 +1448,12 @@ def solve_tikhonov(
         d_reg[target_indices] = 1.0
         gram = valid_matrix.T @ valid_matrix
         gram[np.arange(n_cin), np.arange(n_cin)] += regularization_strength * d_reg
+        # A dead (all-zero) column with a NaN target is unregularized: its gram row/column is
+        # exactly zero, which would make the inverse singular. Pin its diagonal to 1 -- the
+        # block-diagonal structure leaves every other entry of the inverse unchanged and yields
+        # fraction_data = 1.0, the documented convention for non-regularized entries.
+        dead = np.diag(gram) == 0.0
+        gram[dead, dead] = 1.0
         gram_inv_diag = np.diag(np.linalg.inv(gram))
         fraction_data = 1.0 - regularization_strength * gram_inv_diag * d_reg
         return x, fraction_data

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -641,6 +641,9 @@ def time_bin_overlap(*, tedges: npt.ArrayLike, bin_tedges: list[tuple]) -> npt.N
     - tedges must be sorted in ascending order
     - Uses vectorized operations to handle large arrays efficiently
     - Time ranges in bin_tedges can be in any order and can overlap
+    - Datetime inputs are differenced in exact int64 nanoseconds before the final
+      float division; a float64 epoch value rounds to its ulp (1024 ns by the
+      2200s), which would corrupt sub-microsecond bins
 
     Examples
     --------
@@ -672,9 +675,7 @@ def time_bin_overlap(*, tedges: npt.ArrayLike, bin_tedges: list[tuple]) -> npt.N
     # Normalize datetime-like inputs (datetime64 or object arrays of Timestamps/datetimes) to a
     # common int64-nanosecond scale so numeric, datetime64, and Timestamp inputs share one
     # arithmetic path; ``np.maximum(0, Timedelta)`` on an object array would otherwise raise.
-    # Stay in int64 through the differencing below: a float64 epoch value rounds to its ulp
-    # (1024 ns by the 2200s), which would corrupt sub-microsecond bins. Only exact int64
-    # differences enter the final float division, so the shared epoch origin cancels.
+    # Kept in int64 through the differencing for exactness (see Notes); the epoch origin cancels.
     if not np.issubdtype(tedges.dtype, np.number):
         tedges = pd.DatetimeIndex(tedges).asi8
     if not np.issubdtype(bin_tedges_array.dtype, np.number):
@@ -1390,7 +1391,10 @@ def solve_tikhonov(
         - ``fraction_data[j] ≈ 1``: element *j* is data-driven
         - ``fraction_data[j] ≈ 0``: element *j* is target-driven
         - Non-regularized entries (NaN in ``x_target``):
-          ``fraction_data[j] = 1.0``
+          ``fraction_data[j] = 1.0``. This includes dead (all-zero) columns
+          with a NaN target: their zero gram row/column would make the
+          resolution inverse singular, so their diagonal is pinned to 1,
+          which leaves every other entry of the inverse unchanged.
 
     Raises
     ------
@@ -1448,10 +1452,8 @@ def solve_tikhonov(
         d_reg[target_indices] = 1.0
         gram = valid_matrix.T @ valid_matrix
         gram[np.arange(n_cin), np.arange(n_cin)] += regularization_strength * d_reg
-        # A dead (all-zero) column with a NaN target is unregularized: its gram row/column is
-        # exactly zero, which would make the inverse singular. Pin its diagonal to 1 -- the
-        # block-diagonal structure leaves every other entry of the inverse unchanged and yields
-        # fraction_data = 1.0, the documented convention for non-regularized entries.
+        # Dead (all-zero, NaN-target) columns leave a zero gram row/column; pin the diagonal
+        # to 1 so the inverse stays nonsingular (see Returns).
         dead = np.diag(gram) == 0.0
         gram[dead, dead] = 1.0
         gram_inv_diag = np.diag(np.linalg.inv(gram))

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -4627,3 +4627,35 @@ def test_fronttracking_domain_mass_interior_zero_flow_gap_matches_deleted_gap(so
             theta=theta, v_outlet=aquifer_pore_volume, waves=tracker_nogap.state.waves, sorption=sorption
         )
         np.testing.assert_allclose(mass_gap, mass_nogap, rtol=0.0, atol=1e-9)
+def test_infiltration_to_extraction_non_monotonic_tedges_raises():
+    """#313 ADV-P2: the docstring promises a ValueError for non-monotonic time edges.
+
+    Without the check, non-monotonic tedges silently corrupt the cumulative-volume
+    mapping and produce wrong output.
+    """
+    n = 10
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D").to_numpy().copy()
+    tedges[3], tedges[4] = tedges[4], tedges[3]  # swap two interior edges
+    with pytest.raises(ValueError, match="strictly increasing"):
+        infiltration_to_extraction(
+            cin=np.ones(n),
+            flow=np.full(n, 100.0),
+            tedges=pd.DatetimeIndex(tedges),
+            cout_tedges=pd.date_range("2020-01-01", periods=n + 1, freq="D"),
+            aquifer_pore_volumes=np.array([300.0]),
+        )
+
+
+def test_extraction_to_infiltration_non_monotonic_tedges_raises():
+    """#313 ADV-P2: the reverse (deconvolution) path must reject non-monotonic tedges too."""
+    n = 10
+    tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D").to_numpy().copy()
+    tedges[3], tedges[4] = tedges[4], tedges[3]
+    with pytest.raises(ValueError, match="strictly increasing"):
+        extraction_to_infiltration(
+            cout=np.ones(n),
+            flow=np.full(n, 100.0),
+            tedges=pd.DatetimeIndex(tedges),
+            cout_tedges=pd.date_range("2020-01-01", periods=n + 1, freq="D"),
+            aquifer_pore_volumes=np.array([300.0]),
+        )

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -4627,6 +4627,8 @@ def test_fronttracking_domain_mass_interior_zero_flow_gap_matches_deleted_gap(so
             theta=theta, v_outlet=aquifer_pore_volume, waves=tracker_nogap.state.waves, sorption=sorption
         )
         np.testing.assert_allclose(mass_gap, mass_nogap, rtol=0.0, atol=1e-9)
+
+
 def test_infiltration_to_extraction_non_monotonic_tedges_raises():
     """#313 ADV-P2: the docstring promises a ValueError for non-monotonic time edges.
 

--- a/tests/src/test_advection.py
+++ b/tests/src/test_advection.py
@@ -4630,11 +4630,7 @@ def test_fronttracking_domain_mass_interior_zero_flow_gap_matches_deleted_gap(so
 
 
 def test_infiltration_to_extraction_non_monotonic_tedges_raises():
-    """#313 ADV-P2: the docstring promises a ValueError for non-monotonic time edges.
-
-    Without the check, non-monotonic tedges silently corrupt the cumulative-volume
-    mapping and produce wrong output.
-    """
+    """Non-monotonic infiltration time edges raise ValueError instead of corrupting the volume mapping (#313)."""
     n = 10
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D").to_numpy().copy()
     tedges[3], tedges[4] = tedges[4], tedges[3]  # swap two interior edges
@@ -4649,7 +4645,7 @@ def test_infiltration_to_extraction_non_monotonic_tedges_raises():
 
 
 def test_extraction_to_infiltration_non_monotonic_tedges_raises():
-    """#313 ADV-P2: the reverse (deconvolution) path must reject non-monotonic tedges too."""
+    """The reverse (deconvolution) path also rejects non-monotonic tedges (#313)."""
     n = 10
     tedges = pd.date_range("2020-01-01", periods=n + 1, freq="D").to_numpy().copy()
     tedges[3], tedges[4] = tedges[4], tedges[3]

--- a/tests/src/test_radial_asr.py
+++ b/tests/src/test_radial_asr.py
@@ -645,3 +645,21 @@ class TestGeneralEngine:
         )
         ext = flow < 0
         np.testing.assert_allclose(pub[ext], eng[ext], rtol=1e-12, atol=1e-12)
+
+
+def test_reverse_negative_regularization_strength_raises():
+    """#313 RAC-P5: a negative Tikhonov parameter flowed into np.sqrt -> NaN -> silent all-NaN cin.
+
+    Reject it up front instead.
+    """
+    tedges, flow, geom = _scenario()
+    with pytest.raises(ValueError, match="regularization_strength"):
+        extraction_to_infiltration(
+            cout=np.zeros(len(flow)),
+            flow=flow,
+            tedges=tedges,
+            cout_tedges=tedges,
+            **geom,
+            regularization_strength=-1.0,
+            n_quad=80,
+        )

--- a/tests/src/test_radial_asr.py
+++ b/tests/src/test_radial_asr.py
@@ -648,10 +648,7 @@ class TestGeneralEngine:
 
 
 def test_reverse_negative_regularization_strength_raises():
-    """#313 RAC-P5: a negative Tikhonov parameter flowed into np.sqrt -> NaN -> silent all-NaN cin.
-
-    Reject it up front instead.
-    """
+    """Negative regularization_strength raises ValueError instead of a silent all-NaN cin (#313)."""
     tedges, flow, geom = _scenario()
     with pytest.raises(ValueError, match="regularization_strength"):
         extraction_to_infiltration(

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -1694,3 +1694,56 @@ def test_solve_inverse_transport_banded_rejects_nonpositive_lambda():
         solve_inverse_transport_banded(
             band_vals=band_vals, col_start=col_start, observed=observed, n_output=4, regularization_strength=0.0
         )
+
+
+def test_simplify_bins_all_zero_flow_group_falls_back_to_width_weights():
+    """#313 UTI-F2: a merged group whose bins all have zero flow has zero volume weight.
+
+    The volume-weighted average is then 0/0 -> NaN (with a RuntimeWarning) even though
+    the group's value is perfectly well defined; fall back to width weighting there.
+    """
+    edges = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    values = np.array([2.0, 2.0, 5.0, 5.0])
+    flow = np.array([0.0, 0.0, 10.0, 10.0])
+    new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow)
+    np.testing.assert_allclose(new_edges, [0.0, 2.0, 4.0])
+    np.testing.assert_allclose(new_values, [2.0, 5.0])
+    np.testing.assert_allclose(new_flow, [0.0, 10.0])
+
+
+def test_time_bin_overlap_nanosecond_precision_far_epoch():
+    """#313 UTI-F3: datetime edges must be differenced in int64 nanoseconds.
+
+    Converting asi8 to float64 BEFORE differencing rounds a year-2200 epoch value
+    (~7.3e18 ns, float64 ulp = 1024 ns) to the nearest 1024 ns, corrupting
+    sub-microsecond bins. Differences of int64 nanoseconds are exact.
+    """
+    base = pd.Timestamp("2200-01-01")
+    tedges = pd.DatetimeIndex([base + pd.Timedelta(n, "ns") for n in (0, 1000, 2000, 3000)])
+    bin_tedges = [(base + pd.Timedelta(500, "ns"), base + pd.Timedelta(1500, "ns"))]
+    result = time_bin_overlap(tedges=tedges, bin_tedges=bin_tedges)
+    np.testing.assert_allclose(result, [[0.5, 0.5, 0.0]], rtol=0, atol=0)
+
+
+def test_solve_tikhonov_resolution_dead_column_nan_target():
+    """#313 UTI-F4: a dead (all-zero) column whose x_target is NaN is unregularized.
+
+    Its gram row/column is then exactly zero and np.linalg.inv raised LinAlgError.
+    The pinned diagonal leaves every other resolution entry unchanged and reports
+    fraction_data = 1.0, the documented convention for non-regularized entries.
+    """
+    coeff = np.array([[1.0, 0.0], [2.0, 0.0]])
+    rhs = np.array([1.0, 2.0])
+    x_target = np.array([1.0, np.nan])
+    lam = 1e-10
+    x, fraction_data = solve_tikhonov(
+        coefficient_matrix=coeff,
+        rhs_vector=rhs,
+        x_target=x_target,
+        regularization_strength=lam,
+        return_resolution=True,
+    )
+    # lstsq returns the minimum-norm solution: dead column -> 0, live column exact.
+    np.testing.assert_allclose(x, [1.0, 0.0])
+    # Live column: R = 1 - lam / (||col||^2 + lam); dead unregularized column: 1.0 by convention.
+    np.testing.assert_allclose(fraction_data, [1.0 - lam / (5.0 + lam), 1.0], rtol=1e-12)

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -1708,6 +1708,7 @@ def test_simplify_bins_all_zero_flow_group_falls_back_to_width_weights():
     new_edges, new_values, new_flow = simplify_bins(edges=edges, values=values, flow=flow)
     np.testing.assert_allclose(new_edges, [0.0, 2.0, 4.0])
     np.testing.assert_allclose(new_values, [2.0, 5.0])
+    assert new_flow is not None  # narrow the flow=None overload for the type checker
     np.testing.assert_allclose(new_flow, [0.0, 10.0])
 
 

--- a/tests/src/test_utils.py
+++ b/tests/src/test_utils.py
@@ -1697,11 +1697,7 @@ def test_solve_inverse_transport_banded_rejects_nonpositive_lambda():
 
 
 def test_simplify_bins_all_zero_flow_group_falls_back_to_width_weights():
-    """#313 UTI-F2: a merged group whose bins all have zero flow has zero volume weight.
-
-    The volume-weighted average is then 0/0 -> NaN (with a RuntimeWarning) even though
-    the group's value is perfectly well defined; fall back to width weighting there.
-    """
+    """A merged group whose bins all have zero flow gets a width-weighted average, not NaN (#313)."""
     edges = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
     values = np.array([2.0, 2.0, 5.0, 5.0])
     flow = np.array([0.0, 0.0, 10.0, 10.0])
@@ -1713,11 +1709,10 @@ def test_simplify_bins_all_zero_flow_group_falls_back_to_width_weights():
 
 
 def test_time_bin_overlap_nanosecond_precision_far_epoch():
-    """#313 UTI-F3: datetime edges must be differenced in int64 nanoseconds.
+    """Datetime edges are differenced in exact int64 nanoseconds (#313).
 
-    Converting asi8 to float64 BEFORE differencing rounds a year-2200 epoch value
-    (~7.3e18 ns, float64 ulp = 1024 ns) to the nearest 1024 ns, corrupting
-    sub-microsecond bins. Differences of int64 nanoseconds are exact.
+    Near year 2200 the float64 ulp of an epoch-nanosecond value is 1024 ns, so
+    sub-microsecond bins require integer differencing to overlap exactly.
     """
     base = pd.Timestamp("2200-01-01")
     tedges = pd.DatetimeIndex([base + pd.Timedelta(n, "ns") for n in (0, 1000, 2000, 3000)])
@@ -1727,11 +1722,10 @@ def test_time_bin_overlap_nanosecond_precision_far_epoch():
 
 
 def test_solve_tikhonov_resolution_dead_column_nan_target():
-    """#313 UTI-F4: a dead (all-zero) column whose x_target is NaN is unregularized.
+    """A dead (all-zero) column with NaN x_target reports fraction_data = 1.0 (#313).
 
-    Its gram row/column is then exactly zero and np.linalg.inv raised LinAlgError.
-    The pinned diagonal leaves every other resolution entry unchanged and reports
-    fraction_data = 1.0, the documented convention for non-regularized entries.
+    Its pinned gram diagonal keeps the resolution inverse nonsingular and leaves
+    the live entries unchanged.
     """
     coeff = np.array([[1.0, 0.0], [2.0, 0.0]])
     rhs = np.array([1.0, 2.0])


### PR DESCRIPTION
## Summary

Fixes the independently verifiable cheap sub-items of the #313 minor-findings roundup; each behavioural guard ships with a regression test that fails on `origin/main` and passes here.

Behavioural guards (baseline-failing test for each):

- **RAC-P5** `radial_asr.extraction_to_infiltration`: negative `regularization_strength` flowed into `np.sqrt` → NaN augmented rows → silent all-NaN cin (or an opaque `SVD did not converge` LinAlgError). Now rejected up front with `ValueError`.
- **UTI-F2** `utils.simplify_bins`: a merged group of all-zero-flow bins has zero volume weight, so `new_values` was 0/0 → NaN (with RuntimeWarning). Falls back to width weighting for those groups.
- **UTI-F3** `utils.time_bin_overlap`: datetime edges were converted `asi8.astype(float)` *before* differencing; a far-epoch value (year 2200 ≈ 7.3e18 ns, float64 ulp = 1024 ns) corrupts sub-microsecond bins. Edges now stay int64 through the differencing; only the exact differences enter the final float division.
- **UTI-F4** `utils.solve_tikhonov(return_resolution=True)`: a dead (all-zero) column with a NaN `x_target` is unregularized, making its gram row/column exactly zero → `np.linalg.inv` raised LinAlgError. Its diagonal is pinned to 1 (block-diagonal, leaves all other inverse entries unchanged) and reports `fraction_data = 1.0`, the documented convention for non-regularized entries.
- **ADV-P2** `advection`: the docstring promised a `ValueError` for non-monotonic infiltration time edges but no check existed; non-monotone `tedges` silently produced wrong output. `_validate_advection_inputs` now enforces strictly increasing `tedges` on both forward and reverse paths.

Doc corrections (no behaviour change):

- **DEP-F1** `deposition`: rank-qualified the "preserves the exact dep" claim — with the default square `spinup="constant"` system the warm-start padding makes `W` structurally rank-deficient, so exactness only holds at full column rank.
- **DIF-P3** `diffusion`: the module docstring's coarse-output-grid recommendation now carries a caveat pointing at the issue #305 mass-conservation breach; the `extraction_to_infiltration` Notes now name the actual solver (`solve_inverse_transport`, not `solve_tikhonov`) and present the NaN-poison rationale as the reason NaN `cout` is rejected up front (`ValueError`) rather than as a reachable failure path.

Deferred sub-items (and why):

- **DFF-P1** (outlet Gaussian `q_mean`): superseded — #332/#335 rewrote `diffusion_fast_fast` to fold molecular diffusion into a volume-domain effective dispersivity; the original time-Gaussian outlet-kernel site no longer exists, and the remaining `q_mean` freeze is documented there as an approximation by design.
- **DIF-F2** (adaptive refine criterion `D_t`/tau term) and **DIF-P2** (gap-column normalization with `D_m > 0`): substantive numerical-accuracy work needing oracle-gated validation; not a cheap guard, out of scope for this roundup PR.
- **FTO-P3** (`decaying_fan` mass-integration `c_apex`) and **FTO-P4** (`plot_breakthrough_curve` missing `decaying_fan` branch): require front-tracking physics decisions (correct fan-tail concentration / a new render branch); best handled with the front-tracking follow-ups rather than as drive-by edits.

## Test plan

- New regression tests (all fail on `origin/main`, pass here):
  - `tests/src/test_radial_asr.py::test_reverse_negative_regularization_strength_raises`
  - `tests/src/test_utils.py::test_simplify_bins_all_zero_flow_group_falls_back_to_width_weights`
  - `tests/src/test_utils.py::test_time_bin_overlap_nanosecond_precision_far_epoch`
  - `tests/src/test_utils.py::test_solve_tikhonov_resolution_dead_column_nan_target`
  - `tests/src/test_advection.py::test_infiltration_to_extraction_non_monotonic_tedges_raises`
  - `tests/src/test_advection.py::test_extraction_to_infiltration_non_monotonic_tedges_raises`
- Full touched-module suites pass: `test_utils.py` (137), `test_advection.py` (147), `test_radial_asr.py` (44), `test_advection_roundtrip.py` + `test_deposition.py` + `test_deposition_utils.py` (107), `test_diffusion.py` (123).
- `ruff format` / `ruff check` clean on all touched files; `ty check` clean on all touched source files.

Closes #313

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
