### PR TITLE
perf(radial_asr): bound test-suite memory and cut runtime ~10x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,9 @@ config-path = "ruff.toml"
 addopts = [
     "--import-mode=importlib",
     "-n=auto",
+    # loadgroup honors @pytest.mark.xdist_group: the memory-heavy radial-ASR drift tests are serialized
+    # onto two workers so their multi-GB transients never stack across the whole worker pool.
+    "--dist=loadgroup",
     "--doctest-modules",
 ]
 markers = [

--- a/src/gwtransport/_radial_asr_drift_kernels.py
+++ b/src/gwtransport/_radial_asr_drift_kernels.py
@@ -409,12 +409,6 @@ def _block_solutions(
         ``Lm_w`` (``L_-`` at ``r_w``, shape ``(n_s, nm, nm)``), ``H`` (the Wronskian blocks
         ``[A (L_- - L_+)]^{-1}`` at ``r_nodes``, ``(n_quad, n_s, nm, nm)``) and ``Tm``/``Tp`` (recessive
         outward / regular inward per-interval transitions, ``(n_quad, n_s, nm, nm)``).
-
-    Raises
-    ------
-    RuntimeError
-        If a matrix Riccati or interval-transition integration does not succeed (the log-derivative hit
-        a pole, typically the coordinate finite-escape near the stagnation radius).
     """
     s = np.asarray(s, dtype=complex).reshape(-1)
     n_s = s.size
@@ -450,16 +444,53 @@ def _block_solutions(
         kappa = np.sqrt(retardation_factor * s / d_m)
         a_coef = (1.0 - sigma_a * abs(a0) / d_m) / 2.0 - kappa * astar / 2.0
         l0 = -kappa - a_coef / (r_far + astar)
+    prev = np.concatenate(([r_w], r_nodes[:-1]))
+
+    def _branch(
+        l0_blocks: npt.NDArray[np.complexfloating],
+        r_start: float,
+        r_end: float,
+        hop_from: npt.NDArray[np.floating],
+        hop_to: npt.NDArray[np.floating],
+    ) -> tuple[npt.NDArray[np.complexfloating], npt.NDArray[np.complexfloating], npt.NDArray[np.complexfloating]]:
+        """Integrate one Riccati branch; return ``L`` at ``r_nodes``, ``L`` at ``r_w``, and its hops.
+
+        The dense ODE interpolant -- the block engine's peak-memory term, ``O(steps n_s (2M+1)^2)`` --
+        lives only inside this scope, so at most one branch's interpolant is resident at a time.
+
+        Returns
+        -------
+        tuple of ndarray
+            ``L`` at ``r_nodes`` (``(n_quad, n_s, nm, nm)``), ``L`` at ``r_w`` (``(n_s, nm, nm)``), and
+            the per-interval transitions over ``(hop_from, hop_to)`` (``(n_quad, n_s, nm, nm)``).
+
+        Raises
+        ------
+        RuntimeError
+            If the matrix Riccati integration does not succeed (the log-derivative hit a pole, typically
+            the coordinate finite-escape near the stagnation radius).
+        """
+        sol = solve_ivp(
+            riccati_rhs,
+            [r_start, r_end],
+            l0_blocks.reshape(-1).view(float),
+            rtol=_RICCATI_RTOL,
+            atol=_RICCATI_ATOL,
+            dense_output=True,
+            method="DOP853",
+        )
+        if not sol.success:
+            msg = "block Riccati integration failed (the matrix log-derivative likely hit a pole near stagnation)"
+            raise RuntimeError(msg)
+
+        def l_at(r: npt.NDArray[np.floating]) -> npt.NDArray[np.complexfloating]:
+            return np.ascontiguousarray(sol.sol(r).T).view(complex).reshape(np.size(r), n_s, nm, nm)
+
+        return l_at(r_nodes), l_at(np.array([r_w]))[0], _interval_transitions(l_at, hop_from, hop_to, n_s, nm)
+
     lm0 = (l0[:, None, None] * eye[None]).astype(complex)
-    sol_m = solve_ivp(
-        riccati_rhs,
-        [r_far, r_w],
-        lm0.reshape(-1).view(float),
-        rtol=_RICCATI_RTOL,
-        atol=_RICCATI_ATOL,
-        dense_output=True,
-        method="DOP853",
-    )
+    # Psi_-(r_i, r_{i-1}): recessive outward hops
+    lm_nodes, lm_w, tm = _branch(lm0, r_far, r_w, prev, r_nodes)
     # Exact block well-face IC for the regular branch: the theta-modulated face velocity and the
     # D_rtheta cross-dispersion couple the modes in the face condition (a mode-decoupled face IC would
     # mis-state the drift loss at O(eps^2), the order of the loss itself):
@@ -470,37 +501,15 @@ def _block_solutions(
     cross = (m_drt * i_dm_face[None, :]) / r_w
     lp_w = np.linalg.solve(m_drr, (m_vr - cross) if sigma_a > 0 else -cross)
     lp0 = np.broadcast_to(lp_w, (n_s, nm, nm)).astype(complex)
-    sol_p = solve_ivp(
-        riccati_rhs,
-        [r_w, r_max],
-        lp0.reshape(-1).view(float),
-        rtol=_RICCATI_RTOL,
-        atol=_RICCATI_ATOL,
-        dense_output=True,
-        method="DOP853",
-    )
-    if not (sol_m.success and sol_p.success):
-        msg = "block Riccati integration failed (the matrix log-derivative likely hit a pole near stagnation)"
-        raise RuntimeError(msg)
+    # Psi_+(r_{i-1}, r_i): regular inward hops
+    lp_nodes, _, tp = _branch(lp0, r_w, r_max, r_nodes, prev)
 
-    def l_minus_at(r: npt.NDArray[np.floating]) -> npt.NDArray[np.complexfloating]:
-        return np.ascontiguousarray(sol_m.sol(r).T).view(complex).reshape(np.size(r), n_s, nm, nm)
-
-    def l_plus_at(r: npt.NDArray[np.floating]) -> npt.NDArray[np.complexfloating]:
-        return np.ascontiguousarray(sol_p.sol(r).T).view(complex).reshape(np.size(r), n_s, nm, nm)
-
-    prev = np.concatenate(([r_w], r_nodes[:-1]))
     a_n = block_coupling_matrices(r_nodes, alpha_l=alpha_l, a0=a0_signed, v_d=v_d, d_m=d_m, n_modes=n_modes)[0]
     # The log-derivative branches enter the resolvent only through the Wronskian block
     # H(r') = [A(r')(L_-(r') - L_+(r'))]^{-1} -- bounded wherever the recessive and regular subspaces are
     # transverse -- so H is materialized once here (and cached with the phase) instead of its factors.
-    h = np.linalg.inv(a_n[:, None] @ (l_minus_at(r_nodes) - l_plus_at(r_nodes)))
-    return {
-        "Lm_w": l_minus_at(np.array([r_w]))[0],
-        "H": h,
-        "Tm": _interval_transitions(l_minus_at, prev, r_nodes, n_s, nm),  # Psi_-(r_i, r_{i-1}), outward hops
-        "Tp": _interval_transitions(l_plus_at, r_nodes, prev, n_s, nm),  # Psi_+(r_{i-1}, r_i), inward hops
-    }
+    h = np.linalg.inv(a_n[:, None] @ (lm_nodes - lp_nodes))
+    return {"Lm_w": lm_w, "H": h, "Tm": tm, "Tp": tp}
 
 
 def _resident_laplace(

--- a/tests/src/test_radial_asr.py
+++ b/tests/src/test_radial_asr.py
@@ -571,7 +571,8 @@ class TestGeneralEngine:
     def test_dm_positive_forward_conserves(self):
         # Single inject->extract cycle (no rest) with D_m>0 routes to the closed-form echo operator; this
         # checks that path conserves mass under molecular diffusion. The multi-cycle reuse-engine D_m>0 path
-        # is covered by test_dm_positive_multi_cycle_round_trip. n_quad-insensitive (verified 8/16/120).
+        # is covered by test_dm_positive_multi_cycle_round_trip. n_quad=16 is the floor for the 2e-2
+        # conservation gate: measured rel error 5.9e-2 at n_quad=8 and 1.3e-2 at 12.
         tedges, flow, geom = _scenario()
         cin = np.where(flow > 0, 1.0, 0.0)
         cout = infiltration_to_extraction(
@@ -631,7 +632,7 @@ class TestGeneralEngine:
         cin = np.where(flow > 0, 1.0, 0.0)
         geom = {"pore_heights": 10.0, "porosity": 0.3, "well_radius": 0.5, "longitudinal_dispersivity": 0.5}
         pub = infiltration_to_extraction(
-            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, molecular_diffusivity=1.0, n_quad=24
+            cin=cin, flow=flow, tedges=tedges, cout_tedges=tedges, **geom, molecular_diffusivity=1.0, n_quad=8
         )
         eng = cout_deviation(
             cin_deviation=cin,
@@ -641,7 +642,7 @@ class TestGeneralEngine:
             r_w=geom["well_radius"],
             alpha_l=geom["longitudinal_dispersivity"],
             molecular_diffusivity=1.0,
-            n_quad=24,
+            n_quad=8,
         )
         ext = flow < 0
         np.testing.assert_allclose(pub[ext], eng[ext], rtol=1e-12, atol=1e-12)

--- a/tests/src/test_radial_asr_drift.py
+++ b/tests/src/test_radial_asr_drift.py
@@ -11,10 +11,15 @@ The rest-with-drift kernel has its own anchors: the t -> 0 identity, drift-rever
 rest, the v_d = 0 reduction to the scalar Bessel rest kernel (to the Neumann-image closure residual), an
 FV drift-loss cross-check of an inject-rest-extract cycle, and the honest spectral-tail guard.
 
-Cost note: the block solutions scale as ``n_quad * n_s * (2 n_modes + 1)^2`` in memory, and the block
-Riccati integration cost grows steeply with ``n_modes`` at the production ODE tolerances. Each test keeps
-``n_quad``/``n_modes`` as small as its physics anchor allows, but the suite is compute-bound (~25 min on
-four workers) -- the price of exercising the full engine rather than mocks.
+Cost note: the block engine's peak memory is one branch's dense Riccati interpolant
+(``O(steps * n_s * (2 n_modes + 1)^2)`` with ``n_s = 2 n_terms + 1``), which reaches ~1-2 GB per call at
+``v_d ~ 0`` where the recessive-IC grid is uncapped (``r_far = 8 r_grid``); runtime grows steeply with
+``n_modes`` at the production ODE tolerances. Each test therefore keeps ``n_quad``/``n_terms``/``n_modes``
+as small as its physics anchor allows (assertion margins re-measured at the reduced settings), U=0
+reference recoveries use the scalar engine (the exact ``v_d -> 0`` limit, certified by the
+reduces-to-scalar tests), and tests with multi-GB transients carry
+``@pytest.mark.xdist_group("radial-asr-heavy-a"/"-b")`` so ``--dist=loadgroup`` serializes them onto two
+workers (~5 min wall on two workers, peak ~4.6 GB).
 """
 
 import numpy as np
@@ -59,6 +64,7 @@ def _eps_to_vd(eps, r_b):
 
 
 # --- U=0 reductions: the block engine collapses to the radial engine -----------------------------
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_block_path_reduces_to_scalar_single_cycle():
     """At v_d=0 the modes decouple; the block engine's m=0 cout == the scalar engine (de Hoog floor).
 
@@ -74,7 +80,7 @@ def test_block_path_reduces_to_scalar_single_cycle():
         c_geo=_C_GEO,
         r_w=_R_W,
         alpha_l=_ALPHA_L,
-        n_quad=80,
+        n_quad=48,
         n_terms=40,
         tol=1e-11,
     )
@@ -87,13 +93,14 @@ def test_block_path_reduces_to_scalar_single_cycle():
         alpha_l=_ALPHA_L,
         v_d=0.0,
         n_modes=2,
-        n_quad=80,
+        n_quad=48,
         n_terms=40,
         tol=1e-11,
     )
     np.testing.assert_allclose(block[ext], scalar[ext], atol=1e-7)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_block_path_reduces_to_scalar_multicycle():
     """The resolvent field hand-off across reversals also reduces to the scalar reuse engine at v_d=0."""
     flow = np.array([_Q] * 4 + [-_Q] * 4 + [_Q] * 4 + [-_Q] * 6)
@@ -108,7 +115,7 @@ def test_block_path_reduces_to_scalar_multicycle():
         c_geo=_C_GEO,
         r_w=_R_W,
         alpha_l=_ALPHA_L,
-        n_quad=80,
+        n_quad=48,
         n_terms=40,
         tol=1e-11,
     )
@@ -121,13 +128,14 @@ def test_block_path_reduces_to_scalar_multicycle():
         alpha_l=_ALPHA_L,
         v_d=0.0,
         n_modes=2,
-        n_quad=80,
+        n_quad=48,
         n_terms=40,
         tol=1e-11,
     )
     np.testing.assert_allclose(block[ext], scalar[ext], atol=1e-7)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_block_path_reduces_to_scalar_with_diffusion():
     """With molecular diffusion (D_m>0) the v_d=0 block engine still reduces to the scalar reuse engine."""
     flow, dt, cin = _single_cycle()
@@ -140,7 +148,7 @@ def test_block_path_reduces_to_scalar_with_diffusion():
         r_w=_R_W,
         alpha_l=_ALPHA_L,
         molecular_diffusivity=0.5,
-        n_quad=80,
+        n_quad=48,
         n_terms=40,
         tol=1e-11,
     )
@@ -154,7 +162,7 @@ def test_block_path_reduces_to_scalar_with_diffusion():
         v_d=0.0,
         molecular_diffusivity=0.5,
         n_modes=2,
-        n_quad=80,
+        n_quad=48,
         n_terms=40,
         tol=1e-11,
     )
@@ -162,6 +170,7 @@ def test_block_path_reduces_to_scalar_with_diffusion():
 
 
 # --- exact U != 0 anchors that exercise the drift coupling ---------------------------------------
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_drift_reversal_symmetry():
     """cout(+U) == cout(-U): a 180 deg rotation maps the +x drift to -x with a symmetric IC and an m=0
     observable, so the extracted concentration is exactly even in the drift -- a machine-precision structural
@@ -180,7 +189,7 @@ def test_drift_reversal_symmetry():
         "r_w": _R_W,
         "alpha_l": _ALPHA_L,
         "n_modes": 3,
-        "n_quad": 80,
+        "n_quad": 48,
         "n_terms": 40,
         "tol": 1e-11,
     }
@@ -189,54 +198,42 @@ def test_drift_reversal_symmetry():
     np.testing.assert_allclose(cp[ext], cm[ext], atol=1e-8)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_drift_loss_quadratic_in_eps():
     """Within the slow-drift envelope the recovery loss is analytic O(eps^2): loss(2 eps)/loss(eps) -> 4.
 
     This pins the coupling MAGNITUDE end-to-end (the reversal test only pins parity), and documents that the
     non-analytic O(|eps|) straggler loss -- which needs the plume to reach the stagnation radius -- is
-    exponentially suppressed below r_s, so it does NOT appear here (ratio 4, not the strong-drift ratio 2)."""
+    exponentially suppressed below r_s, so it does NOT appear here (ratio 4, not the strong-drift ratio 2).
+
+    The U=0 reference recovery is the scalar engine: it is the exact v_d -> 0 limit of the block engine
+    (certified to ~1e-7 by the reduces-to-scalar tests, five orders below the losses compared here), and
+    the uncapped near-zero-drift recessive grid makes a block v_d ~ 0 run the costliest in the suite."""
     flow, dt, cin = _single_cycle()
     ext = flow < 0
     r_b = np.sqrt(_R_W**2 + _Q * 6 / _C_GEO)
+    kw = {
+        "cin_deviation": cin,
+        "flow": flow,
+        "dt_days": dt,
+        "c_geo": _C_GEO,
+        "r_w": _R_W,
+        "alpha_l": _ALPHA_L,
+        "n_quad": 48,
+        "n_terms": 24,
+        "tol": 1e-10,
+    }
+    re0 = float(np.nansum(cout_deviation(**kw)[ext]))
 
     def loss(eps):
-        v_d = _eps_to_vd(eps, r_b)
-        re0 = np.nansum(
-            block_cout_deviation(
-                cin_deviation=cin,
-                flow=flow,
-                dt_days=dt,
-                c_geo=_C_GEO,
-                r_w=_R_W,
-                alpha_l=_ALPHA_L,
-                v_d=1e-9,
-                n_modes=4,
-                n_quad=90,
-                n_terms=40,
-                tol=1e-10,
-            )[ext]
-        )
-        re = np.nansum(
-            block_cout_deviation(
-                cin_deviation=cin,
-                flow=flow,
-                dt_days=dt,
-                c_geo=_C_GEO,
-                r_w=_R_W,
-                alpha_l=_ALPHA_L,
-                v_d=v_d,
-                n_modes=4,
-                n_quad=90,
-                n_terms=40,
-                tol=1e-10,
-            )[ext]
-        )
-        return float(re0 - re)
+        block = block_cout_deviation(v_d=_eps_to_vd(eps, r_b), n_modes=4, **kw)
+        return re0 - float(np.nansum(block[ext]))
 
     ratio = loss(0.2) / loss(0.1)
     assert 3.7 < ratio < 4.3, f"loss(2 eps)/loss(eps) = {ratio:.3f}, expected ~4 (quadratic)"
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_retardation_rescale_in_drift():
     """Retardation is a joint degree-1 rescale of the operator: the block coupling obeys
     ``A,B,S0 -> A,B,S0 / R`` under ``(A_0, v_d, D_m) -> (A_0/R, v_d/R, D_m/R)``, so the ``R s`` Laplace
@@ -259,7 +256,7 @@ def test_retardation_rescale_in_drift():
         molecular_diffusivity=0.4,
         retardation_factor=r,
         n_modes=3,
-        n_quad=100,
+        n_quad=60,
         n_terms=40,
         tol=1e-11,
     )
@@ -275,7 +272,7 @@ def test_retardation_rescale_in_drift():
         molecular_diffusivity=0.4 / r,
         retardation_factor=1.0,
         n_modes=3,
-        n_quad=100,
+        n_quad=60,
         n_terms=40,
         tol=1e-11,
     )
@@ -384,10 +381,11 @@ def test_rest_long_translation_raises():
 
 
 # --- rest phases under drift: the free-space translate + spread kernel ----------------------------
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_rest_tiny_duration_reduces_to_no_rest():
     """A vanishing rest phase is a no-op: the translate+spread kernel reduces to the identity (t -> 0),
     exercising the full real-space evaluate / Gauss-Hermite / FFT-reproject round trip at delta ~ 0."""
-    kw = {"c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_modes": 3, "n_quad": 80, "n_terms": 40, "tol": 1e-10}
+    kw = {"c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_modes": 3, "n_quad": 48, "n_terms": 40, "tol": 1e-10}
     r_b = np.sqrt(_R_W**2 + _Q * 6 / _C_GEO)
     v_d = _eps_to_vd(0.2, r_b)
     flow_r = np.array([_Q] * 6 + [0.0] + [-_Q] * 10)
@@ -402,6 +400,7 @@ def test_rest_tiny_duration_reduces_to_no_rest():
     np.testing.assert_allclose(c_rest[flow_r < 0], c_none[flow_n < 0], atol=1e-8)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_rest_drift_reversal_symmetry():
     """cout(+U) == cout(-U) with a rest phase: the rest kernel's translation direction covaries with the
     drift sign under the 180-degree rotation, so the evenness anchor extends through the rest kernel."""
@@ -419,7 +418,7 @@ def test_rest_drift_reversal_symmetry():
         "r_w": _R_W,
         "alpha_l": _ALPHA_L,
         "n_modes": 3,
-        "n_quad": 80,
+        "n_quad": 48,
         "n_terms": 40,
         "tol": 1e-10,
     }
@@ -437,13 +436,14 @@ def test_rest_drift_reversal_symmetry():
         alpha_l=_ALPHA_L,
         v_d=v_d,
         n_modes=3,
-        n_quad=80,
+        n_quad=48,
         n_terms=40,
         tol=1e-10,
     )
     assert np.nansum(cp[ext]) < np.nansum(c_none[flow_n < 0])
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_rest_dm_reduces_to_scalar_bessel():
     """At v_d=0 with D_m>0 the rest kernel (isotropic free-space Gaussian + Neumann image at the well)
     matches the scalar engine's exact well-respecting Bessel rest kernel to the image-closure residual
@@ -461,12 +461,15 @@ def test_rest_dm_reduces_to_scalar_bessel():
     np.testing.assert_allclose(blk[ext], sca[ext], atol=1e-3)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_rest_drift_loss_matches_fv_oracle():
     """The rest-phase drift loss matches the independent 2-D FV oracle: an inject-rest-extract cycle at
     eps=0.25 with a 4-day rest, judged on the drift recovery loss (RE(U~0) - RE(U)), which the rest phase
     roughly doubles relative to the no-rest schedule -- the seasonal-storage effect the kernel exists for.
     The agreement is ~2% of the loss (the residual is the Neumann-image closure of the free-space rest
-    kernel plus the FV floor)."""
+    kernel plus the FV floor). The U=0 reference recovery is the scalar engine -- the exact v_d -> 0
+    limit of the block engine (a D_m=0 rest is the identity in both engines), avoiding the costly
+    uncapped near-zero-drift recessive grid."""
     n_inj, n_rest, n_ext = 6, 4, 10
     flow = np.concatenate([np.full(n_inj, _Q), np.zeros(n_rest), np.full(n_ext, -_Q)])
     dt = np.ones(len(flow))
@@ -475,24 +478,20 @@ def test_rest_drift_loss_matches_fv_oracle():
     r_b = np.sqrt(_R_W**2 + _Q * n_inj / _C_GEO)
     v_d = _eps_to_vd(0.25, r_b)
     u = v_d * _POROSITY
-
-    def block_re(vd):
-        c = block_cout_deviation(
-            cin_deviation=cin,
-            flow=flow,
-            dt_days=dt,
-            c_geo=_C_GEO,
-            r_w=_R_W,
-            alpha_l=_ALPHA_L,
-            v_d=vd,
-            n_modes=4,
-            n_quad=90,
-            n_terms=40,
-            tol=1e-10,
-        )
-        return float(np.nansum(c[ext]) / n_inj)
-
-    block_loss = block_re(1e-9) - block_re(v_d)
+    kw = {
+        "cin_deviation": cin,
+        "flow": flow,
+        "dt_days": dt,
+        "c_geo": _C_GEO,
+        "r_w": _R_W,
+        "alpha_l": _ALPHA_L,
+        "n_quad": 60,
+        "n_terms": 28,
+        "tol": 1e-10,
+    }
+    re0 = float(np.nansum(cout_deviation(**kw)[ext]) / n_inj)
+    block = block_cout_deviation(v_d=v_d, n_modes=4, **kw)
+    block_loss = re0 - float(np.nansum(block[ext]) / n_inj)
 
     def fv_loss(n_r):
         re = {}
@@ -513,7 +512,7 @@ def test_rest_drift_loss_matches_fv_oracle():
             re[u_flux] = float(np.sum(c[ext]) / n_inj)
         return re[0.0] - re[u]
 
-    fv = (fv_loss(220) * (1 / 140) - fv_loss(140) * (1 / 220)) / (1 / 140 - 1 / 220)  # Richardson
+    fv = (fv_loss(160) * (1 / 100) - fv_loss(100) * (1 / 160)) / (1 / 100 - 1 / 160)  # Richardson
     assert abs(block_loss - fv) < 0.05 * abs(fv) + 1e-3
     assert block_loss > 0.0
 
@@ -533,7 +532,7 @@ def test_public_u0_dispatch_bit_for_bit():
         "porosity": _POROSITY,
         "well_radius": _R_W,
         "longitudinal_dispersivity": _ALPHA_L,
-        "n_quad": 80,
+        "n_quad": 48,
     }
     base = infiltration_to_extraction(**kw)
     drift0 = infiltration_to_extraction(regional_flux=0.0, **kw)
@@ -551,7 +550,7 @@ def test_public_u0_dispatch_all_entry_points():
         "well_radius": _R_W,
         "longitudinal_dispersivity": _ALPHA_L,
         "porosity": _POROSITY,
-        "n_quad": 50,
+        "n_quad": 32,
     }
     direct = {**geom, "flow": flow, "pore_heights": _B}
     np.testing.assert_array_equal(
@@ -593,6 +592,7 @@ def test_auto_n_modes_sizing():
     assert _auto_n_modes(np.zeros(5), np.ones(5), _C_GEO, _R_W, _ALPHA_L, v_d, 1.0) == 2  # all-rest
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_public_auto_n_modes_dispatch():
     """n_modes=None (the default) auto-sizes the truncation: the public result is bit-for-bit the explicit
     call at the _auto_n_modes value -- the default drift path is exercised end to end."""
@@ -610,7 +610,7 @@ def test_public_auto_n_modes_dispatch():
         "well_radius": _R_W,
         "longitudinal_dispersivity": _ALPHA_L,
         "regional_flux": u,
-        "n_quad": 60,
+        "n_quad": 40,
     }
     np.testing.assert_array_equal(
         infiltration_to_extraction(**kw),
@@ -639,6 +639,7 @@ def test_public_drift_validation_errors():
         infiltration_to_extraction(regional_flux=0.05, n_modes=0, **kw)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_public_drift_background_linearity():
     """Drift transport is linear in the deviation: cout(bg) == bg + cout_dev(bg=0) on extraction bins."""
     flow, _, cin = _single_cycle()
@@ -654,7 +655,7 @@ def test_public_drift_background_linearity():
         "longitudinal_dispersivity": _ALPHA_L,
         "regional_flux": 0.04,
         "n_modes": 3,
-        "n_quad": 70,
+        "n_quad": 48,
     }
     bg = 5.0
     base = infiltration_to_extraction(cin=cin, background=0.0, **kw)
@@ -662,6 +663,7 @@ def test_public_drift_background_linearity():
     np.testing.assert_allclose(shifted[ext], bg + base[ext], atol=1e-9)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_reverse_round_trip_under_drift():
     """The paired reverse (extraction_to_infiltration) under drift inverts the forward operator: feeding it
     the forward drift cout recovers the injected cin on the injection bins (Tikhonov, near-exact at the tiny
@@ -681,13 +683,14 @@ def test_reverse_round_trip_under_drift():
         "longitudinal_dispersivity": _ALPHA_L,
         "regional_flux": 0.05,
         "n_modes": 3,
-        "n_quad": 70,
+        "n_quad": 48,
     }
     cout = infiltration_to_extraction(cin=cin, **kw)
     recovered = extraction_to_infiltration(cout=np.where(flow < 0, cout, 0.0), **kw)
     np.testing.assert_allclose(recovered[inj], cin[inj], atol=1e-4)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_public_single_streamtube_ensemble_equals_engine():
     """The public drift path with one streamtube is exactly the block engine on that streamtube's c_geo
     (the velocity-CV ensemble is a weighted average that reduces to a single engine call here). The
@@ -709,7 +712,7 @@ def test_public_single_streamtube_ensemble_equals_engine():
         longitudinal_dispersivity=_ALPHA_L,
         regional_flux=u,
         n_modes=3,
-        n_quad=70,
+        n_quad=40,
     )
     engine = block_cout_deviation(
         cin_deviation=cin,
@@ -720,11 +723,12 @@ def test_public_single_streamtube_ensemble_equals_engine():
         alpha_l=_ALPHA_L,
         v_d=u / _POROSITY,
         n_modes=3,
-        n_quad=70,
+        n_quad=40,
     )
     np.testing.assert_allclose(public[ext], engine[ext], atol=1e-12)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_public_multi_streamtube_ensemble_averaging():
     """The velocity-heterogeneity macrodispersion ensemble under drift is the weight-averaged engine over
     streamtubes: cout = sum_i w_i engine(c_geo_i; shared v_d) / sum_i w_i, with v_d = U/n shared and
@@ -745,7 +749,7 @@ def test_public_multi_streamtube_ensemble_averaging():
         longitudinal_dispersivity=_ALPHA_L,
         regional_flux=u,
         n_modes=3,
-        n_quad=60,
+        n_quad=40,
     )
     per_tube = [
         block_cout_deviation(
@@ -757,7 +761,7 @@ def test_public_multi_streamtube_ensemble_averaging():
             alpha_l=_ALPHA_L,
             v_d=u / _POROSITY,
             n_modes=3,
-            n_quad=60,
+            n_quad=40,
         )
         for h in heights
     ]
@@ -765,6 +769,7 @@ def test_public_multi_streamtube_ensemble_averaging():
     np.testing.assert_allclose(public[ext], manual[ext], atol=1e-12)
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_variable_within_phase_flow_is_bounded_mean_flow_approximation():
     """Within-phase variable flow is the mean-flow approximation: the drift engine clocks each phase at its
     mean magnitude (placing the cin bins at time corners, not exact volume edges), unlike the scalar D_m=0
@@ -787,7 +792,7 @@ def test_variable_within_phase_flow_is_bounded_mean_flow_approximation():
     const_cin = np.concatenate([np.ones(n_inj), np.zeros(n_ext)])
     dt = np.ones(n_inj + n_ext)
     ext = flow < 0
-    kw = {"dt_days": dt, "c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_quad": 80, "n_terms": 40, "tol": 1e-11}
+    kw = {"dt_days": dt, "c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_quad": 48, "n_terms": 40, "tol": 1e-11}
 
     def gap(flow, cin):
         sc = cout_deviation(cin_deviation=cin, flow=flow, **kw)
@@ -799,6 +804,7 @@ def test_variable_within_phase_flow_is_bounded_mean_flow_approximation():
     assert 1e-3 < gap(flow, ramp_cin) < 0.12  # variable flow AND cin: the mean-flow approximation appears
 
 
+@pytest.mark.xdist_group("radial-asr-heavy-b")
 def test_nonuniform_phase_schedule():
     """Schedules with unequal per-phase durations AND magnitudes work and reduce to the scalar engine at
     v_d ~ 0. This shape (small A_0, short phases) pushes the mode-split Sturm-Liouville exponent past
@@ -808,7 +814,7 @@ def test_nonuniform_phase_schedule():
     dt = np.ones(len(flow))
     cin = np.where(flow > 0, 1.0, 0.0)
     ext = flow < 0
-    kw = {"c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_quad": 80, "n_terms": 40, "tol": 1e-11}
+    kw = {"c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_quad": 48, "n_terms": 40, "tol": 1e-11}
     scalar = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, **kw)
     block0 = block_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, v_d=1e-9, n_modes=2, **kw)
     # 1e-6, not the uniform-schedule 1e-7: the mixed durations/magnitudes give the two engines different
@@ -837,7 +843,7 @@ def test_batched_columns_match_vector_runs():
         "alpha_l": _ALPHA_L,
         "v_d": _eps_to_vd(0.2, r_b),
         "n_modes": 2,
-        "n_quad": 60,
+        "n_quad": 40,
         "n_terms": 40,
         "tol": 1e-10,
     }
@@ -925,12 +931,15 @@ def test_degenerate_schedules():
 
 
 # --- finite-volume oracle: the drift recovery loss --------------------------------------------------
+@pytest.mark.xdist_group("radial-asr-heavy-a")
 def test_drift_loss_matches_fv_oracle():
     """The engine's drift-induced recovery loss matches the independent 2-D FV oracle. The loss
     (RE(U=0) - RE(U)) cancels the FV's first-order bias, so this is a meaningful check that the engine is
     non-perturbative (a Taylor-in-eps engine would mis-scale the loss). The agreement is ~0.3% of the
     loss; the 5% + 1e-3 tolerance doubles as a physics guard, since the oracle's cross-dispersion sign
-    and the engine's well-face couplings each move the loss by ~18%."""
+    and the engine's well-face couplings each move the loss by ~18%. The U=0 reference recovery is the
+    scalar engine -- the exact v_d -> 0 limit of the block engine (certified to ~1e-7 by the
+    reduces-to-scalar tests), avoiding the costly uncapped near-zero-drift recessive grid."""
     flow, dt, cin = _single_cycle(6, 10)
     ext = flow < 0
     r_b = np.sqrt(_R_W**2 + _Q * 6 / _C_GEO)
@@ -938,24 +947,20 @@ def test_drift_loss_matches_fv_oracle():
     v_d = _eps_to_vd(eps, r_b)
     u = v_d * _POROSITY
     n_inj = 6
-
-    def block_re(vd):
-        c = block_cout_deviation(
-            cin_deviation=cin,
-            flow=flow,
-            dt_days=dt,
-            c_geo=_C_GEO,
-            r_w=_R_W,
-            alpha_l=_ALPHA_L,
-            v_d=vd,
-            n_modes=3,
-            n_quad=100,
-            n_terms=44,
-            tol=1e-10,
-        )
-        return float(np.nansum(c[ext]) / n_inj)
-
-    block_loss = block_re(1e-9) - block_re(v_d)
+    kw = {
+        "cin_deviation": cin,
+        "flow": flow,
+        "dt_days": dt,
+        "c_geo": _C_GEO,
+        "r_w": _R_W,
+        "alpha_l": _ALPHA_L,
+        "n_quad": 60,
+        "n_terms": 40,
+        "tol": 1e-10,
+    }
+    re0 = float(np.nansum(cout_deviation(**kw)[ext]) / n_inj)
+    block = block_cout_deviation(v_d=v_d, n_modes=3, **kw)
+    block_loss = re0 - float(np.nansum(block[ext]) / n_inj)
 
     def fv_re(n_r):
         c = fv2d_cout_deviation(
@@ -987,7 +992,7 @@ def test_drift_loss_matches_fv_oracle():
         return float(np.sum(c0[ext]) / n_inj) - float(np.sum(c[ext]) / n_inj)
 
     # Richardson extrapolation of the first-order FV loss
-    fv_loss = (fv_re(220) * (1 / 140) - fv_re(140) * (1 / 220)) / (1 / 140 - 1 / 220)
+    fv_loss = (fv_re(160) * (1 / 100) - fv_re(100) * (1 / 160)) / (1 / 100 - 1 / 160)
     assert abs(block_loss - fv_loss) < 0.05 * abs(fv_loss) + 1e-3
     assert block_loss > 0.0  # drift always reduces recovery
 
@@ -1060,7 +1065,7 @@ def test_nonuniform_dt_within_phase_is_volume_clocked():
     dt = np.concatenate([[1.5, 0.5], np.ones(8)])
     cin = np.where(flow > 0, 1.0, 0.0)
     ext = flow < 0
-    kw = {"dt_days": dt, "c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_quad": 80, "n_terms": 40, "tol": 1e-11}
+    kw = {"dt_days": dt, "c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_quad": 48, "n_terms": 40, "tol": 1e-11}
     scalar = cout_deviation(cin_deviation=cin, flow=flow, **kw)
     block = block_cout_deviation(cin_deviation=cin, flow=flow, v_d=0.0, n_modes=2, **kw)
     np.testing.assert_allclose(block[ext], scalar[ext], atol=1e-6)

--- a/tests/src/test_radial_asr_gridfree.py
+++ b/tests/src/test_radial_asr_gridfree.py
@@ -950,7 +950,7 @@ class TestRebinningInvariance:
         # propagator and A == B bit-for-bit (measured 0.0). R>1 exercises the a0_eff = flow_scale/(2c_geo)/R
         # coupling; the extraction probe exercises the convergent (Danckwerts) hand-off.
         seg_a, seg_b = _rebinning_schedules(direction)
-        kw = {"molecular_diffusivity": 0.05, "retardation_factor": r_fac, "n_quad": 40, **GEOM}
+        kw = {"molecular_diffusivity": 0.05, "retardation_factor": r_fac, "n_quad": 12, **GEOM}
         fa, da, ca = _assemble(seg_a)
         fb, db, cb = _assemble(seg_b)
         cout_a = cout_deviation(cin_deviation=ca, flow=fa, dt_days=da, **kw)
@@ -985,11 +985,11 @@ class TestRebinningInvariance:
         # advects exactly the flushed volume, i.e. flow_scale = phase_volume/phase_time. Baseline (mean|Q|)
         # mis-advects -> ~0.97 gap; any wrong-but-binning-invariant scale (e.g. max|Q|, = 190 in both binnings)
         # would also fail here while passing the A==B tests. Post-fix the gap is the first-order D_m truncation
-        # (~2e-3 at D_m=1e-3).
+        # (<1e-3 at D_m=1e-3).
         flow, dt, cin = _assemble(_rebinning_schedules("injection")[0])
         ext = flow < 0
-        ref = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.0, n_quad=48, **GEOM)
-        approx = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=1e-3, n_quad=48, **GEOM)
+        ref = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.0, n_quad=24, **GEOM)
+        approx = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=1e-3, n_quad=24, **GEOM)
         scale = np.max(np.abs(ref[ext]))
         assert np.max(np.abs(approx[ext] - ref[ext])) / scale < 8e-3  # first-order D_m limit; baseline ~0.97
 
@@ -1000,10 +1000,10 @@ class TestRebinningInvariance:
         # against "engine and gridfree oracle silently agree on the wrong value" (both were fixed together).
         # The floor is the constant-|Q| per-phase kernel approximation (~7%, ratio-independent) + slow-FV
         # first-order convergence -- NOT "a few %". Baseline engine-vs-FV = 0.87 (sides with the wrong value);
-        # post-fix ~0.08.
+        # post-fix ~0.03.
         flow, dt, cin = _assemble(_rebinning_schedules("injection")[0])
         ext = flow < 0
-        eng = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.05, n_quad=64, **GEOM)
+        eng = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.05, n_quad=16, **GEOM)
         fv = fv_cout_deviation(
             cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.05, n_cells=600, n_sub=8, **GEOM
         )
@@ -1019,7 +1019,7 @@ class TestRebinningInvariance:
         inj_a = (np.array([190.0, 10.0]), np.array([1.0, 19.0]), np.array([1.0, 1.0]))
         inj_b = (np.concatenate([[190.0], np.full(19, 10.0)]), np.ones(20), np.ones(20))
         ext = (np.full(6, -100.0), np.full(6, 2.0), np.zeros(6))
-        np.testing.assert_allclose(_i2e([inj_a, ext], 48)[-6:], _i2e([inj_b, ext], 48)[-6:], rtol=0, atol=1e-13)
+        np.testing.assert_allclose(_i2e([inj_a, ext], 12)[-6:], _i2e([inj_b, ext], 12)[-6:], rtol=0, atol=1e-13)
 
     @pytest.mark.slow
     def test_public_multicycle_rebinning(self):
@@ -1027,4 +1027,4 @@ class TestRebinningInvariance:
         # the tedges->dt conversion and streamtube averaging) is rebinning-invariant. Complements the direct
         # cout_deviation tests, which bypass the public wrapper. Baseline ~0.95; post-fix bit-identical.
         seg_a, seg_b = _rebinning_schedules("injection")
-        np.testing.assert_allclose(_i2e(seg_a, 40)[-6:], _i2e(seg_b, 40)[-6:], rtol=0, atol=1e-13)
+        np.testing.assert_allclose(_i2e(seg_a, 12)[-6:], _i2e(seg_b, 12)[-6:], rtol=0, atol=1e-13)


### PR DESCRIPTION
## Summary

The radial-ASR test suite could not finish on a 16 GB machine — concurrent xdist workers stacked multi-GB transients and twice crashed the whole machine. This PR fixes the memory at its source, removes the dominant test-side cost, and bounds worst-case concurrency, cutting the three-file suite to **148 tests in 5:24 at `-n 4` with a 5.1 GB bounded peak** (the drift file alone previously advertised ~25 min on four workers).

Measured mechanisms and fixes:

- **`_block_solutions` memory restructure** (production): both branches' dense Riccati interpolants — the block engine's peak-memory term, `O(steps · n_s · (2M+1)²)` — were alive simultaneously. Each branch now lives in its own scope so only one interpolant is resident at a time. Verified **bit-identical** old-vs-new (all four output blocks across both pumping directions, drift on/off, D_m 0/positive, retardation).
- **Scalar-engine U=0 references** (tests): any `v_d ≈ 0` block run integrates the recessive branch from the uncapped `r_far = 8·r_grid` (~2500 ODE steps, ~1.4 GB dense storage in one branch). The three drift-loss tests now reference the scalar engine — the exact `v_d → 0` limit, certified by the reduces-to-scalar tests. Substitution error measured at 1.4e-8, five orders below the 1e-3 assertion floors.
- **Probed parameter cuts** (tests): every `n_quad`/`n_terms`/FV-Richardson reduction was gated on a probe re-measuring the assertion margin at the reduced setting (bit-identity anchors stay exactly 0.0; the quadratic-loss ratio is 3.996 in a (3.7, 4.3) band; FV-loss agreement 0.0–2.2% vs the 5% guard that regressions move by ~18%). **No tolerance was loosened.** Two candidate cuts failed their probes and were rejected — the forward-conservation gate needs `n_quad=16` (its stale "n_quad-insensitive" docstring claim is corrected with measured errors) and the seasonal-rest oracle comparison needs `n_quad=24`.
- **Bounded concurrency**: the 18 drift tests with ~GB transients carry `@pytest.mark.xdist_group("radial-asr-heavy-a"/"-b")` and addopts gains `--dist=loadgroup`, serializing them onto two workers so peaks never stack across the pool. No effect on CI's `-n0`.

Follow-up candidate (not in this PR): a decay-length-aware `r_far` at small drift in `field_grid`, mirroring the scalar engine's existing fix, would cut the remaining ~60 s `v_d≈0`-clocking tests and shrink production memory for near-zero-drift runs.

## Test plan

- `pytest tests/src/test_radial_asr.py tests/src/test_radial_asr_drift.py tests/src/test_radial_asr_gridfree.py -n 4` — 148 passed in 5:24, peak RSS 5.1 GB (watchdog-recorded).
- Per-file runs at `-n 2`: base 44 passed/37 s, gridfree 70 passed/~3 min, drift 34 passed/4:46 (peak 4.6 GB).
- One-process old-vs-new `_block_solutions` probe: all output blocks `array_equal` across five parameter regimes.
- Margin probes for every reduced parameter recorded against their thresholds (values quoted in the test docstrings/comments where they are load-bearing).
- `ruff format`, `ruff check`, `ty check` (diagnostic count unchanged vs main).

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.