### PR TITLE
fix: cross-module nit roundup — doc corrections, dead-code removal, edge-case guards (#314)

### DIFF
--- a/src/gwtransport/_radial_asr_kernels.py
+++ b/src/gwtransport/_radial_asr_kernels.py
@@ -143,6 +143,14 @@ def transfer_function(
     -------
     ndarray of complex
         ``g_hat(s)``, same shape as ``s``.
+
+    Notes
+    -----
+    Validity floor: for ``|s|`` below ~1e-10 the scaled-Airy building blocks of the
+    ``D_m = 0`` branch degenerate and the result is NaN instead of the analytic limit
+    ``g_hat -> 1``. This is unreachable through the public API: the smallest de Hoog
+    node is ``gamma ~ -ln(tol) / (2 * 1.3 * max(mu, tau)) ~ 8 / max(mu, tau)``, which
+    stays orders of magnitude above 1e-10 for any physical phase volume.
     """
     # Linear retardation rescales the constant-Q operator: A_0 -> A_0/R, D_m -> D_m/R (alpha_L is
     # geometric and unchanged); the residence time then scales by R.

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -1171,8 +1171,10 @@ def _flow_weighted_front_tracking_output(
 
     # A zero-flow input span leaves θ stationary, so its sub-bins have zero width in
     # θ and zero q·dt weight. Drop them before the exact averaging (which rejects
-    # non-positive-width bins); their concentration cannot affect the flow-weighted
-    # mean, so they read back as 0 and carry no weight. Consecutive kept bins stay
+    # non-positive-width bins); they read back as 0 and carry no weight in THIS
+    # averaging. Note this only handles the readback: a cin step injected during a
+    # zero-flow bin still enters the tracker as a wave at a degenerate θ and can
+    # corrupt adjacent output bins (issue #309). Consecutive kept bins stay
     # contiguous because the dropped bins share their neighbours' θ value.
     theta_lo, theta_hi = fine_theta_edges[:-1], fine_theta_edges[1:]
     nondegenerate = theta_hi > theta_lo

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -1151,6 +1151,12 @@ def _flow_weighted_front_tracking_output(
     -------
     ndarray
         Flow-weighted bin-averaged concentrations. Length = len(cout_tedges_days) - 1.
+
+    Notes
+    -----
+    Zero-flow sub-bins are dropped from the averaging only; a cin step injected
+    during a zero-flow bin still enters the tracker as a wave at a degenerate θ
+    and can corrupt adjacent output bins (#309).
     """
     inner_flow_edges = flow_tedges_days[
         (flow_tedges_days > cout_tedges_days[0]) & (flow_tedges_days < cout_tedges_days[-1])
@@ -1171,10 +1177,8 @@ def _flow_weighted_front_tracking_output(
 
     # A zero-flow input span leaves θ stationary, so its sub-bins have zero width in
     # θ and zero q·dt weight. Drop them before the exact averaging (which rejects
-    # non-positive-width bins); they read back as 0 and carry no weight in THIS
-    # averaging. Note this only handles the readback: a cin step injected during a
-    # zero-flow bin still enters the tracker as a wave at a degenerate θ and can
-    # corrupt adjacent output bins (issue #309). Consecutive kept bins stay
+    # non-positive-width bins); they read back as 0 and carry no weight in this
+    # averaging (see Notes for the #309 caveat). Consecutive kept bins stay
     # contiguous because the dropped bins share their neighbours' θ value.
     theta_lo, theta_hi = fine_theta_edges[:-1], fine_theta_edges[1:]
     nondegenerate = theta_hi > theta_lo

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -339,13 +339,17 @@ def deposition_to_extraction(
         Compound retardation factor, by default 1.0.
     spinup : {"constant"} | None, optional
         Spin-up policy applied before computing deposition weights.
-        Default ``"constant"`` shifts ``tedges[0]`` backward by
-        ``retardation_factor * aquifer_pore_volume / flow[0]`` and treats
-        ``dep`` and ``flow`` as constant at their first observed values
-        over the prepended interval. ``None`` keeps the existing
-        strict-validity behavior (NaN cout rows during spin-up). A float
-        raises ``NotImplementedError`` -- the fraction-threshold mode is
-        not implemented for deposition (matching the diffusion family).
+        Default ``"constant"`` shifts ``tedges[0]`` backward by at least
+        ``retardation_factor * aquifer_pore_volume / flow[0]`` (rounded up to
+        whole bins, plus one extra bin) and treats ``dep`` and ``flow`` as
+        constant at their first observed values over the prepended interval.
+        When the warm-start is undefined -- ``flow[0] <= 0``, zero/NaN pore
+        volume, a non-positive first bin width, or a pad exceeding the memory
+        cap -- ``"constant"`` silently reverts to the strict-validity
+        behavior. ``None`` keeps the existing strict-validity behavior (NaN
+        cout rows during spin-up). A float raises ``NotImplementedError`` --
+        the fraction-threshold mode is not implemented for deposition
+        (matching the diffusion family).
 
     Returns
     -------
@@ -360,12 +364,18 @@ def deposition_to_extraction(
         is the physically correct value rather than an undefined result. NaN is
         reserved for spin-up bins whose residence time is not yet resolved.
 
+        Cout bins lying entirely outside the flow record (before ``tedges[0]``
+        or after ``tedges[-1]``) also return ``0.0``: their out-of-record edges
+        clamp to the record boundaries, so they extract zero volume and fall
+        under the same zero-mass convention.
+
     Raises
     ------
     ValueError
         If tedges does not have one more element than dep or flow, if input
-        arrays contain NaN values, or if physical parameters are out of
-        valid range (porosity not in (0, 1), non-positive thickness or
+        arrays contain NaN values, if ``flow`` contains negative values, if
+        ``retardation_factor`` is less than 1.0, or if physical parameters are
+        out of valid range (porosity not in (0, 1), non-positive thickness or
         aquifer pore volume).
     NotImplementedError
         If ``spinup`` is anything other than ``None`` or ``"constant"`` (the
@@ -512,14 +522,17 @@ def extraction_to_deposition(
         values trust the data more (noisier, less biased). Default is 1e-10.
     spinup : {"constant"} | None, optional
         Spin-up policy applied before building the forward weight matrix.
-        Default ``"constant"`` shifts ``tedges[0]`` backward by
-        ``retardation_factor * aquifer_pore_volume / flow[0]`` and treats
-        flow as constant at its first value over the prepended interval;
-        the recovered deposition vector is sliced back to the original
-        ``tedges`` length so the public output shape is unchanged.
-        ``None`` keeps strict-validity behavior. A float raises
-        ``NotImplementedError`` -- the fraction-threshold mode is not
-        implemented for deposition (matching the diffusion family).
+        Default ``"constant"`` shifts ``tedges[0]`` backward by at least
+        ``retardation_factor * aquifer_pore_volume / flow[0]`` (rounded up to
+        whole bins, plus one extra bin) and treats flow as constant at its
+        first value over the prepended interval; the recovered deposition
+        vector is sliced back to the original ``tedges`` length so the public
+        output shape is unchanged. When the warm-start is undefined
+        (``flow[0] <= 0``, zero/NaN pore volume, non-positive first bin width,
+        or a pad exceeding the memory cap), ``"constant"`` silently reverts to
+        strict-validity behavior. ``None`` keeps strict-validity behavior. A
+        float raises ``NotImplementedError`` -- the fraction-threshold mode is
+        not implemented for deposition (matching the diffusion family).
 
     Returns
     -------
@@ -530,7 +543,10 @@ def extraction_to_deposition(
     Raises
     ------
     ValueError
-        If input dimensions are incompatible or if flow contains NaN values.
+        If input dimensions are incompatible, if flow contains NaN or negative
+        values, if ``retardation_factor`` is less than 1.0, or if physical
+        parameters are out of valid range (porosity not in (0, 1),
+        non-positive thickness or aquifer pore volume).
     NotImplementedError
         If ``spinup`` is anything other than ``None`` or ``"constant"`` (the
         fraction-threshold mode is not implemented for deposition).
@@ -553,9 +569,11 @@ def extraction_to_deposition(
     The forward model is ``W @ dep = cout``, where the weight matrix ``W``
     encodes the physical relationship between deposition rates and
     concentrations. ``W`` is genuinely banded -- row ``i`` is nonzero only on
-    the cin bins inside its residence-time window -- and is built and solved in
-    a compact banded layout (peak memory ``O(n_cin * band)``, never the dense
-    ``O(n_cout * n_cin)``). Unlike advection (where rows sum to ~1), deposition
+    the cin bins inside its residence-time window -- and is *built* in a
+    compact banded layout (peak memory ``O(n_cin * band)``); the Tikhonov
+    *solve* (:func:`gwtransport.utils.solve_inverse_transport_banded`)
+    transiently materializes the dense matrix and its Gram product
+    (``O(n_cout * n_cin + n_cin**2)``). Unlike advection (where rows sum to ~1), deposition
     rows sum to ``r_i = residence_time_i / (retardation_factor * porosity *
     thickness)``. Rows are
     rescaled by ``r_i`` before solving: for systems where ``cout`` lies in
@@ -723,13 +741,15 @@ def extraction_to_deposition_full(
         Default is None (uses numpy default).
     spinup : {"constant"} | None, optional
         Spin-up policy applied before building the forward weight matrix.
-        Default ``"constant"`` shifts ``tedges[0]`` backward by
-        ``retardation_factor * aquifer_pore_volume / flow[0]``; the
-        recovered deposition is sliced back to the original ``tedges``
-        length. ``None`` keeps strict-validity behavior. A float raises
-        ``NotImplementedError`` -- the fraction-threshold mode is not
-        implemented for deposition (matching the diffusion family).
-        See :func:`extraction_to_deposition` for full semantics.
+        Default ``"constant"`` shifts ``tedges[0]`` backward by at least
+        ``retardation_factor * aquifer_pore_volume / flow[0]`` (rounded up to
+        whole bins, plus one extra bin), silently reverting to strict-validity
+        when the warm-start is undefined; the recovered deposition is sliced
+        back to the original ``tedges`` length. ``None`` keeps strict-validity
+        behavior. A float raises ``NotImplementedError`` -- the
+        fraction-threshold mode is not implemented for deposition (matching
+        the diffusion family). See :func:`extraction_to_deposition` for full
+        semantics.
 
     Returns
     -------
@@ -741,9 +761,10 @@ def extraction_to_deposition_full(
     ------
     ValueError
         If cout_tedges does not have one more element than cout, if tedges
-        does not have one more element than flow, if flow contains NaN
-        values, or if physical parameters are out of valid range (porosity
-        not in (0, 1), non-positive thickness or aquifer pore volume).
+        does not have one more element than flow, if flow contains NaN or
+        negative values, if ``retardation_factor`` is less than 1.0, or if
+        physical parameters are out of valid range (porosity not in (0, 1),
+        non-positive thickness or aquifer pore volume).
     NotImplementedError
         If ``spinup`` is anything other than ``None`` or ``"constant"`` (the
         fraction-threshold mode is not implemented for deposition).
@@ -860,11 +881,10 @@ def spinup_duration(
     """
     # Spin-up is the residence time of water *currently being extracted*: how
     # far back in history we must know deposition to fully characterise the
-    # extracted concentration. This uses the ``extraction_to_infiltration``
-    # direction. Under variable flow this differs from
-    # ``infiltration_to_extraction`` (which would describe how long ahead
-    # water infiltrated at the first time step will take to be extracted, a
-    # forward-in-time question that is not what spin-up means).
+    # extracted concentration. For this boundary quantity -- the extraction
+    # time of the water infiltrated exactly at tedges[0] -- the two transport
+    # directions coincide: the infiltration->extraction and extraction->
+    # infiltration maps are inverses, so both solve V(t*) = R * V_p below.
     #
     # The smallest extraction time t* at which the extracted water was
     # infiltrated exactly at tedges[0] satisfies

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -147,7 +147,7 @@ from gwtransport.residence_time import fraction_explained_full
 from gwtransport.utils import cumulative_flow_volume, solve_inverse_transport
 
 # Numerical tolerance for coefficient sum to determine valid output bins
-EPSILON_COEFF_SUM = 1e-10
+_EPSILON_COEFF_SUM = 1e-10
 
 # Gauss-Legendre quadrature nodes and weights for volume-space integration
 _GL_NODES, _GL_WEIGHTS = np.polynomial.legendre.leggauss(16)
@@ -225,7 +225,9 @@ def _cfrac_mean_volume(
     (in volume units); a sub-interval whose front is under-resolved by a single
     16-point rule (front width far below the sub-interval width) is tiled with
     front-centred panels (see ``_FRONT_OFFSETS``), while smooth/already-resolved
-    sub-intervals keep the plain single 16-point rule (bit-identical to it). No
+    sub-intervals keep the plain single 16-point rule (bit-identical to it *per
+    sub-interval*; a cell split at flow-bin boundaries still integrates more
+    accurately than one un-split rule over the whole cell). No
     "fully capped" branch: the moving-frame variance keeps growing past
     breakthrough, and the K-Z identity requires Bear's formula to satisfy the
     variable-coefficient ADE exactly (which it does only without capping).
@@ -945,7 +947,7 @@ def infiltration_to_extraction(
     # Output bins are invalid where the coefficient sum is near zero (no cin has broken
     # through yet) or the bin extends beyond the input data range (valid_cout_bins).
     total_coeff = np.sum(coeff_matrix, axis=1)
-    no_valid_contribution = (total_coeff < EPSILON_COEFF_SUM) | ~valid_cout_bins
+    no_valid_contribution = (total_coeff < _EPSILON_COEFF_SUM) | ~valid_cout_bins
     cout[no_valid_contribution] = np.nan
 
     return cout
@@ -1043,8 +1045,9 @@ def extraction_to_infiltration(
     -----
     The algorithm builds the forward coefficient matrix ``W_forward`` (same as
     used by :func:`infiltration_to_extraction`) and solves ``W_forward @ cin = cout``
-    using :func:`gwtransport.utils.solve_tikhonov`. This ensures mathematical
-    consistency between forward and inverse operations.
+    using :func:`gwtransport.utils.solve_inverse_transport` (which builds the
+    reverse regularization target and then applies Tikhonov regularization).
+    This ensures mathematical consistency between forward and inverse operations.
 
     NaN values in ``cout`` are rejected. The Tikhonov solver here does not
     mask NaN rows, so any NaN in ``cout`` would poison the solution. This

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -19,8 +19,8 @@ antiderivative ``I(x) = 0.5*x + 0.5*[x*erf(x/s) + (s/sqrt(pi))*exp(-(x/s)^2)]``,
 ``s = 2*sqrt(D_t)``. Evaluating ``I`` once per cout edge with ``D_t`` carried *per edge*
 and differencing yields the flux concentration ``C_F`` directly -- not merely ``C_R`` --
 because ``dD_t/dx = D_m/v_s + alpha_L = D_s/v_s`` is exactly the Kreft-Zuber flux coefficient
-at the solute-front velocity ``v_s = Q*L/(R*V_pore)`` (using ``d(tau)/dx = 1/v_s`` with
-``tau = R*V/(L*Q)``). The dispersive boundary-flux correction therefore emerges from the
+at the solute-front velocity ``v_s = Q*L/(R*V_pore)`` (using ``d(tau)/dx = 1/v_s =
+R*V_pore/(L*Q)``). The dispersive boundary-flux correction therefore emerges from the
 ``D_t`` variation across the bin; no explicit correction term is added.
 
 The elapsed time ``tau`` and travel distance ``xi`` are read directly from the time and
@@ -124,7 +124,8 @@ def _pv_band_geometry(
     Locates the narrow cumulative-volume band where the breakthrough transitions between 0 and 1
     -- the only cin bins with a non-zero coefficient. Within a streamtube the moving-frame
     dispersion product is exactly linear in the breakthrough coordinate, ``D_t(x) = A + B*x``,
-    with slope ``B = dD_t/dx = R*D_m/v + alpha_L`` and intercept ``A`` the front value, so the
+    with slope ``B = dD_t/dx = R*D_m/v_fluid + alpha_L`` (``v_fluid = Q*L/V_pore``) and
+    intercept ``A`` the front value, so the
     saturation edge ``|x| = saturation_threshold * 2*sqrt(D_t(x))`` is the root of a quadratic --
     the band half-width is closed form, no iteration. The band is centred per cout bin on the
     front ``V_cin = V_cout - R*V_pore`` and mapped to cin-edge columns with ``searchsorted`` (so
@@ -224,7 +225,7 @@ def _pv_band_values(
 
     ``C_F`` over a cout bin is ``(I(x_hi) - I(x_lo)) / dx`` with the closed-form antiderivative
     ``I`` evaluated at the two cout edges bounding the bin. Because ``D_t = D_m*tau + alpha_L*xi``
-    with ``tau = R*V/(L*Q)``, the antiderivative's slope ``dD_t/dx = R*D_m/v_fluid + alpha_L =
+    with ``d(tau)/dx = 1/v_s = R*V_pore/(L*Q)``, the antiderivative's slope ``dD_t/dx = R*D_m/v_fluid + alpha_L =
     D_s/v_s`` is exactly the Kreft-Zuber flux coefficient at the solute-front velocity
     ``v_s = Q*L/(R*V_pore)``, so the flux concentration emerges natively -- no correction term is
     added. The stripe is the band itself: each row spans cin edges
@@ -492,7 +493,7 @@ def infiltration_to_extraction(
         Travel distance L [m]: a scalar (shared by all streamtubes) or an array with one
         value per aquifer pore volume. Must be positive.
     molecular_diffusivity : float or ndarray
-        Effective molecular diffusivity D_m [m²/day]: scalar or one value per pore volume.
+        Effective (retarded-frame) molecular diffusivity D_m [m²/day]: scalar or one value per pore volume.
         Must be non-negative.
     longitudinal_dispersivity : float or ndarray
         Longitudinal dispersivity alpha_L [m] (microdispersion): scalar or one value per pore volume.
@@ -620,7 +621,7 @@ def extraction_to_infiltration(
         Travel distance L [m]: a scalar (shared by all streamtubes) or an array with one
         value per aquifer pore volume. Must be positive.
     molecular_diffusivity : float or ndarray
-        Effective molecular diffusivity D_m [m²/day]: scalar or one value per pore volume.
+        Effective (retarded-frame) molecular diffusivity D_m [m²/day]: scalar or one value per pore volume.
         Must be non-negative.
     longitudinal_dispersivity : float or ndarray
         Longitudinal dispersivity alpha_L [m] (microdispersion): scalar or one value per pore volume.
@@ -748,7 +749,7 @@ def gamma_infiltration_to_extraction(
     streamline_length : float
         Travel distance L [m], applied to all gamma streamtubes. Must be positive.
     molecular_diffusivity : float
-        Effective molecular diffusivity D_m [m²/day], applied to all streamtubes. Must be
+        Effective (retarded-frame) molecular diffusivity D_m [m²/day], applied to all streamtubes. Must be
         non-negative.
     longitudinal_dispersivity : float
         Longitudinal dispersivity alpha_L [m] (microdispersion), applied to all streamtubes. Must be
@@ -841,7 +842,7 @@ def gamma_extraction_to_infiltration(
     streamline_length : float
         Travel distance L [m], applied to all gamma streamtubes. Must be positive.
     molecular_diffusivity : float
-        Effective molecular diffusivity D_m [m²/day], applied to all streamtubes. Must be
+        Effective (retarded-frame) molecular diffusivity D_m [m²/day], applied to all streamtubes. Must be
         non-negative.
     longitudinal_dispersivity : float
         Longitudinal dispersivity alpha_L [m] (microdispersion), applied to all streamtubes. Must be

--- a/src/gwtransport/diffusion_fast_fast.py
+++ b/src/gwtransport/diffusion_fast_fast.py
@@ -377,11 +377,11 @@ def _build_forward_operator(
     # bins). residence_time uses the extended grid when warm-starting so spin-up bins stay valid.
     work_tedges = tedges
     if extend:
-        edge_values = tedges.to_numpy().copy()
-        delta = np.timedelta64(36500, "D")
-        edge_values[0] -= delta
-        edge_values[-1] += delta
-        work_tedges = pd.DatetimeIndex(edge_values)
+        # Timestamp arithmetic keeps the input timezone (tz-naive stays naive, tz-aware
+        # stays tz-aware); going through ``.to_numpy()`` would strip the tz. Mirrors
+        # diffusion_fast's extension.
+        pad = pd.Timedelta(days=36500)
+        work_tedges = (tedges[:1] - pad).append(tedges[1:-1]).append(tedges[-1:] + pad)
     # Output bin valid where every streamtube's advective look-back is in-record across the whole
     # bin (advective coverage == 1 for all pore volumes; NaN outside the record -> invalid).
     valid = np.all(

--- a/src/gwtransport/diffusion_fast_fast.py
+++ b/src/gwtransport/diffusion_fast_fast.py
@@ -378,8 +378,7 @@ def _build_forward_operator(
     work_tedges = tedges
     if extend:
         # Timestamp arithmetic keeps the input timezone (tz-naive stays naive, tz-aware
-        # stays tz-aware); going through ``.to_numpy()`` would strip the tz. Mirrors
-        # diffusion_fast's extension.
+        # stays tz-aware); going through ``.to_numpy()`` would strip the tz.
         pad = pd.Timedelta(days=36500)
         work_tedges = (tedges[:1] - pad).append(tedges[1:-1]).append(tedges[-1:] + pad)
     # Output bin valid where every streamtube's advective look-back is in-record across the whole

--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -14,7 +14,11 @@ Functions
     compute_domain_mass(theta, v_outlet, waves, sorption)
     compute_cumulative_inlet_mass(theta, cin, theta_edges)
     compute_cumulative_outlet_mass(theta, v_outlet, waves, sorption, *, cin, theta_edges)
-    compute_total_outlet_mass(v_outlet, sorption, *, cin, theta_edges) -> float
+    compute_total_outlet_mass(*, cin, theta_edges) -> float
+    identify_outlet_segments(theta_start, theta_end, v_outlet, waves, ...)
+    integrate_rarefaction_exact(raref, v_outlet, theta_start, theta_end, sorption)
+    integrate_fan_exact(theta_origin, v_origin, v_outlet, theta_start, theta_end, sorption, c_apex=0.0)
+    integrate_fan_spatial_exact(theta_origin, v_origin, v_start, v_end, theta, sorption, c_apex=0.0)
 
 Outlet-mass functions use the PDE conservation identity
 ``m_out(θ) = m_in(θ) − m_dom(θ)`` (Bear & Cheng 2010, Ch. 3: mass
@@ -650,8 +654,7 @@ def _integrate_fan_exact_universal(
 
     # For a c_apex=0 fan the upper bound may be +∞. The integral converges only when
     # c → 0 as R → ∞ (so base·c → 0). Freundlich n<1 (c → ∞ as R → ∞) diverges — reject it
-    # explicitly. (DecayingShockWave.mass_after_outlet_arrival returns 0 for the n<1 mirror
-    # before reaching here, so this is a defensive guard for direct callers.)
+    # explicitly via the fan_converges_at_infinity guard.
     if theta_end_fan == float("inf") and not sorption.fan_converges_at_infinity():
         msg = "Fan integral diverges at θ=+∞ for this sorption (e.g. Freundlich n<1); pass a finite theta_end"
         raise ValueError(msg)
@@ -1200,8 +1203,6 @@ def compute_cumulative_outlet_mass(
 
 
 def compute_total_outlet_mass(
-    v_outlet: float,  # noqa: ARG001
-    sorption: SorptionModel,  # noqa: ARG001
     *,
     cin: npt.ArrayLike,
     theta_edges: npt.NDArray[np.floating],
@@ -1221,10 +1222,6 @@ def compute_total_outlet_mass(
 
     Parameters
     ----------
-    v_outlet : float
-        Outlet position [m³] (unused for ``c_∞ = 0``; the ``+inf`` branch does not need it).
-    sorption : SorptionModel
-        Sorption model (kept for API symmetry; no ``C_T`` evaluation is required).
     cin : array-like (kw-only)
         Inlet concentration per θ-bin [mass/volume].
     theta_edges : ndarray (kw-only)

--- a/src/gwtransport/fronttracking/solver.py
+++ b/src/gwtransport/fronttracking/solver.py
@@ -123,9 +123,8 @@ class FrontTrackerState:
         ``flow[i] == 0``, θ is constant across ``[tedges_days[i], tedges_days[i+1])``;
         ``np.searchsorted(..., side='right') - 1`` lands on the rightmost
         such bin, so this function returns ``tedges_days[i]`` for the
-        right-most i sharing that θ. Events scheduled at zero-flow bin
-        boundaries therefore align with the END of the zero-flow interval
-        — pick one convention and call it documented.
+        right-most i sharing that θ. Convention: events at a zero-flow θ
+        plateau map to the END of the zero-flow interval.
         """
         if theta <= self.theta_edges[0]:
             return float(self.tedges_days[0])

--- a/src/gwtransport/fronttracking/waves.py
+++ b/src/gwtransport/fronttracking/waves.py
@@ -1558,7 +1558,9 @@ def _c_decay_freundlich(
     alpha = sorption.bulk_density * sorption.k_f / sorption.porosity
 
     if c_fixed == 0.0:
-        if np.isclose(n, 2.0, rtol=1e-12):
+        # atol=0.0: the default atol=1e-8 would silently route any n within 1e-8 of 2
+        # to the n=2 closed form instead of the general-n inversion.
+        if np.isclose(n, 2.0, rtol=1e-12, atol=0.0):
             disc = k_invariant * k_invariant + theta_local * k_invariant * alpha
             u = (k_invariant + np.sqrt(disc)) / theta_local
             return float(u * u)

--- a/src/gwtransport/gamma.py
+++ b/src/gwtransport/gamma.py
@@ -123,6 +123,10 @@ def parse_parameters(
         msg = "Provide either (alpha, beta) or (mean, std), not both."
         raise ValueError(msg)
 
+    if (mean is None) != (std is None):
+        msg = "mean and std must both be provided or both be None."
+        raise ValueError(msg)
+
     # The ``or beta is None`` is redundant at runtime (the check above pairs them) but lets the
     # type checker narrow ``beta`` to a float on the fall-through return.
     if alpha is None or beta is None:
@@ -382,6 +386,11 @@ def bins(
             raise ValueError(msg)
         n_bins = len(quantile_edges) - 1
     else:
+        if n_bins <= 1:
+            # Validate before np.linspace: a negative n_bins would otherwise surface as
+            # numpy's opaque "Number of samples ... must be non-negative" error.
+            msg = "Number of bins must be greater than 1"
+            raise ValueError(msg)
         quantile_edges = np.linspace(0, 1, n_bins + 1)
 
     if n_bins <= 1:
@@ -417,8 +426,9 @@ def bins(
 
     # Conditional mean within each bin for the unshifted distribution, then shift by loc.
     # E[X | a <= X < b] for X ~ Gamma(alpha, beta) uses the identity
-    #     E[X * 1_{a<=X<b}] = alpha * beta * (F_{alpha+1}(b/beta) - F_{alpha+1}(a/beta))
-    # where F_{alpha+1} is the CDF of Gamma(alpha+1, beta).
+    #     E[X * 1_{a<=X<b}] = alpha * beta * (F_{alpha+1}(b) - F_{alpha+1}(a))
+    # where F_{alpha+1} is the CDF of Gamma(alpha+1, scale=beta) (equivalently the regularized
+    # lower incomplete gamma P(alpha+1, b/beta) - P(alpha+1, a/beta)).
     cdf_alpha_plus_1 = gamma_dist.cdf(unshifted_edges, alpha + 1, scale=beta)
     diff_alpha_plus_1 = np.diff(cdf_alpha_plus_1)
 

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -319,7 +319,8 @@ def _auto_n_modes(
     r"""Azimuthal truncation ``M`` sized from the drift ratio ``eps`` and the rest-phase displacement.
 
     The pumping-phase mode amplitudes decay geometrically, ``|c_m| ~ eps^|m|`` with
-    ``eps = v_d R_b / A_0``, so keeping modes ``-M .. M`` truncates the azimuthal field at
+    ``eps = v_d (R_b + delta) / A_0`` (worst-case ratio at the rest-displaced plume edge, so the
+    rest displacement ``delta`` feeds this bound too), so keeping modes ``-M .. M`` truncates the azimuthal field at
     ``O(eps^{M+1})``; ``M`` is chosen so that tail is below ``~5e-3``. An interior rest phase
     additionally translates the plume by ``delta = v_d t_rest / R`` (the free-space rest kernel's
     own translation; idle bins before the first or after the last pumping do not move the field),
@@ -356,7 +357,9 @@ def _auto_n_modes(
     # Rest translation is v_d t / R (the free-space rest kernel's exact drift), not v_d t.
     delta = abs(v_d) * float(np.sum(dt_days[interior][flow[interior] == 0.0])) / retardation_factor
     eps = min(abs(v_d) * (r_b + delta) / abs(a0), _RS_FRAC)
-    m_eps = int(np.ceil(np.log(5e-3) / np.log(eps))) if eps > 0.0 else 2
+    # eps > 0 always holds here: v_d != 0 (this function is only reached for nonzero drift),
+    # r_b >= r_w > 0, and a0 > 0.
+    m_eps = int(np.ceil(np.log(5e-3) / np.log(eps)))
     width = np.sqrt(longitudinal_dispersivity * r_b + longitudinal_dispersivity**2)
     m_shift = int(np.ceil(delta / width)) + 2 if delta > 0.0 else 2
     return int(np.clip(max(m_eps, m_shift), 2, 8))

--- a/tests/regression/test_phase1_invariants.py
+++ b/tests/regression/test_phase1_invariants.py
@@ -412,8 +412,6 @@ def test_mass_balance_freundlich_nhalf_mirror_pointwise_breakthrough(n):
     # old finite form ``m_in − C_T(c_∞)·V_outlet`` mixed a finite record
     # integral with an infinite-time steady-state fill and could go negative.
     mass_out = compute_total_outlet_mass(
-        v_outlet=v_outlet,
-        sorption=sorption,
         cin=cin,
         theta_edges=tr.state.theta_edges,
     )
@@ -442,8 +440,6 @@ def test_mass_balance_freundlich_n2_multipulse():
 
     mass_in = float(np.sum(cin * np.diff(tr.state.theta_edges)))
     mass_out = compute_total_outlet_mass(
-        v_outlet=v_outlet,
-        sorption=sorption,
         cin=cin,
         theta_edges=tr.state.theta_edges,
     )
@@ -545,8 +541,6 @@ def test_freundlich_n_just_above_1_plateau_holds_inlet_c():
 
     mass_in = float(np.sum(cin * np.diff(tr.state.theta_edges)))
     mass_out = compute_total_outlet_mass(
-        v_outlet=v_outlet,
-        sorption=sorption,
         cin=cin,
         theta_edges=tr.state.theta_edges,
     )

--- a/tests/src/test_front_tracking_output.py
+++ b/tests/src/test_front_tracking_output.py
@@ -942,10 +942,9 @@ class TestTotalOutletMassSemantics:
 
     def test_pulse_returns_injected_mass(self):
         """``cin[-1] == 0`` returns the finite injected mass ``Σ cin·Δθ``."""
-        sorption = FreundlichSorption(k_f=0.01, n=2.0, bulk_density=1500.0, porosity=0.3)
         cin = np.array([0.0, 4.0, 4.0, 0.0])
         theta_edges = np.array([0.0, 100.0, 200.0, 300.0, 400.0])
-        m_out = compute_total_outlet_mass(v_outlet=500.0, sorption=sorption, cin=cin, theta_edges=theta_edges)
+        m_out = compute_total_outlet_mass(cin=cin, theta_edges=theta_edges)
         assert m_out == float(np.sum(cin * np.diff(theta_edges)))  # = 800.0, exact
 
     def test_sustained_ambient_returns_inf_not_negative(self):
@@ -956,7 +955,7 @@ class TestTotalOutletMassSemantics:
         v_outlet = 5000.0  # large enough that C_T(c_∞)·v_outlet > m_in_total (baseline went negative)
         m_in_total = float(np.sum(cin * np.diff(theta_edges)))
         assert float(sorption.total_concentration(4.0)) * v_outlet > m_in_total  # the baseline-negative regime
-        m_out = compute_total_outlet_mass(v_outlet=v_outlet, sorption=sorption, cin=cin, theta_edges=theta_edges)
+        m_out = compute_total_outlet_mass(cin=cin, theta_edges=theta_edges)
         assert m_out == np.inf
 
 

--- a/tests/src/test_front_tracking_solver.py
+++ b/tests/src/test_front_tracking_solver.py
@@ -778,9 +778,7 @@ class TestRiemannProblems:
         tracker = FrontTracker(cin=cin, flow=flow, tedges=tedges, aquifer_pore_volume=v_pore, sorption=sorption)
         tracker.run(max_iterations=10000, verbose=False)
 
-        analytic_total = compute_total_outlet_mass(
-            v_outlet=v_pore, sorption=sorption, cin=cin, theta_edges=tracker.state.theta_edges
-        )
+        analytic_total = compute_total_outlet_mass(cin=cin, theta_edges=tracker.state.theta_edges)
 
         theta_max = float(tracker.state.theta_edges[-1])
         theta_grid = np.linspace(0.0, theta_max, 2000)
@@ -941,12 +939,7 @@ class TestParametricMassBalance:
         tr.run(max_iterations=100000)
 
         mass_in = float(np.sum(cin * np.diff(tr.state.theta_edges)))
-        mass_out = compute_total_outlet_mass(
-            v_outlet=v_outlet,
-            sorption=sorption,
-            cin=cin,
-            theta_edges=tr.state.theta_edges,
-        )
+        mass_out = compute_total_outlet_mass(cin=cin, theta_edges=tr.state.theta_edges)
         # Empirical rel_err ≤ 7e-15 across the parameter sweep (worst at s_max=0.2, k_l=10); 1e-13 leaves 14× headroom.
         assert np.isclose(mass_out, mass_in, rtol=1e-13), (
             f"Langmuir s={s_max}, k_l={k_l}: total mass mass_in={mass_in:.4f} mass_out={mass_out:.4f}"

--- a/tests/src/test_front_tracking_waves.py
+++ b/tests/src/test_front_tracking_waves.py
@@ -14,6 +14,7 @@ import pytest
 from scipy.integrate import quad, solve_ivp
 from scipy.optimize import brentq
 
+from gwtransport.fronttracking import waves as waves_mod
 from gwtransport.fronttracking.math import (
     ConstantRetardation,
     FreundlichSorption,
@@ -1077,3 +1078,46 @@ class TestDoubleFanShockWave:
             pos = w.position_at_theta(th)
             assert pos is not None  # defined at every θ in the wave's active window
             np.testing.assert_allclose(pos, float(sol.sol(th)[0]), rtol=1e-6)
+
+
+class TestFreundlichNearTwoRouting:
+    """Regression (issue #314, FTF-F3): n within 1e-8 of 2 must use the general-n inversion.
+
+    ``_c_decay_freundlich`` dispatches on ``np.isclose(n, 2.0, rtol=1e-12)``; the numpy
+    default ``atol=1e-8`` silently routed any ``n`` within 1e-8 of 2 to the n=2 closed
+    form. With ``atol=0.0`` only (essentially) exact n=2 takes the closed form.
+    """
+
+    C0 = 4.0
+    THETA_COLL = 100.0
+    THETA = 250.0
+
+    def _call(self, n):
+        sorption = FreundlichSorption(k_f=0.01, n=n, bulk_density=1500.0, porosity=0.3)
+        alpha = sorption.bulk_density * sorption.k_f / sorption.porosity
+        # Invariant K consistent with u(theta_coll) = c0**(1/n): closed form of
+        # u0*theta_c = K + sqrt(K**2 + theta_c*K*alpha) solved for K.
+        u0 = self.C0 ** (1.0 / n)
+        k_invariant = u0**2 * self.THETA_COLL / (2.0 * u0 + alpha)
+        return waves_mod._c_decay_freundlich(sorption, k_invariant, self.C0, 0.0, self.THETA_COLL, self.THETA)  # noqa: SLF001
+
+    def test_n_within_atol_of_two_routes_to_general_path(self, monkeypatch):
+        """n = 2 + 1e-10 must call the general-n brentq inversion, not the n=2 closed form."""
+        calls = []
+        general = waves_mod._invert_freundlich_cr_zero  # noqa: SLF001
+
+        def recording(*args, **kwargs):
+            calls.append(args)
+            return general(*args, **kwargs)
+
+        monkeypatch.setattr(waves_mod, "_invert_freundlich_cr_zero", recording)
+        self._call(2.0 + 1e-10)
+        assert len(calls) == 1  # baseline: 0 (silently misrouted to the n=2 closed form)
+
+        calls.clear()
+        self._call(2.0)  # exact n=2 keeps the closed form
+        assert len(calls) == 0
+
+    def test_general_path_is_continuous_at_two(self):
+        """The general-n inversion agrees with the n=2 closed form as n -> 2 (sanity)."""
+        np.testing.assert_allclose(self._call(2.0 + 1e-10), self._call(2.0), rtol=1e-8)

--- a/tests/src/test_front_tracking_waves.py
+++ b/tests/src/test_front_tracking_waves.py
@@ -1081,11 +1081,11 @@ class TestDoubleFanShockWave:
 
 
 class TestFreundlichNearTwoRouting:
-    """Regression (issue #314, FTF-F3): n within 1e-8 of 2 must use the general-n inversion.
+    """``_c_decay_freundlich`` routes only (essentially) exact n=2 to the closed form (#314).
 
-    ``_c_decay_freundlich`` dispatches on ``np.isclose(n, 2.0, rtol=1e-12)``; the numpy
-    default ``atol=1e-8`` silently routed any ``n`` within 1e-8 of 2 to the n=2 closed
-    form. With ``atol=0.0`` only (essentially) exact n=2 takes the closed form.
+    The dispatch uses ``np.isclose(n, 2.0, rtol=1e-12, atol=0.0)``: any other ``n``,
+    including values within numpy's default ``atol=1e-8`` of 2, must take the
+    general-n inversion.
     """
 
     C0 = 4.0
@@ -1112,7 +1112,7 @@ class TestFreundlichNearTwoRouting:
 
         monkeypatch.setattr(waves_mod, "_invert_freundlich_cr_zero", recording)
         self._call(2.0 + 1e-10)
-        assert len(calls) == 1  # baseline: 0 (silently misrouted to the n=2 closed form)
+        assert len(calls) == 1
 
         calls.clear()
         self._call(2.0)  # exact n=2 keeps the closed form

--- a/tests/src/test_gamma.py
+++ b/tests/src/test_gamma.py
@@ -260,11 +260,16 @@ def test_parse_parameters_partial_alpha_beta():
 
 
 def test_parse_parameters_partial_mean_std():
-    """Test parse_parameters raises error with partial mean/std."""
-    with pytest.raises(ValueError, match=r"Either \(alpha, beta\) or \(mean, std\) must be provided"):
+    """Partial mean/std raises the same symmetric pairing error as partial alpha/beta.
+
+    Regression (issue #314, GAM-P4): the baseline raised the generic
+    "Either (alpha, beta) or (mean, std) must be provided" for a partial mean/std pair,
+    asymmetric with the "alpha and beta must both be provided" pairing check.
+    """
+    with pytest.raises(ValueError, match="mean and std must both be provided"):
         parse_parameters(mean=10.0)
 
-    with pytest.raises(ValueError, match=r"Either \(alpha, beta\) or \(mean, std\) must be provided"):
+    with pytest.raises(ValueError, match="mean and std must both be provided"):
         parse_parameters(std=3.0)
 
 
@@ -372,12 +377,20 @@ def test_bins_both_n_bins_and_quantiles():
 
 
 def test_bins_n_bins_too_small():
-    """Test bins raises error with n_bins <= 1."""
+    """Test bins raises error with n_bins <= 1.
+
+    The negative case is a regression (issue #314, GAM-P3): the baseline reached
+    ``np.linspace(0, 1, n_bins + 1)`` first and surfaced numpy's opaque
+    "Number of samples ... must be non-negative" error instead of the clear guard.
+    """
     with pytest.raises(ValueError, match="Number of bins must be greater than 1"):
         gamma_bins(alpha=5.0, beta=2.0, n_bins=1)
 
     with pytest.raises(ValueError, match="Number of bins must be greater than 1"):
         gamma_bins(alpha=5.0, beta=2.0, n_bins=0)
+
+    with pytest.raises(ValueError, match="Number of bins must be greater than 1"):
+        gamma_bins(alpha=5.0, beta=2.0, n_bins=-2)
 
 
 def test_bins_quantile_edges_must_span_unit_interval():

--- a/tests/src/test_gamma.py
+++ b/tests/src/test_gamma.py
@@ -260,12 +260,7 @@ def test_parse_parameters_partial_alpha_beta():
 
 
 def test_parse_parameters_partial_mean_std():
-    """Partial mean/std raises the same symmetric pairing error as partial alpha/beta.
-
-    Regression (issue #314, GAM-P4): the baseline raised the generic
-    "Either (alpha, beta) or (mean, std) must be provided" for a partial mean/std pair,
-    asymmetric with the "alpha and beta must both be provided" pairing check.
-    """
+    """Partial mean/std raises the same symmetric pairing error as partial alpha/beta (#314)."""
     with pytest.raises(ValueError, match="mean and std must both be provided"):
         parse_parameters(mean=10.0)
 
@@ -377,12 +372,7 @@ def test_bins_both_n_bins_and_quantiles():
 
 
 def test_bins_n_bins_too_small():
-    """Test bins raises error with n_bins <= 1.
-
-    The negative case is a regression (issue #314, GAM-P3): the baseline reached
-    ``np.linspace(0, 1, n_bins + 1)`` first and surfaced numpy's opaque
-    "Number of samples ... must be non-negative" error instead of the clear guard.
-    """
+    """bins raises the clear "greater than 1" error for any n_bins <= 1, including negative (#314)."""
     with pytest.raises(ValueError, match="Number of bins must be greater than 1"):
         gamma_bins(alpha=5.0, beta=2.0, n_bins=1)
 


### PR DESCRIPTION
## Summary

Batches the remaining cross-module nits from the 2026-07-12 review (issue #314). Three behavioural edge-case guards, four dead-code/API cleanups, and ~15 docstring/comment corrections across 11 modules.

**Behavioural guards** (each regression test verified to FAIL on `origin/main` before the fix):

- **GAM-P3** — `gamma.bins(n_bins=-2)` now raises the clear `"Number of bins must be greater than 1"`; the baseline reached `np.linspace(0, 1, -1)` first and surfaced numpy's opaque "Number of samples, -1, must be non-negative".
- **GAM-P4** — partial `(mean, std)` in `parse_parameters` raises `"mean and std must both be provided or both be None."`, symmetric with the existing alpha/beta pairing check (baseline gave the generic "Either (alpha, beta) or (mean, std) must be provided").
- **FTF-F3** — `fronttracking.waves._c_decay_freundlich` dispatches on `np.isclose(n, 2.0, rtol=1e-12, atol=0.0)`; the numpy default `atol=1e-8` silently routed any Freundlich `n` within 1e-8 of 2 to the n=2 closed form instead of the general-n inversion.

**Dead code / API cleanup:**

- **RAC-P3** — `_auto_n_modes`: dropped the unreachable `else 2` (`eps > 0` always holds for nonzero drift; comment added).
- **FTO-P7** — `compute_total_outlet_mass`: removed the two fully-unused `v_outlet`/`sorption` parameters (`# noqa: ARG001`); all callers updated.
- **DIF-P5** — `EPSILON_COEFF_SUM` → `_EPSILON_COEFF_SUM` in `diffusion.py`, matching its identical-valued private twin in `_diffusion_shared.py`.
- **DFF-P5/P6** — `diffusion_fast_fast` warm-start tedges extension now uses tz-preserving `pd.Timedelta` Timestamp arithmetic, mirroring `diffusion_fast` (baseline `.to_numpy()` + `np.timedelta64` stripped the timezone; latent, benign).

**Docstring/comment corrections** (each verified by before/after grep):

- **DIF-P4** — reverse Notes now name `solve_inverse_transport` (the actual entry point) instead of the inner `solve_tikhonov`.
- **DIF-P6** — "bit-identical" quadrature claim qualified per sub-interval (a cell split at flow-bin boundaries integrates more accurately, not bit-identically).
- **DFA-P1/P2/P3** — dimensionally wrong `tau = R*V/(L*Q)` (units day/m) replaced with `d(tau)/dx = 1/v_s = R*V_pore/(L*Q)` at both sites; bare `v` in the band-slope formula now `v_fluid` with its definition.
- **DFA-F3** — all four `molecular_diffusivity` docstrings gain the "(retarded-frame)" qualifier the dense module documents.
- **DEP-P2** — `Raises` sections of all three public functions now list `retardation_factor >= 1.0` and non-negative-flow; `extraction_to_deposition`'s terser section aligned with its siblings.
- **DEP-P3** — `spinup="constant"` docstrings document the silent revert to strict-validity (flow[0] <= 0, zero/NaN pore volume, non-positive first bin width, pad cap) and the round-up-to-whole-bins-plus-one shift.
- **DEP-P4** — documented that cout bins entirely outside the flow record return 0.0 (clamped edges, zero extracted volume), keeping the existing behaviour but making the convention explicit.
- **DEP-P5** — `spinup_duration` comment no longer claims a forward/reverse difference that does not exist (both directions solve `V(t*) = R*V_p` for this boundary quantity).
- **DEP-P6** — banded-memory Notes now state the Tikhonov solve transiently materializes the dense matrix and Gram product.
- **GAM-P1** — conditional-mean identity comment made self-consistent (`F_{alpha+1}(b)` with `scale=beta`, matching the code).
- **RAC-P4** — `_auto_n_modes` docstring `eps` formula includes the `+delta` augmentation the code applies.
- **RAC-P2** — documented the `|s| ≲ 1e-10` Airy-branch validity floor on `transfer_function` (unreachable via de Hoog nodes; per the review, no code guard required).
- **ADV-P3** — zero-flow comment no longer claims the concentration "cannot affect the flow-weighted mean"; it now states the readback-only scope and cross-references issue #309.
- **FTC-P2** — `t_at_theta` zero-flow convention stated plainly; "pick one convention and call it documented" note-to-self removed.
- **FTO-P5/P6** — stale `mass_after_outlet_arrival` reference removed; module `Functions` index completed with the four missing public functions.

**Deliberately deferred** (with reasons):

- **RT-P3** (`residence_time.gamma()` all-NaN at `retardation_factor=0`): the maintainer's constraint from #315 requires honoring the R=0 zero-shift limit *without a special-case branch*, but the closed-form integrator divides by `r` at ~8 sites (breakpoint families, support clips); removing those divisions needs a genuine reformulation of the integrator, not a nit-level edit. Left open for its own correctness PR.
- **FTC-P3** (solver guard comments overstating detector coverage): depends on the open #304/FTC-P1 gap; the detectors changed in the #316/#317 merges, so stating "actual coverage" accurately requires re-verifying them first.
- **RAC-P2 code guard** (analytic `s -> 0` limit): the deep review concluded the regime is unreachable through the public API and recommended documentation only, which this PR does.

**Already fixed on `origin/main` by sibling merges** (no action here): GAM-P2 quantile-gap + huge-alpha guards (#331/#338); DFF-P2 envelope wording, DFF-P3 sigma comment, and DFF-P4 test R-coverage (#332/#335 removed the time-domain smear entirely and rewrote the test to vary R at fixed V_pore); RT-P4/P5/P6/F3 (#315).

Closes #314

## Test plan

- New/updated regressions, each confirmed to FAIL on unchanged `origin/main` src and pass after: `test_bins_n_bins_too_small` (n_bins=-2 case), `test_parse_parameters_partial_mean_std` (symmetric message), `TestFreundlichNearTwoRouting` (routing + continuity at n→2).
- `pytest tests/src/test_gamma.py tests/src/test_front_tracking_waves.py tests/src/test_front_tracking_output.py tests/regression/test_phase1_invariants.py` — 190 passed.
- `pytest tests/src/test_diffusion.py` (rename), `tests/src/test_diffusion_fast_fast.py` (tz change), `tests/src/test_deposition.py`, and the targeted `test_retardation_rescale_selects_same_n_modes` / `test_auto_n_modes_sizing` — all passed.
- `ruff format` + `ruff check` clean; `ty check` clean on all changed source files.
- Every doc nit verified by before/after grep of the cited wording.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
