### PR TITLE
docs: restore module overviews, verified complete against the public API

### DIFF
--- a/src/gwtransport/_diffusion_shared.py
+++ b/src/gwtransport/_diffusion_shared.py
@@ -2,11 +2,13 @@
 Shared closed-form helpers for the Kreft-Zuber flux-concentration transport modules.
 
 This private module holds the pieces common to :mod:`gwtransport.diffusion_fast` and
-:mod:`gwtransport.diffusion_fast_fast`: the breakthrough antiderivative, the input
-coerce/validate/broadcast preamble, the warm-start and advective-validity grids, and the banded
-Tikhonov reverse solve. Both modules import from here so these primitives are defined once
-and evaluate bit-identically in either module (the modules' overall transport is *not* identical:
-diffusion_fast is exact, diffusion_fast_fast approximate).
+:mod:`gwtransport.diffusion_fast_fast`: the closed-form breakthrough antiderivative, the input
+coerce/validate/broadcast preamble, the cout-edge cumulative-volume axis, the warm-start (spin-up)
+grid and its policy flag, the advective-validity gate, and the banded Tikhonov reverse solve. Both
+modules import from here so these primitives are defined once and evaluate bit-identically in either
+module (the modules' overall transport is *not* identical: diffusion_fast is exact,
+diffusion_fast_fast approximate). :mod:`gwtransport.diffusion`, the quadrature reference, shares only
+the parameter broadcasting and the spin-up policy flag; its kernel is its own.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.

--- a/src/gwtransport/_time.py
+++ b/src/gwtransport/_time.py
@@ -1,13 +1,12 @@
 """
 Time-axis conversion atoms for transport-module entry points.
 
-The transport modules in :mod:`gwtransport.advection`,
-:mod:`gwtransport.diffusion`, :mod:`gwtransport.diffusion_fast`,
-:mod:`gwtransport.deposition`, and :mod:`gwtransport.residence_time` repeatedly
-convert a :class:`pandas.DatetimeIndex` of bin edges into a float64 array of
-days relative to a reference timestamp. The two helpers here factor that
-idiom once so the conversion (and its object-dtype-on-old-pandas contract)
-lives in a single place.
+The transport modules across :mod:`gwtransport` -- advection, diffusion,
+deposition, percolation, recharge, residence time, radial ASR and front
+tracking -- repeatedly convert a :class:`pandas.DatetimeIndex` of bin edges into
+a float64 array of days relative to a reference timestamp. The two helpers here
+factor that idiom once so the conversion (and its object-dtype-on-old-pandas
+contract) lives in a single place.
 
 Both helpers return ``float64`` arrays. ``tedges_to_days`` measures each edge
 relative to ``ref`` (defaulting to the first edge); ``dt_to_days`` returns the
@@ -16,7 +15,7 @@ conversions (e.g. output edges measured against the input-flow reference) must
 share a common origin.
 
 This module has no public API; importers are the transport modules themselves
-plus ``tests/src/test_utils.py``.
+plus their unit tests.
 """
 
 from __future__ import annotations

--- a/src/gwtransport/advection.py
+++ b/src/gwtransport/advection.py
@@ -19,6 +19,44 @@ solute with D_m ~ 1e-4 m²/day), the molecular diffusion contribution is baked i
 calibrated std. The cleanest fix is to calibrate with :mod:`gwtransport.diffusion_fast`
 instead, which keeps the three contributions separate.
 
+The aquifer pore volume distribution (APVD) enters in one of two forms. The ``gamma_*`` pair takes
+the APVD in closed form as a (shifted) gamma distribution, parameterized by either (mean, std, loc)
+or (alpha, beta, loc), and discretizes it internally into ``n_bins`` equal-probability-mass
+streamtubes. The plain pair takes ``aquifer_pore_volumes``: an explicit array of pore volumes [m³],
+one per streamtube, treated as equally weighted at the outlet.
+
+Available functions:
+
+- :func:`infiltration_to_extraction` - Compute the concentration (or temperature) of the extracted
+  water from an infiltration series and an explicit array of aquifer pore volumes. Each
+  ``cout_tedges`` bin gets the flow-weighted average of ``cin`` over each streamtube's
+  back-projected source window, averaged over the streamtubes; units are those of ``cin``. Sorption
+  is linear, through a constant ``retardation_factor``. The ``spinup`` policy (default
+  ``"constant"``) warm-starts the record before ``tedges[0]``; ``spinup=None`` instead returns NaN
+  for every cout bin whose streamtube source windows are not fully inside the cin range.
+
+- :func:`extraction_to_infiltration` - Reverse operation: reconstruct the infiltrating
+  concentration from measured extraction concentrations by inverting the forward weight matrix
+  with Tikhonov regularization (``regularization_strength``). Returns one value per ``tedges``
+  bin. NaN in ``cout`` marks measurement gaps; those rows are excluded from the solve, and cin
+  bins constrained only by gapped cout bins come back as NaN.
+
+- :func:`gamma_infiltration_to_extraction` - Forward transport as in
+  :func:`infiltration_to_extraction`, with the APVD supplied as gamma parameters rather than as an
+  explicit array of pore volumes.
+
+- :func:`gamma_extraction_to_infiltration` - Deconvolution as in
+  :func:`extraction_to_infiltration`, with the APVD supplied as gamma parameters rather than as an
+  explicit array of pore volumes.
+
+- :func:`infiltration_to_extraction_nonlinear_sorption` - Forward transport with a
+  concentration-dependent isotherm -- Freundlich, Langmuir, or a constant retardation factor --
+  solved by front tracking along each pore volume. Returns a tuple: the flow-weighted bin-averaged
+  extraction concentration, and one diagnostic structure per pore volume holding the waves, events,
+  first arrival and final solver state. Cout bins whose source window leaves the flow record are
+  returned as ``0.0`` rather than NaN, while bins with zero throughflow are NaN. Forward only:
+  non-linear sorption forms shocks, and there is no extraction-to-infiltration counterpart.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/advection_utils.py
+++ b/src/gwtransport/advection_utils.py
@@ -1,9 +1,20 @@
 """
 Private helper functions for advective transport modeling.
 
-This module contains internal helper functions used by the advection module.
-These functions implement various algorithms for computing transport weights
-and handling nonlinear sorption.
+This module contains internal helper functions used by :mod:`gwtransport.advection`. It has no
+public API; every name is private and the module is not part of the documented interface.
+
+The helpers build and post-process the linear infiltration-to-extraction operator that both the
+forward and the reverse advection entry points share. One helper computes the raw
+streamtube-bundle weights on the cumulative-throughflow-volume axis, in a compact banded layout
+together with the per-cout-bin count of contributing streamtubes and the zero-flow cout mask; a
+second turns those raw outputs into the final banded weights plus the mask of cout bins the
+spin-up policy rejects; a third reconstructs the dense ``(n_cout, n_cin)`` matrix from the banded
+layout; and a fourth validates the ``spinup`` argument and applies its input-side effect of
+prepending warm-start bins to tedges, flow and cin.
+
+Nonlinear sorption is not handled here -- the front-tracking solver lives in
+:mod:`gwtransport.fronttracking`.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.

--- a/src/gwtransport/deposition.py
+++ b/src/gwtransport/deposition.py
@@ -11,6 +11,42 @@ The model is a *source* term (positive deposition adds mass to the water); it do
 processes such as pathogen attachment, particle filtration, or chemical precipitation, which would
 remove mass from the water and require the opposite sign convention.
 
+Available functions:
+
+- :func:`deposition_to_extraction` - Forward model: from areal deposition rates [g/m²/day] and
+  flow, compute the concentration [g/m³] of the extracted water on ``cout_tedges``. Each output
+  bin is the flow-weighted average over the water extracted in that bin; a parcel's concentration
+  gain is proportional to the residence-time contact with the areal flux, mixed over
+  ``porosity * thickness``. Bins whose residence time is not yet resolved (spin-up) return NaN,
+  while bins that extract zero volume -- including bins lying outside the flow record -- return 0.0.
+
+- :func:`extraction_to_deposition` - Inverse model (deconvolution): from the concentration of the
+  extracted water [g/m³], estimate the mean deposition rate [g/m²/day] in each ``tedges`` bin.
+  Solves the banded forward system with Tikhonov regularization toward a physically motivated
+  target (transpose-and-normalize of the forward operator), with ``regularization_strength``
+  trading data fit against that target. Rows without a resolved residence time, zero-flow output
+  bins and NaN entries in ``cout`` are excluded from the solve. This is the recommended inverse.
+
+- :func:`extraction_to_deposition_full` - Same inversion routed through the dense nullspace solver
+  :func:`gwtransport.utils.solve_underdetermined_system`, exposing its options: the nullspace
+  objective (``"squared_differences"`` for smooth solutions, ``"summed_differences"`` for
+  piecewise-constant ones, or a callable), the scipy ``optimization_method``, and the
+  least-squares ``rcond`` cutoff. Reach for it when the choice of nullspace component matters;
+  otherwise prefer :func:`extraction_to_deposition`, which is cheaper and needs no dense operator.
+
+- :func:`compute_deposition_weights` - Build the operator relating deposition rates to extracted
+  concentrations in a compact banded layout, returning the band values, the first cin column of
+  each row, and the row masks for valid and spin-up output bins. Row ``k`` sums to
+  ``residence_time_k / (retardation_factor * porosity * thickness)`` rather than to one, because a
+  deposition rate maps to a concentration through the residence time. Exposed for custom inverse
+  solvers; the forward and both inverse entry points build on it.
+
+- :func:`spinup_duration` - Time in days, measured from ``tedges[0]``, at which the cumulative flow
+  first reaches ``retardation_factor * aquifer_pore_volume``: the earliest extraction time whose
+  water carries a complete deposition history, and hence the start of the valid analysis period.
+  Under constant flow this is ``retardation_factor * aquifer_pore_volume / flow``. Raises
+  ``ValueError`` when the flow record is too short to reach that volume.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/deposition_utils.py
+++ b/src/gwtransport/deposition_utils.py
@@ -1,9 +1,10 @@
 """
 Utility Functions for the Deposition Module.
 
-This module provides the clipped-trapezoid integral helpers (``_clipped_linear_integral``
-and ``_positive_part_integral``) used by the deposition module's banded weight builder to
-integrate ``clip(y(x), y_lower, y_upper)`` over each cin bin of a streamtube's residence window.
+This module provides the clipped-trapezoid integral helper ``_clipped_linear_integral``, which the
+deposition module's banded weight builder uses to integrate ``clip(f(x), lo, hi)`` over each cin bin
+inside an output bin's residence window, and ``_positive_part_integral``, the positive-part integral
+it is built from.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.

--- a/src/gwtransport/diffusion.py
+++ b/src/gwtransport/diffusion.py
@@ -9,23 +9,8 @@ macrodispersion. Forward and backward modeling are supported. The flow is assume
 The orthogonal-flow (Cartesian) geometry is what makes the Kreft-Zuber breakthrough the exact
 1D solution used below.
 
-Key functions:
-
-- :func:`infiltration_to_extraction` - Main transport function combining advection,
-  microdispersion, and molecular diffusion with explicit pore volume distribution and
-  streamline lengths.
-
-- :func:`extraction_to_infiltration` - Inverse operation (deconvolution with dispersion).
-
-- :func:`gamma_infiltration_to_extraction` - Gamma-distributed pore volumes with dispersion.
-  Models aquifer heterogeneity with 2-parameter gamma distribution. Parameterizable via
-  (alpha, beta) or (mean, std). Discretizes gamma distribution into equal-probability bins.
-
-- :func:`gamma_extraction_to_infiltration` - Gamma-distributed pore volumes, deconvolution
-  with dispersion. Symmetric inverse of gamma_infiltration_to_extraction.
-
-When to choose this module vs :mod:`gwtransport.diffusion_fast`
----------------------------------------------------------------
+Choosing among the three diffusion modules
+------------------------------------------
 
 This is the reference implementation: it evaluates the bin-averaged Kreft-Zuber flux
 concentration by resolution-aware composite Gauss-Legendre quadrature (splitting at
@@ -40,6 +25,15 @@ molecular diffusivity, whose flux correction it also evaluates in closed form) a
 per-streamtube ``streamline_length`` / ``molecular_diffusivity`` /
 ``longitudinal_dispersivity`` arrays (heterogeneous flow paths -- partially-penetrating
 wells, wedge-shaped capture zones).
+
+:mod:`gwtransport.diffusion_fast_fast` is the third rung and is approximate by design: it folds
+molecular diffusion into an effective dispersivity ``alpha_eff = alpha_L + D_m * R * V_pore /
+(L * q_mean)`` per streamtube, so the whole streamtube bundle collapses to one banded breakthrough
+on the native cumulative-volume grid -- the fastest of the three. At constant flow it reproduces
+:mod:`gwtransport.diffusion_fast` to ~1e-6 for smooth inputs and ~1e-4 for sharp ones, and it loses
+accuracy in the molecular-diffusion-dominated corner (``alpha_L`` ~ 0) under strongly variable flow,
+where the frozen record-mean flow leaves a commutator residual. This module is the ground truth both
+fast modules are validated against.
 
 Reported outlet concentration: Kreft-Zuber (1978) flux concentration
 ---------------------------------------------------------------------
@@ -114,6 +108,28 @@ the streamline length ``L`` and the pore volume ``V_pore`` together fixing the i
 streamtube cross-section ``A = V_pore / L``. Callers who need distributed-area effects must
 provide multiple streamtubes (via ``aquifer_pore_volumes`` or the gamma-parameterised
 wrappers).
+
+Available functions:
+
+- :func:`infiltration_to_extraction` - Forward transport from an explicit ``aquifer_pore_volumes``
+  distribution: returns the bin-averaged Kreft-Zuber flux concentration on ``cout_tedges``, integrated
+  over the full ``tedges``-resolution flow within each output bin and averaged with equal weight over
+  the streamtubes. ``streamline_length``, ``molecular_diffusivity`` and ``longitudinal_dispersivity``
+  are either scalars shared by all streamtubes or one value per pore volume. Output bins that no
+  infiltration has reached, or whose look-back leaves the record, are NaN.
+
+- :func:`extraction_to_infiltration` - Reverse direction: builds the same forward coefficient matrix
+  and solves ``W @ cin = cout`` by Tikhonov regularization, returning the bin-averaged infiltration
+  concentration on ``tedges``. NaN entries in ``cout`` mark measurement gaps; their rows are dropped
+  from the solve and cin bins that nothing else constrains are returned as NaN.
+
+- :func:`gamma_infiltration_to_extraction` - :func:`infiltration_to_extraction` with the pore volume
+  distribution given as a (shifted) gamma -- either (mean, std) or (alpha, beta), plus ``loc`` --
+  discretized into ``n_bins`` equal-probability streamtubes that share one ``streamline_length`` and
+  one pair of dispersion parameters.
+
+- :func:`gamma_extraction_to_infiltration` - :func:`extraction_to_infiltration` with the same gamma
+  parameterization of the pore volume distribution: reconstructs ``cin`` on ``tedges`` from ``cout``.
 
 References
 ----------

--- a/src/gwtransport/diffusion_fast.py
+++ b/src/gwtransport/diffusion_fast.py
@@ -37,8 +37,8 @@ enters the V-space variance through ``D_m * tau`` and microdispersion through
 ``longitudinal_dispersivity`` may be a scalar (shared by all streamtubes) or an array with
 one value per pore volume, exactly as in :mod:`gwtransport.diffusion`.
 
-When to choose this module vs :mod:`gwtransport.diffusion`
-----------------------------------------------------------
+Choosing among the three diffusion modules
+------------------------------------------
 
 Whenever the cout grid is at or finer than the flow grid, this module reproduces
 :mod:`gwtransport.diffusion` to machine precision for *every* parameter regime -- including
@@ -49,6 +49,37 @@ favours :mod:`gwtransport.diffusion` is a cout grid *coarser* than the flow deta
 treats ``flow_out`` as constant within each cout bin, whereas :mod:`gwtransport.diffusion`
 integrates the full ``tedges``-resolution flow within each cout bin -- a ~0.1%-of-peak
 difference for a rapidly-varying ``cin`` over wide cout bins under variable flow.
+
+The third rung is :mod:`gwtransport.diffusion_fast_fast`, which is approximate by design: it folds
+molecular diffusion into an effective dispersivity per streamtube and evaluates one banded
+breakthrough on the native cumulative-volume grid, so it is faster still. It agrees with this module
+to ~1e-6 (smooth inputs) to ~1e-4 (sharp inputs) at constant flow and degrades in the
+molecular-diffusion-dominated corner (``alpha_L`` ~ 0) under strongly variable flow; this module is
+the one to use whenever machine precision against :mod:`gwtransport.diffusion` is required.
+
+Available functions:
+
+- :func:`infiltration_to_extraction` - Forward transport from an explicit ``aquifer_pore_volumes``
+  distribution: returns the bin-averaged Kreft-Zuber flux concentration on ``cout_tedges``, evaluated
+  from the closed-form antiderivative on the breakthrough band only and averaged with equal weight over
+  the streamtubes. ``streamline_length``, ``molecular_diffusivity`` and ``longitudinal_dispersivity``
+  are either scalars shared by all streamtubes or one value per pore volume. ``flow_out`` (extraction
+  flow on the ``cout_tedges`` grid) is required whenever ``cout_tedges`` differs from ``tedges``: it
+  sets the cout-bin volumes and the outlet velocity. Output bins without complete breakthrough
+  information are NaN.
+
+- :func:`extraction_to_infiltration` - Reverse direction: assembles the same banded forward operator
+  and deconvolves it with banded Tikhonov regularization (banded Cholesky on the normal equations),
+  returning the bin-averaged infiltration concentration on ``tedges``. NaN entries in ``cout`` mark
+  measurement gaps and are excluded from the solve; spin-up and unconstrained cin bins come back NaN.
+
+- :func:`gamma_infiltration_to_extraction` - :func:`infiltration_to_extraction` with the pore volume
+  distribution given as a (shifted) gamma -- either (mean, std) or (alpha, beta), plus ``loc`` --
+  discretized into ``n_bins`` equal-probability streamtubes that share one ``streamline_length`` and
+  one pair of dispersion parameters.
+
+- :func:`gamma_extraction_to_infiltration` - :func:`extraction_to_infiltration` with the same gamma
+  parameterization of the pore volume distribution: reconstructs ``cin`` on ``tedges`` from ``cout``.
 
 References
 ----------

--- a/src/gwtransport/diffusion_fast_fast.py
+++ b/src/gwtransport/diffusion_fast_fast.py
@@ -11,6 +11,12 @@ native-grid evaluation that does not depend on the flow being constant. It is **
 see Accuracy below for the error budget and when to reach for :mod:`gwtransport.diffusion_fast`
 instead.
 
+The three modules form an accuracy/speed ladder: :mod:`gwtransport.diffusion` is the dense reference
+implementation and the ground-truth oracle (composite Gauss-Legendre quadrature, slowest),
+:mod:`gwtransport.diffusion_fast` is its banded closed-form equivalent (agrees to machine precision,
+~80-90x faster), and this module is the approximate rung -- fastest, and exact only up to the error
+budget below.
+
 How it works -- one skewed breakthrough on the native volume grid
 -----------------------------------------------------------------
 
@@ -60,6 +66,31 @@ regularisation (banded Cholesky, ``O(n * band**2)``), so it is much faster than
 forward operator makes a round trip self-consistent (recovering the input up to the deconvolution
 conditioning); on *real* extraction data the reverse carries the forward's error budget above,
 amplified by the deconvolution conditioning.
+
+Available functions:
+
+- :func:`infiltration_to_extraction` - Forward transport from an explicit ``aquifer_pore_volumes``
+  distribution: returns the approximate bin-averaged Kreft-Zuber flux concentration on ``cout_tedges``,
+  from one banded breakthrough on the native cumulative-volume grid with molecular diffusion folded
+  into the effective dispersivity ``alpha_eff = alpha_L + D_m * R * V_pore / (L * q_mean)`` per
+  streamtube. ``streamline_length``, ``molecular_diffusivity`` and ``longitudinal_dispersivity`` are
+  either scalars shared by all streamtubes or one value per pore volume. ``flow_out`` (extraction flow
+  on the ``cout_tedges`` grid) is required whenever ``cout_tedges`` differs from ``tedges``. Output
+  bins without complete breakthrough information are NaN.
+
+- :func:`extraction_to_infiltration` - Reverse direction: assembles the same approximate banded
+  operator and deconvolves it with banded Tikhonov regularization (banded Cholesky on the normal
+  equations, ``O(n * band**2)``), returning the bin-averaged infiltration concentration on ``tedges``.
+  NaN entries in ``cout`` mark measurement gaps and are excluded from the solve; spin-up and
+  unconstrained cin bins come back NaN.
+
+- :func:`gamma_infiltration_to_extraction` - :func:`infiltration_to_extraction` with the pore volume
+  distribution given as a (shifted) gamma -- either (mean, std) or (alpha, beta), plus ``loc`` --
+  discretized into ``n_bins`` equal-probability streamtubes that share one ``streamline_length`` and
+  one pair of dispersion parameters.
+
+- :func:`gamma_extraction_to_infiltration` - :func:`extraction_to_infiltration` with the same gamma
+  parameterization of the pore volume distribution: reconstructs ``cin`` on ``tedges`` from ``cout``.
 
 References
 ----------

--- a/src/gwtransport/examples.py
+++ b/src/gwtransport/examples.py
@@ -6,6 +6,35 @@ and testing groundwater transport models. It creates realistic flow patterns,
 concentration/temperature time series, and deposition events suitable for testing
 advection, diffusion, and deposition analysis functions.
 
+Available functions:
+
+- :func:`generate_example_data` - Build a daily ``(DataFrame, tedges)`` pair with columns
+  ``flow`` (seasonal sinusoid plus noise and randomly placed low-flow spill periods, floored at
+  5 m³/day), ``cin`` (a seasonal sinusoid, a constant, or inline KNMI De Bilt soil temperature,
+  selected with ``cin_method``), and ``cout``, obtained by transporting the noiseless ``cin``
+  through either a gamma-distributed or an explicitly listed set of aquifer pore volumes, using
+  :mod:`gwtransport.advection` or, when the three diffusion parameters are given,
+  :mod:`gwtransport.diffusion_fast`. Independent Gaussian measurement noise is added to ``cin``
+  and ``cout``, so the pair is not exactly consistent when ``measurement_noise > 0``. The aquifer
+  and generation settings are recorded in ``df.attrs``. Consumed by
+  ``examples/04_Deposition_Analysis_Bank_Filtration.ipynb``.
+
+- :func:`generate_temperature_example_data` - Same dataset viewed as heat transport: a thin
+  wrapper over :func:`generate_example_data` whose defaults are thermal (retardation factor 2.0,
+  diffusivity 0.05 m²/day, longitudinal dispersivity 1.0 m, streamline length 100 m), so the
+  diffusion path is taken. Consumed by
+  ``examples/01_Aquifer_Characterization_Temperature.ipynb``,
+  ``examples/02_Residence_Time_Analysis.ipynb``,
+  ``examples/03_Pathogen_Removal_Bank_Filtration.ipynb``, and
+  ``examples/08_bank_filtration_timflow.ipynb``.
+
+- :func:`generate_example_deposition_timeseries` - Build a ``(Series, tedges)`` pair of surface
+  deposition rates (ng/m²/day) on a UTC index: a baseline plus an annual sinusoid, Gaussian noise,
+  and episodic events that start at the given dates and decay exponentially over
+  ``event_duration`` days, optionally clipped at zero. Feeds
+  :func:`gwtransport.deposition.deposition_to_extraction` in
+  ``examples/04_Deposition_Analysis_Bank_Filtration.ipynb``.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/fronttracking/events.py
+++ b/src/gwtransport/fronttracking/events.py
@@ -13,6 +13,45 @@ Events include:
 - Outlet crossings
 
 All calculations return exact floating-point results with machine precision.
+The ``theta`` coordinate is cumulative flow [m³]; see
+:mod:`gwtransport.fronttracking.waves` for the (V, θ) convention.
+
+Available functions:
+
+- :class:`EventType` - Enumeration of the event kinds the solver dispatches on: characteristic-characteristic,
+  shock-shock, shock-characteristic, rarefaction-characteristic and shock-rarefaction collisions, decaying-shock
+  fan exhaustion, wave merges from the face calculus, and outlet crossings.
+
+- :class:`Event` - Record of one scheduled event: the θ at which it occurs, its :class:`EventType`, the waves
+  involved, the position ``location`` [m³], the ``'head'``/``'tail'`` ``boundary_type`` for rarefaction
+  collisions, and the colliding face pair for merges. It defines no ordering, because the solver orders
+  ``(theta, counter, ...)`` tuples rather than the objects themselves.
+
+- :func:`find_characteristic_intersection` - First strictly-future crossing ``(θ, V)`` of two characteristics,
+  or ``None`` when their speeds are equal or they never meet after ``theta_current``. Both lines are evaluated
+  from the shared reference ``max(θ_start_1, θ_start_2, θ_current)``.
+
+- :func:`find_shock_shock_intersection` - Same line/line crossing for two shocks, using each shock's constant
+  Rankine-Hugoniot speed.
+
+- :func:`find_shock_characteristic_intersection` - Same for a shock against a characteristic. The operand
+  order is load-bearing: ``V`` is evaluated on the first line, so it fixes the successor wave's ``v_start``
+  bit for bit.
+
+- :func:`find_rarefaction_boundary_intersections` - Crossings of a rarefaction's head and tail lines (which
+  travel at ``1/R(c_head)`` and ``1/R(c_tail)``) with another wave, returned as a list of
+  ``(θ, V, boundary_type)`` with ``boundary_type`` in ``{'head', 'tail'}``.
+
+- :func:`find_outlet_crossing` - Cumulative flow at which a wave reaches ``v_outlet``, assuming positive flow:
+  a straight-line inverse for characteristics and shocks, and the cached-trajectory inverse
+  ``outlet_crossing_theta`` for the fan-fed shocks (both the decaying and the doubly-fed one). Returns
+  ``None`` if the wave is inactive, moves backward, has a pinned characteristic speed, or has already passed
+  the outlet within a relative tolerance that stops a just-processed crossing from re-firing. Rarefactions
+  are excluded — their callers split head and tail into separate boundary crossings.
+
+- :func:`is_outlet_crossing_pinned` - Whether a boundary state sits on the ``c_min`` retardation floor with an
+  inflated ``R(c_min)``, so that its scheduled outlet crossing is a floor artifact rather than physics and the
+  caller should drop it.
 """
 
 from dataclasses import dataclass

--- a/src/gwtransport/fronttracking/handlers.py
+++ b/src/gwtransport/fronttracking/handlers.py
@@ -12,7 +12,40 @@ All handlers enforce physical correctness:
 - Causality (no backward-traveling information)
 
 Handlers modify wave states in-place by deactivating parent waves and
-creating new child waves.
+creating new child waves. Positions are volumetric [m³] and ``theta_event``
+is cumulative flow [m³]; see :mod:`gwtransport.fronttracking.waves` for the
+(V, θ) convention.
+
+Available functions:
+
+- :func:`handle_characteristic_collision` - Two characteristics meet, the faster catching the slower from
+  behind. This compression always emits a single shock spanning the two concentrations, in every sorption
+  regime; a resulting shock that fails the Lax condition raises ``RuntimeError``.
+
+- :func:`handle_shock_collision` - Two shocks merge into one connecting the outer states: ``c_left`` from the
+  upstream shock, ``c_right`` from the downstream one, with the speed recomputed from Rankine-Hugoniot. An
+  entropy-violating merge raises ``RuntimeError``.
+
+- :func:`handle_shock_characteristic_collision` - A shock and a characteristic meet; the characteristic's
+  concentration replaces ``c_right`` when the shock does the catching and ``c_left`` when the characteristic
+  does. The successor is the modified shock if it satisfies entropy, otherwise a rarefaction, so mass balance
+  is preserved either way.
+
+- :func:`handle_shock_rarefaction_collision` - A shock meets a rarefaction head or tail. The pair is replaced
+  by one :class:`~gwtransport.fronttracking.waves.DecayingShockWave` that subsumes fan and shock together: a
+  head collision decays the left side from ``raref.c_head`` with ``c_fixed = shock.c_right``, a tail collision
+  decays the right side from ``raref.c_tail`` with ``c_fixed = shock.c_left``, and the fan's opposite boundary
+  becomes ``c_fan_tail`` so partial drying is resolved exactly. Degenerate input where the boundary is not
+  faster than the shock deactivates both waves and emits nothing.
+
+- :func:`handle_rarefaction_characteristic_collision` - A rarefaction boundary meets a characteristic. The
+  characteristic is absorbed when its concentration matches the boundary value within tolerance; otherwise
+  ``RuntimeError`` is raised rather than silently destroying mass.
+
+- :func:`create_inlet_waves_at_theta` - Emit the wave a step from ``c_prev`` to ``c_new`` produces at the
+  inlet face ``V = 0``: a shock when the new characteristic speed is higher (compression), a rarefaction when
+  it is lower (expansion), and a characteristic when the two speeds tie. Returns an empty list for a
+  negligible step or for a shock that fails the entropy check.
 """
 
 from gwtransport.fronttracking.math import (

--- a/src/gwtransport/fronttracking/interactions.py
+++ b/src/gwtransport/fronttracking/interactions.py
@@ -21,6 +21,34 @@ calculus:
   double-crossings inside one step. The bound is per-pair (not a global ``1``) because the
   percolation conductivity isotherms have ``R < 1`` regions.
 
+Available functions:
+
+- :class:`Face` - One separating surface of a wave: the wave it belongs to, a ``role`` tag
+  (``'shock'``, ``'contact'``, ``'head'``, ``'tail'`` or ``'boundary'``), its left (upstream) and right
+  (downstream) :class:`~gwtransport.fronttracking.waves.Feeder`, whether its trajectory is curved, and an
+  upper bound on its speed for the Lipschitz march. ``position(theta)`` evaluates the face, returning ``None``
+  outside the owning wave's active θ-window.
+
+- :func:`iter_faces` - Enumerate the faces a wave exposes at ``theta``: one contact for a characteristic, one
+  shock face for a shock, head and tail for a rarefaction, and for the fan-fed shocks a curved shock face plus
+  each fan boundary line that is still free. The ``theta`` argument selects the historical state, so a
+  boundary already consumed by a wave entering the fan is not re-exposed.
+
+- :func:`find_face_crossing` - First θ in ``(θ_start, θ_horizon]`` at which two faces coincide, or ``None``.
+  The gap is marched with a per-pair speed bound so no sign change can be stepped over, and each step also
+  brackets the gap's interior minimum to catch a grazing double crossing.
+
+- :func:`make_wave_from_feeders` - Build the successor a merge produces from a ``(left, right)`` feeder pair
+  at ``(v, θ)``: two constants give a :class:`~gwtransport.fronttracking.waves.ShockWave` (or ``None`` for a
+  zero jump), one constant and one fan give a :class:`~gwtransport.fronttracking.waves.DecayingShockWave`, and
+  two fans give a :class:`~gwtransport.fronttracking.waves.DoubleFanShockWave`. A feeder whose far boundary is
+  already owned marks the successor's boundary consumed on that side.
+
+- :func:`resolve_merge` - Resolve a two-face collision into the successor waves. It identifies which face is
+  rear (upstream) and which is front just before the crossing, forms the successor from
+  ``(rear.left, front.right)``, and retires the parents — a wave whose shock, contact or rarefaction face
+  merged is deactivated, while a bare fan boundary line is only marked consumed and its wave lives on.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/fronttracking/math.py
+++ b/src/gwtransport/fronttracking/math.py
@@ -15,6 +15,51 @@ All sorption-class computations are exact analytical formulas; the
 van Genuchten-Mualem class uses ``scipy.optimize.brentq`` for the two
 inversions that have no closed form.
 
+Available functions:
+
+- :class:`NonlinearSorption` - Abstract base for concentration-dependent isotherms. Subclasses supply
+  ``retardation(c)``, ``total_concentration(c)`` and ``concentration_from_retardation(r)``; the base derives
+  the Rankine-Hugoniot ``shock_speed(c_left, c_right)``, the Lax ``check_entropy_condition``, the paired
+  ``c_and_total_from_retardation`` and ``fan_converges_at_infinity`` from them.
+
+- :class:`FreundlichSorption` - Power-law isotherm ``s(C) = k_f · C^(1/n)`` with closed-form
+  ``R(C) = 1 + (ρ_b · k_f)/(n_por · n) · C^(1/n − 1)``. ``n > 1`` makes higher concentrations travel faster,
+  ``n < 1`` mirrors that, and ``n = 1`` is rejected (use :class:`ConstantRetardation`). Because ``R → ∞`` as
+  ``C → 0`` for ``n > 1``, ``retardation`` and ``concentration_from_retardation`` clamp ``C`` at ``c_min``.
+
+- :class:`ConstantRetardation` - Linear sorption ``s(C) = K_d · C`` reduced to one ``retardation_factor``:
+  every concentration moves at ``dV/dθ = 1/R``, so no rarefaction ever forms and the solution is a pure
+  θ-shift with shocks only at inlet discontinuities.
+
+- :class:`LangmuirSorption` - Favorable isotherm ``s(C) = s_max · C/(K_L + C)`` with
+  ``R(C) = 1 + (ρ_b · s_max · K_L)/(n_por · (K_L + C)²)``, which is finite at ``C = 0``, so no concentration
+  floor is needed; ``R`` decreases with ``C``, giving shocks on concentration rises and fans on falls.
+
+- :class:`BrooksCoreyConductivity` - Brooks-Corey unsaturated conductivity ``K(θ) = K_s · Θ^a`` recast into
+  the ``(C, C_T)`` variables of the sorption interface by identifying ``C ≡ K`` (flux) and ``C_T ≡ θ − θ_r``
+  (storage), which lets :mod:`gwtransport.percolation` run Kinematic-Wave percolation on this solver. All
+  three curve methods are closed form; ``C`` is clamped at a dry-soil floor in ``retardation`` and
+  ``concentration_from_retardation`` but not in ``total_concentration``, keeping the ``c_R = 0``
+  wetting-front shock speed exact.
+
+- :class:`VanGenuchtenMualemConductivity` - Mualem conductivity for the van Genuchten retention curve, recast
+  the same way. ``total_concentration`` and the flux derivative are closed form; the two inversions ``S_e(C)``
+  and ``S_e(R)`` use ``scipy.optimize.brentq``. The retention parameter ``α_vG`` is not needed because the
+  Kinematic-Wave approximation drops capillary suction.
+
+- :func:`characteristic_speed` - Characteristic speed ``dV/dθ = 1/R(c)`` in (V, θ) coordinates, a property of
+  the isotherm alone. Its ``sorption`` argument is any of the classes above (the ``SorptionModel`` alias is
+  their union).
+
+- :func:`characteristic_position` - Position of a characteristic at cumulative flow ``theta``, evaluated as
+  ``v_start + (θ − θ_start)/R(c)``, or ``None`` when ``theta`` lies before ``theta_start``.
+
+- :func:`compute_first_front_arrival_theta` - Cumulative flow at which the first injected concentration level
+  is fully present at the outlet: the θ-edge of the first bin that both carries water (positive θ-width) and
+  has ``cin > 0``, plus ``V · R(c_first)`` for Freundlich ``n < 1`` and ``V · C_T(c_first)/c_first``
+  otherwise. These are *tail*-arrival semantics — a rarefaction head can reach the outlet much earlier — and
+  the result is ``inf`` when no water-carrying bin injects concentration.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/fronttracking/output.py
+++ b/src/gwtransport/fronttracking/output.py
@@ -10,6 +10,55 @@ conservation for transport with sorption). ``m_dom`` honors historical
 wave activity via ``wave.was_active_at(theta)`` so retrospective queries
 at θ before a collision event correctly attribute c at v_outlet.
 
+Available functions:
+
+- :func:`concentration_at_point` - Exact concentration at a single point ``(v, θ)``: the upstream state of the
+  nearest wave face at or downstream of ``v`` among the waves active at ``θ``, the downstream state of the
+  outermost face when nothing lies downstream, and ``0`` in a virgin domain. Exactly on a shock or fan face the
+  two sides are averaged; a contact carries its upstream value at its own position. The ``sorption`` argument is
+  unused — each wave carries its own sorption reference.
+
+- :func:`compute_breakthrough_curve` - Outlet concentration sampled at every θ of a θ-array, i.e.
+  :func:`concentration_at_point` evaluated at ``v_outlet``. Returns one concentration [mass/volume] per θ; these
+  are point samples of the exact trace, not bin averages.
+
+- :func:`compute_bin_averaged_concentration_exact` - Outlet concentration averaged over each output θ-bin (a
+  flow-weighted average, since θ is cumulative flow), evaluated through the conservation identity
+  ``c_avg = (Δm_in − Δm_dom) / Δθ`` rather than by integrating the outlet trace, so overlapping fans need no
+  ownership dispatch. A residual inside the floating-point cancellation band is set to zero; a bin more negative
+  than that band warns and is clamped to zero to preserve the ``cout >= 0`` contract.
+
+- :func:`identify_outlet_segments` - Partition of a θ-interval into the segments over which a single wave
+  controls the outlet, as a list of dicts holding the segment θ-range, its type (``'constant'``,
+  ``'rarefaction'`` or ``'decaying_fan'``), the controlling wave and the concentrations at both segment ends.
+  Crossings extrapolated at or past a wave's deactivation are dropped.
+
+- :func:`compute_domain_mass` - Total mass ``∫₀^{v_outlet} C_total(v, θ) dv`` held in the domain at one θ [mass],
+  dissolved plus sorbed. The domain is partitioned at the active wave faces; a constant region integrates as
+  ``C_total·Δv`` and a fan region in closed form via :func:`integrate_fan_spatial_exact`.
+
+- :func:`compute_cumulative_inlet_mass` - Mass injected at the inlet from ``θ = 0`` up to ``theta``,
+  ``∫₀^θ cin dτ`` [mass], exact for the piecewise-constant ``cin`` on ``theta_edges``.
+
+- :func:`compute_cumulative_outlet_mass` - Mass that has left through the outlet from ``θ = 0`` up to ``theta``
+  [mass], as ``m_in(θ) − m_dom(θ)``; ``0`` for ``θ <= 0``.
+
+- :func:`compute_total_outlet_mass` - Outlet mass over all θ, from the inlet record alone: the full injected mass
+  ``Σ cin·Δθ`` when the record returns to ``cin[-1] = 0``, and ``+inf`` for a sustained ``cin[-1] > 0`` boundary,
+  which keeps injecting forever.
+
+- :func:`integrate_fan_exact` - Exact ``∫ c(θ) dθ`` [mass] at a fixed position for any self-similar fan, given
+  the fan apex ``(theta_origin, v_origin)``, via the universal integration-by-parts antiderivative
+  ``F(θ) = c·(θ − θ_origin) − Δv·C_T(c)``. ``c_apex > 0`` clamps the fan at its tail θ and adds the constant
+  plateau beyond it; ``theta_end`` may be ``+inf`` where the fan integral converges, and raises otherwise.
+
+- :func:`integrate_rarefaction_exact` - :func:`integrate_fan_exact` with the apex and ``c_apex = raref.c_tail``
+  read off a :class:`~gwtransport.fronttracking.waves.RarefactionWave`.
+
+- :func:`integrate_fan_spatial_exact` - Exact ``∫ C_total(v, θ) dv`` [mass] over a v-segment of a self-similar
+  fan at fixed θ, via the spatial counterpart ``G(u) = C_T(c)·u − κ·c`` with ``κ = θ − θ_origin`` and
+  ``u = v − v_origin``. ``c_apex > 0`` splits off the constant-``C_total(c_apex)`` region near the apex.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/fronttracking/plot.py
+++ b/src/gwtransport/fronttracking/plot.py
@@ -2,12 +2,33 @@
 Visualization functions for front tracking.
 
 This module provides plotting utilities for visualizing front-tracking simulations:
+
 - V-t diagrams showing wave propagation in space-time
 - Breakthrough curves showing concentration at outlet over time
 
 Internally the simulation uses cumulative-flow coordinates (V, θ). All plots
 remain in user-facing time t (days). Translation is done via the state's
 ``t_at_theta`` / ``theta_at_t`` methods at the plotting boundary.
+
+Available functions:
+
+- :func:`plot_vt_diagram` - Draw every wave of a completed simulation in the (time, position) plane:
+  characteristics as thin blue lines, shocks as thick red lines, rarefactions as filled green fans, with the
+  inlet and the outlet marked as horizontal lines. Each straight-in-θ trajectory is sampled in θ and translated
+  to time t before plotting. Returns the axes; ``show_inactive`` adds the waves deactivated by interactions and
+  ``show_events`` marks the interaction events.
+
+- :func:`plot_inlet_concentration` - Draw ``cin`` on its ``tedges`` as a step function of time [days], optionally
+  marking a first-arrival time with a vertical line. Returns the axes.
+
+- :func:`plot_front_tracking_summary` - Three-panel figure for one simulation: the V-t diagram, the inlet
+  concentration, and across the bottom the outlet concentration as the exact analytical breakthrough curve
+  and/or the bin-averaged ``cout`` step trace, both referenced to the tracker's own time origin so the two
+  overlay without a shift. Returns the figure and a dict of axes keyed ``'vt'``, ``'inlet'`` and ``'outlet'``.
+
+- :func:`plot_sorption_comparison` - 2x3 figure contrasting a pulse inlet and a dip inlet with the exact outlet
+  response each produces under a favorable (``n>1``) and an unfavorable (``n<1``) isotherm: column 0 holds the
+  two inlets, columns 1-2 their responses. Returns the figure and the 2x3 array of axes.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.

--- a/src/gwtransport/fronttracking/solver.py
+++ b/src/gwtransport/fronttracking/solver.py
@@ -16,6 +16,29 @@ Algorithm:
 5. Repeat until no more events.
 
 All calculations are exact analytical with machine precision.
+
+Available functions:
+
+- :class:`FrontTrackerState` - Dataclass carrying the whole simulation state: every wave ever created
+  (active and deactivated), the event log, the current θ, the outlet position ``v_outlet``, the sorption
+  model, the inlet series, and the ``tedges_days``/``theta_edges`` grids. Its ``t_at_theta``, ``theta_at_t``
+  and ``theta_at_t_array`` methods are the piecewise-linear θ↔t maps a caller needs to read any solver output
+  in user-facing days; events at a zero-flow θ plateau map to the end of that plateau.
+
+- :class:`FrontTracker` - The event-driven solver. Construction validates the inputs (non-negative ``cin``
+  and ``flow``, ``len(tedges) == len(cin) + 1``, positive pore volume), builds ``theta_edges`` by cumulating
+  ``flow · dt``, sets the resolution horizon ``theta_horizon`` (default: the last inlet edge), computes
+  ``theta_first_arrival``, and emits the inlet waves. ``find_next_event`` returns the earliest candidate in
+  θ — characteristic, shock and rarefaction collisions, face merges involving a decaying or doubly-fed shock,
+  fan exhaustion, and outlet crossings — ``handle_event`` dispatches it to the handler that retires the
+  parents and appends the successors, and ``run`` repeats until the candidate set is empty or
+  ``max_iterations`` is reached. ``verify_physics`` asserts that every active shock still satisfies the Lax
+  entropy condition.
+
+- :func:`find_unresolved_interaction` - Invariant tripwire over a completed state. The cumulative outlet mass
+  ``m_out(θ) = m_in(θ) − m_dom(θ)`` must never decrease; this returns a short description of the first θ
+  where it does beyond the floating-point cancellation band — the fingerprint of an interaction the solver
+  failed to resolve — and ``None`` for a mass-conserving wave field.
 """
 
 import logging

--- a/src/gwtransport/fronttracking/validation.py
+++ b/src/gwtransport/fronttracking/validation.py
@@ -8,6 +8,17 @@ and event ordering. The solver runs in cumulative-flow coordinate
 ``flow ≥ 0`` is enforced, θ is monotone non-decreasing in t, so θ-ordering and
 chronological ordering are equivalent.
 
+Available functions:
+
+- :func:`verify_physics` - Run seven checks on a completed front-tracking result and return a summary
+  dictionary with ``'all_passed'``, the check counts, the ``'failures'`` list, a per-check record list and a
+  one-line ``'summary'``: Lax entropy for every shock, no negative concentrations, output bounded by the
+  inlet maximum, finite first-arrival θ, no NaN after spin-up, θ-ordered events, and mass conservation
+  comparing an independent outlet integral plus the domain mass against the injected mass at ``θ_max``. The
+  mass-balance check uses ``max(rtol, _MASS_BALANCE_RTOL)`` because integrating a shock-bearing breakthrough
+  curve is only first-order accurate. Passing ``verbose=False`` suppresses printing but returns the same
+  dictionary.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/fronttracking/waves.py
+++ b/src/gwtransport/fronttracking/waves.py
@@ -9,7 +9,49 @@ knows how to compute its position at any later θ.
 In (V, θ) every wave velocity is a property of the sorption isotherm alone —
 flow does not enter wave dynamics. Time-varying flow is absorbed entirely into
 the θ(t) mapping at the API boundary, so no wave needs recreation when the flow
-rate changes.
+rate changes. Attributes named ``theta_*`` are therefore cumulative flow [m³],
+never time; ``v_*`` are volumetric positions [m³] measured from the inlet face
+``V = 0``. Every module in :mod:`gwtransport.fronttracking` follows this convention.
+
+Available functions:
+
+- :class:`Wave` - Abstract base of the hierarchy. Holds the formation point ``(v_start, theta_start)``, the
+  ``is_active`` flag and the ``theta_deactivation`` history marker, and requires ``position_at_theta``,
+  ``concentration_left``, ``concentration_right`` and ``concentration_at_point`` from every subclass. Use
+  ``was_active_at(theta)`` for retrospective queries; ``is_active`` describes only the current state.
+
+- :class:`CharacteristicWave` - A single characteristic line carrying one constant concentration at the
+  flow-free speed ``1/R(c)``. Physically a contact discontinuity in a smooth region: the concentration value
+  travels unchanged, and ``c_ahead`` records the state it separates from downstream.
+
+- :class:`ShockWave` - A sharp front across which concentration jumps from ``c_left`` to ``c_right``, formed
+  where faster water overtakes slower water. Its ``speed`` is the Rankine-Hugoniot secant
+  ``(c_R − c_L)/(C_T(c_R) − C_T(c_L))``, constant in θ; ``satisfies_entropy`` tests the Lax condition.
+
+- :class:`RarefactionWave` - An expansion fan spreading between ``c_head`` and ``c_tail``, formed where
+  slower water follows faster water. The interior is self-similar, ``R(c) = (θ − θ_start)/(V − v_start)``, so
+  head and tail move at the characteristic speeds ``1/R(c_head)`` and ``1/R(c_tail)``; construction is
+  rejected when the head is not faster than the tail (that geometry is a compression, hence a shock).
+
+- :class:`DecayingShockWave` - A shock with a fan on one side, formed when a rarefaction and a shock collide.
+  The fan feeds the ``decay_side``, whose concentration relaxes from ``c_decay_initial`` toward the fan's far
+  bound ``c_fan_tail`` while the other side stays at ``c_fixed``, so the front decelerates along a curved
+  trajectory instead of a straight line. The trajectory uses a closed form where one exists (Freundlich with
+  ``c_fixed = 0`` or ``n = 2``, Langmuir and Brooks-Corey with ``c_fixed = 0``) and a cached quadrature
+  profile otherwise; ``theta_at_fan_exhaustion`` reports the θ at which the fan is spent and the wave hands
+  off to a plain shock.
+
+- :class:`DoubleFanShockWave` - A shock fed by a self-similar fan on *both* sides, formed when a fan boundary
+  catches a decaying shock whose surviving side is itself a fan. Both side concentrations then relax as the
+  front advances. The trajectory is closed form for Freundlich ``n = 2`` with a shared apex position (the
+  case every inlet-born fan produces) and a cached RK4 spline otherwise; a side ending is detected
+  externally, as the shock face crossing its own fan boundary line.
+
+- :class:`Feeder` - The boundary state on one side of a front: either a constant concentration or a bounded
+  self-similar fan with apex ``(v_apex, theta_apex)`` spanning ``[c_a, c_b]``, evaluated by inverting
+  ``R = (θ − θ_apex)/(v − v_apex)`` and clamped in ``R``-space so a query past the fan edge reads the plateau
+  value. Feeders are the common currency of the interaction calculus in
+  :mod:`gwtransport.fronttracking.interactions`.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.

--- a/src/gwtransport/gamma.py
+++ b/src/gwtransport/gamma.py
@@ -32,6 +32,23 @@ gamma distribution.
 
 Streamtube discretization by :func:`bins` is always into bins of **equal probability mass**.
 
+Available functions:
+
+- :func:`parse_parameters` - Resolve either ``(mean, std)`` or ``(alpha, beta)``, together with an
+  optional ``loc``, into the validated ``(alpha, beta, loc)`` triple the rest of the package works with.
+  Exactly one of the two pairs must be supplied; positivity, ``0 <= loc < mean`` and finiteness are
+  enforced, otherwise ``ValueError`` is raised.
+
+- :func:`mean_std_loc_to_alpha_beta` - Convert the physically intuitive ``(mean, std, loc)`` parameters
+  to gamma shape and scale from the excess-over-``loc`` moments,
+  ``alpha = ((mean - loc) / std) ** 2`` and ``beta = std ** 2 / (mean - loc)``.
+
+- :func:`bins` - Split the (shifted) gamma distribution at the ``n_bins + 1`` uniform quantile edges, so
+  every bin (streamtube) carries probability mass ``1 / n_bins``. Returns a dict of arrays: the bin edges
+  (``lower_bound``, ``upper_bound``, ``edges``; the first lower bound is ``loc`` and the last upper bound
+  is infinite), the per-bin conditional mean pore volume (``expected_values``) that serves as the
+  streamtube pore volume in transport calculations, and the per-bin ``probability_mass``.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/logremoval.py
+++ b/src/gwtransport/logremoval.py
@@ -63,6 +63,43 @@ shape/scale and the mean/std pairs are validated through :func:`gwtransport.gamm
 so invalid parameters (e.g. a negative shape) raise ``ValueError`` rather than silently returning
 an unphysical result.
 
+Available functions:
+
+- :func:`residence_time_to_log_removal` - Multiply residence times [days] by a log10 decay rate
+  [log10/day] to get log removal, returning an array of the same shape as the input. Negative
+  residence times or a negative rate give negative log removal; the caller interprets the sign.
+
+- :func:`decay_rate_to_log10_decay_rate` - Convert a natural-log first-order decay rate constant
+  lambda [1/day] to a log10 decay rate mu [log10/day] via ``mu = lambda / ln(10)``.
+
+- :func:`log10_decay_rate_to_decay_rate` - Convert a log10 decay rate mu [log10/day] to a
+  natural-log first-order decay rate constant lambda [1/day] via ``lambda = mu * ln(10)``.
+
+- :func:`parallel_mean` - Combine the log removals of parallel flow paths into the single log
+  removal of their blended outflow, ``-log10(sum(F_i * 10^(-LR_i)))``. Flow fractions default to
+  an equal split and must sum to 1.0 along the reduction axis; ``axis=None`` reduces over the
+  flattened input and returns a scalar.
+
+- :func:`gamma_pdf` - Probability density of log removal when the residence time is (shifted)
+  gamma-distributed: a gamma density with shape ``rt_alpha``, scale ``log10_decay_rate * rt_beta``,
+  and location ``log10_decay_rate * rt_loc``, evaluated at the requested log removal values.
+
+- :func:`gamma_cdf` - Cumulative distribution of log removal for the same shifted-gamma residence
+  time, i.e. the fraction of the extracted water whose log removal does not exceed ``r``.
+
+- :func:`gamma_mean` - Effective (flow-weighted, concentration-mixing) mean log removal for
+  gamma-distributed residence time,
+  ``log10_decay_rate * rt_loc + rt_alpha * log10(1 + rt_beta * log10_decay_rate * ln(10))``. This
+  is the continuous counterpart of :func:`parallel_mean` and lies below the arithmetic mean
+  ``log10_decay_rate * (rt_alpha * rt_beta + rt_loc)``, because short-residence-time paths
+  dominate the mixed outflow.
+
+- :func:`gamma_find_flow_for_target_mean` - Invert :func:`gamma_mean` for the flow rate that
+  attains a target effective mean log removal, given a gamma-distributed **aquifer pore volume**
+  (hence the ``apv_`` prefix; dividing the pore volume by the flow gives the residence time).
+  Closed form when ``apv_loc == 0``, otherwise a bracketed :func:`scipy.optimize.brentq` root in
+  ``1 / flow``. Requires a positive ``target_mean`` and a positive ``log10_decay_rate``.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/percolation.py
+++ b/src/gwtransport/percolation.py
@@ -1,15 +1,9 @@
 """
 Percolation through thick unsaturated zones via the Kinematic Wave method.
 
-This module provides one public function:
-
-- :func:`root_zone_to_water_table_kinematic_wave` — exact front-tracking
-  solver for gravity-driven percolation between the bottom of the root
-  zone and the water table, following the Kinematic-Wave method described
-  in Olsthoorn (2026, *Stromingen* 32(1)). Supports Brooks-Corey and
-  van Genuchten-Mualem constitutive curves and a time-varying
-  multiplicative scaling of K(θ) (e.g. for temperature-corrected
-  viscosity).
+This module solves gravity-driven percolation between the bottom of the
+root zone and the water table by exact front tracking, following the
+Kinematic-Wave method described in Olsthoorn (2026, *Stromingen* 32(1)).
 
 **Forward-only.** Inverse mapping ``water_table_to_root_zone`` is not
 provided. The KW unsaturated-zone problem is fundamentally one-way under
@@ -27,6 +21,21 @@ spells out the recovery rule and the layered-porosity generalisation.
 
 The full Kinematic-Wave derivation and the constitutive-curve references
 are documented on :func:`root_zone_to_water_table_kinematic_wave`.
+
+Available functions:
+
+- :func:`root_zone_to_water_table_kinematic_wave` - Solve the Kinematic-Wave conservation law
+  ``∂θ_m/∂t + ∂K(θ_m)/∂z = 0`` exactly by front tracking, returning the bin-averaged percolation flux
+  at the water table on ``q_water_table_tedges`` together with the per-column solver structures
+  (waves, events, first-arrival time, counts, and the tracker state that maps cumulative effective
+  time back to wall-clock time). The flux is in the same units as ``q_root_zone`` and is averaged
+  over the columns listed in ``cumulative_pore_volumes_outlet``, whose entries are cumulative pore
+  volume per unit area rather than geometric depth. The constitutive curve is Brooks-Corey when
+  ``brooks_corey_lambda`` is given and van Genuchten-Mualem when ``van_genuchten_n`` is given;
+  exactly one of the two is required. The optional ``k_scaling`` applies a time-only multiplicative
+  factor ``f(t)`` to the whole ``K(θ)`` curve (e.g. temperature-corrected viscosity) and then
+  requires ``q_water_table_tedges`` to equal ``tedges``, since the back-transform
+  ``q_water_table = f · cout`` is exact only on the input grid.
 
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.

--- a/src/gwtransport/radial_asr.py
+++ b/src/gwtransport/radial_asr.py
@@ -57,6 +57,36 @@ displacement) must stay well inside the stagnation radius ``r_s = |A_0|/|v_d|`` 
 Rest phases (``flow == 0``) are propagated by the exact free-space drift kernel (translate + anisotropic
 spread). The drift-induced recovery loss is validated against an independent 2-D finite-volume oracle.
 
+Available functions:
+
+- :func:`infiltration_to_extraction` - Forward transport: compute the extracted flux concentration ``cout`` from an
+  injected concentration ``cin``, a signed flow schedule (``> 0`` injection, ``< 0`` extraction, ``0`` rest) and the
+  well geometry. Grid-free -- the exact per-phase kernels are composed across every flow reversal, and the phases
+  (and hence the number of push-pull / ASR cycles) follow from the flow sign pattern rather than from an argument.
+  ``cout`` is the flow-weighted average over each output bin, in the units of ``cin``, defined on the extraction bins
+  and ``NaN`` on injection and rest bins; ``cout_tedges`` must equal ``tedges``. ``pore_heights`` is a scalar
+  (one homogeneous screen) or an array of streamtube heights -- each streamtube carries the full flow, and the
+  breakthroughs are averaged with ``weights`` (equal by default). Sorption is linear through ``retardation_factor``;
+  ``background`` is the ambient aquifer concentration, so the deviation ``cin - background`` is transported and
+  ``background`` added back. Nonzero ``regional_flux`` engages the azimuthal-mode drift engine within its
+  slow-drift envelope, and raises ``ValueError`` when the plume leaves that envelope.
+
+- :func:`extraction_to_infiltration` - Reverse operation: recover the injected concentration from measured extracted
+  concentrations under the same flow schedule and geometry. The forward operator is assembled column-by-column from
+  unit injection-pulse responses and inverted by Tikhonov least squares (``regularization_strength``). Returns one
+  value per bin: the recovered ``cin`` on injection bins and ``NaN`` on extraction and rest bins. ``NaN`` in ``cout``
+  on an extraction bin raises ``ValueError``; structural ``NaN`` on injection and rest bins is ignored.
+
+- :func:`gamma_infiltration_to_extraction` - Forward transport as in :func:`infiltration_to_extraction`, with the
+  streamtube ensemble built from a gamma distribution of the layer velocity across a well screen of known height
+  ``screen_height``. The velocity ratio has mean 1 and coefficient of variation ``velocity_cv``, a streamtube of
+  velocity ratio ``rho`` gets effective pore height ``screen_height / rho``, and the distribution is discretized into
+  ``n_bins`` equal-probability bins averaged by probability mass. ``velocity_cv = 0`` is the homogeneous screen: a
+  single streamtube at pore height ``screen_height``.
+
+- :func:`gamma_extraction_to_infiltration` - Reverse operation as in :func:`extraction_to_infiltration`, over the same
+  gamma layer-velocity streamtube ensemble as :func:`gamma_infiltration_to_extraction`.
+
 References
 ----------
 The references below give the published closed-form solutions for the **single-phase** radial *injection*

--- a/src/gwtransport/recharge.py
+++ b/src/gwtransport/recharge.py
@@ -34,6 +34,16 @@ entry point:
   (:func:`gwtransport.advection.infiltration_to_extraction`); with the
   boundary never feeding the well it reduces exactly to the unbounded model.
 
+Available functions:
+
+- :func:`recharge_to_extraction` - Compute the extracted concentration from the recharge
+  concentration ``cin_recharge`` and, in the bounded model, the upstream-boundary concentration
+  ``cin`` and the extraction rate ``flow``. Forward only: there is no extraction-to-recharge
+  inverse. The result is one value per ``cout_tedges`` bin, a flow-weighted bin average in the
+  bounded model and a recharge-weighted bin average in the unbounded model, NaN outside the input
+  time range and in bins whose weight is zero. All terms are closed-form, so the output is exact
+  to machine precision for bin-constant inputs.
+
 References
 ----------
 Haitjema, H.M. (1995). On the residence time distribution in idealized

--- a/src/gwtransport/residence_time.py
+++ b/src/gwtransport/residence_time.py
@@ -60,6 +60,39 @@ range of infiltration times that is not captured there, so no bin is fully infor
 is present (for that dispersive informed fraction use the captured kernel mass of the diffusion
 coefficient matrix).
 
+Available functions:
+
+- :func:`full` - Flow-weighted mean residence time [days] over each output bin, resolved per pore volume:
+  the full ``(n_pore_volumes, n_output_bins)`` array, without collapsing the pore-volume axis. The bin
+  average is uniform in cumulative throughflow volume, and ``direction`` selects whether the time is the
+  look-back to infiltration (``extraction_to_infiltration``) or the look-forward to extraction
+  (``infiltration_to_extraction``).
+
+- :func:`mean` - Mean residence time [days] per output bin for a discrete aquifer pore-volume
+  distribution: the :func:`full` array collapsed by averaging over the equally-weighted streamtubes that
+  are valid in each bin, shape ``(n_output_bins,)``.
+
+- :func:`gamma` - Mean residence time [days] per output bin for a continuous (shifted) gamma aquifer
+  pore-volume distribution, parameterized by either ``(mean, std, loc)`` or ``(alpha, beta, loc)``. The
+  expectation is taken in closed form from regularized incomplete-gamma partial moments, so there is no
+  pore-volume discretization and no accuracy/cost knob; shape ``(n_output_bins,)``.
+
+- :func:`fraction_explained_full` - Advective coverage per pore volume: the flow-weighted fraction of each
+  output bin, in ``[0, 1]``, whose retarded parcel lies inside the supplied flow record. Returned as the
+  full ``(n_pore_volumes, n_output_bins)`` array, mirroring :func:`full`.
+
+- :func:`fraction_explained_mean` - Equally-weighted mean of :func:`fraction_explained_full` over the
+  discrete streamtubes, shape ``(n_output_bins,)``.
+
+- :func:`fraction_explained_gamma` - Closed-form expectation of the advective in-record indicator over a
+  (shifted) gamma pore-volume distribution, shape ``(n_output_bins,)`` -- the continuum analogue of
+  :func:`fraction_explained_mean`, evaluated from the antiderivative of the shifted-gamma CDF.
+
+- :func:`freundlich_retardation` - Concentration-dependent retardation factors
+  ``R = 1 + (rho_b / theta) * k_f * (1 / n) * C ** (1 / n - 1)`` from the Freundlich isotherm
+  ``s = k_f * C ** (1 / n)``, one per concentration entry, for use as the ``retardation_factor`` input of
+  the transport functions.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """

--- a/src/gwtransport/utils.py
+++ b/src/gwtransport/utils.py
@@ -12,6 +12,62 @@ both fed by :func:`compute_reverse_target` and built on :func:`solve_tikhonov`) 
 overdetermined deconvolution in advection/diffusion, and a separate nullspace solver
 (:func:`solve_underdetermined_system`) for the underdetermined deposition inverse.
 
+Available functions:
+
+- :func:`step_plot_coords` - Expand bin edges (n+1) and bin-averaged values (n) into paired x/y arrays of 2n
+  points each, so that ``ax.plot(x, y)`` draws the piecewise-constant series as a step function. Edges may be
+  numeric or datetime; each output keeps the dtype of its input.
+
+- :func:`cumulative_flow_volume` - Accumulate per-bin flow rates times bin widths into the cumulative volume at
+  every bin edge (n+1 values, starting at zero). With ``strictly_monotone=True`` the plateaus left by zero-flow
+  bins are bumped by a few ulps, which is required before inverting the sequence from volume back to time.
+
+- :func:`linear_interpolate` - Interpolate ``y_ref`` at ``x_query`` linearly; ``x_ref`` must be ascending and the
+  result has the shape of ``x_query``. Query points outside the reference range clamp to the end values unless
+  ``left`` / ``right`` supply a fill value such as NaN.
+
+- :func:`simplify_bins` - Merge adjacent bins of a piecewise-constant series until the peak-to-peak range within
+  each merged group is at most ``tol``, returning the merged edges, values and flow. Values are volume-weighted
+  (flow times width) when ``flow`` is given and width-weighted otherwise, while the merged flow is always
+  width-weighted. Splitting at the largest value jump makes the result independent of scan direction.
+
+- :func:`compute_time_edges` - Build the n+1 bin edges as a nanosecond-precision DatetimeIndex from exactly one of
+  explicit edges, per-bin start times, or per-bin end times, validating the length against ``number_of_bins``.
+  From ``tstart`` or ``tend`` the single missing outer edge is extrapolated from the adjacent interval alone, so
+  pass ``tedges`` directly when the bins are not uniformly spaced.
+
+- :func:`get_soil_temperature` - Download the KNMI soil-temperature record of one of four Dutch weather stations
+  and return it as a DataFrame in degrees Celsius on a UTC DatetimeIndex, with columns for the temperature at 5,
+  10, 20, 50 and 100 cm depth and the six-hourly minima and maxima at 5 and 10 cm. The download is cached on disk
+  for the calendar day; missing values are interpolated and forward-filled unless disabled. This is the only
+  function here that needs ``requests``, which is therefore imported lazily.
+
+- :func:`solve_underdetermined_system` - Solve ``A x = b`` for a wide system (more unknowns than equations) by
+  taking the least-squares solution and adding the nullspace component that minimizes a roughness objective;
+  rows holding NaN are dropped first. The closed-form squared-differences optimum is always computed and also
+  seeds the iterative optimization of the other objectives, so a nullspace containing a near-constant vector
+  raises :class:`numpy.linalg.LinAlgError` whichever objective is requested.
+
+- :func:`compute_reverse_target` - Transpose the forward coefficient matrix, normalize its rows and apply it to
+  the observations, giving each input bin the contribution-weighted average of the output bins it fed. This is
+  the reference solution the Tikhonov solvers pull poorly-determined modes toward; input bins with negligible
+  forward weight are returned as NaN.
+
+- :func:`solve_tikhonov` - Solve ``min ||A x - b||² + λ ||x - x_target||²`` as a single augmented least-squares
+  problem. Rows of the system holding NaN are excluded, and NaN entries of ``x_target`` are left unregularized.
+
+- :func:`solve_inverse_transport` - Recover the input signal of the dense forward model
+  ``w_forward @ x = observed`` by building the target with :func:`compute_reverse_target` and solving it with
+  :func:`solve_tikhonov`. Observation rows that are NaN or carry negligible weight drop out (an explicit
+  ``valid_rows`` mask overrides the weight test), and output bins left without forward contribution come back
+  as NaN.
+
+- :func:`solve_inverse_transport_banded` - Solve the same inverse problem for a forward operator stored in banded
+  layout (row ``k`` is ``band_vals[k]`` placed at column ``col_start[k]``), through banded Cholesky normal
+  equations plus corrected semi-normal refinement. The factorization, solve and refinement stay at
+  ``O(n_output * full_band)``. The regularization strength must be strictly positive, since it is what makes the
+  banded factor positive definite.
+
 This file is part of gwtransport which is released under AGPL-3.0 license.
 See the ./LICENSE file or go to https://github.com/gwtransport/gwtransport/blob/main/LICENSE for full license details.
 """


### PR DESCRIPTION
## Summary

Restores the `Available functions:` overview block at the top of each module. #353 removed these on the grounds that Sphinx autodoc renders the same content; in practice they are useful when reading the source, so they are back — but **regenerated against the current API rather than reverted**, because the old blocks were incomplete and partly stale.

Coverage before this PR:

| Module | Public names | Listed |
| ------ | ------------ | ------ |
| `advection`, `deposition`, `diffusion_fast`, `radial_asr`, `recharge`, `fronttracking/output` | — | no index at all |
| `utils` | 11 | 5 |
| `logremoval` | 8 | 5 |
| `gamma` | 3 | 1 |

All 26 modules now list their public API exactly. Every entry was checked to resolve to a real name, and completeness was enforced mechanically: the set of listed names must equal the set of public functions and classes per module — the run reports **0 mismatches**.

### Descriptions corrected against the implementation

Each description was written from the function body, not copied from its summary line. That surfaced four documented behaviours that were no longer true:

- **`linear_interpolate`** — documented as handling unsorted input. It no longer sorts (the argsort was removed in #353); it is a thin `np.interp` wrapper requiring ascending `x_ref`. The entry now states that precondition.
- **`solve_underdetermined_system`** — its `Raises` section implies the `LinAlgError` is specific to `nullspace_objective="squared_differences"` and suggests switching objective as a remedy, but the closed-form squared-differences solve runs unconditionally and seeds the other objectives, so the error fires whichever objective is requested.
- **`simplify_bins`** — returns width-weighted flow even when values are volume-weighted, and falls back to width weighting for all-zero-flow groups.
- **`compute_time_edges`** — normalizes to nanosecond precision and extrapolates a missing outer edge from a single adjacent interval, which is unsafe for non-uniform bins.

### Contracts the overviews now state

The indices carry the information that decides which function to reach for: the diffusion accuracy ladder (dense reference / banded / approximate-by-design), the gamma-parameter versus explicit-pore-volume distinction in `advection`, deposition as a **source** term, `logremoval`'s `rt_*` (residence time) versus `apv_*` (pore volume) parameterizations, and the V/θ coordinate convention in `fronttracking`.

## Test plan

Module docstrings only. This is verified structurally, not asserted: with the module-level docstring stripped from each changed file, **every file's AST is identical to `main`** — no code changed, so no unit test can be affected.

```
ruff format --check .                                  # 102 files already formatted
ruff check .                                           # All checks passed
pytest --doctest-modules src/gwtransport -n2           # 37 passed
pytest tests/docs -n2                                  # 9 passed
ty check --python .venv-claude .                       # 2 diagnostics, identical to main
```

Not indexed, deliberately: the private `_radial_asr_*` internals, and `_time.py`, where a prose paragraph naming both helpers reads better than a two-entry index.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.
