### PR TITLE
fix(ci): exclude validate-pyproject-schema-store 2026.7.20 (crashes the lint job on every branch)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,10 @@ test = [
   "numba>=0.63",
   "ty",
   "validate-pyproject[all,store]",
+  # schema-store 2026.7.20 ships a uv.json schema that crashes validate-pyproject 0.25's
+  # generated validator (UnboundLocalError: 'data_keys'), failing the lint job on every
+  # branch. Exclude the broken release; drop the exclusion once a fixed version is out.
+  "validate-pyproject-schema-store!=2026.7.20",
 ]
 docs = [
   # Do NOT add the "jupyter" metapackage (or "notebook"/"jupyterlab") here. The docs


### PR DESCRIPTION
## Summary

The **2026.7.20** release of `validate-pyproject-schema-store` ships a `uv.json` schema that crashes `validate-pyproject 0.25`'s generated validator with `UnboundLocalError: cannot access local variable 'data_keys'` — before ruff/ty even report. Because the repo intentionally has no lockfile, **every** lint run since that release fails, on every branch (main's last green run on 2026-07-20 resolved 2026.7.17). This is what turned the `ruff` check red on #345, #348 and #349 after their repairs — not their code.

One-line fix: exclude the broken release from the `test` extra; drop the exclusion once a fixed schema-store version is published.

## Test plan

- Reproduced on unchanged `main`: fresh `uv sync --extra test` resolves 2026.7.20 and `uv run validate-pyproject pyproject.toml` crashes with the identical CI traceback.
- With the exclusion: resolves 2026.7.17, reports `Valid file: pyproject.toml`.

**After merging:** re-run the failed `ruff` checks on #345/#348/#349 — the `pull_request` merge ref picks up the exclusion and they go green (their only other red is the CLA checkbox).

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.