### PR TITLE
perf(radial_asr): cap the radial test suite's true memory footprint at ~1.3 GB

### DIFF
--- a/src/gwtransport/_radial_asr_drift_kernels.py
+++ b/src/gwtransport/_radial_asr_drift_kernels.py
@@ -295,7 +295,11 @@ def field_grid(
         raise ValueError(msg)
     # r_far >= r_significant (the cap was not exceeded and the washout floor is >= r_grid >= r_significant),
     # so clipping the generous grid at r_far drops only the negligible far tail, not the significant plume.
-    r_far = min(max(_RFAR_FIELD_MULT * r_grid, r_grid + _RFAR_DECAY * alpha_l), r_far_cap)
+    # D_m = 0: branch separation >= 1/alpha_L uniformly in s, r, and mode, so _RFAR_DECAY * alpha_L e-folds
+    # wash the recessive IC to double precision; D_m > 0: the slow-node decay length is s-dependent and
+    # unknown here, so keep the generous grid multiple.
+    washout = _RFAR_DECAY * alpha_l if d_m == 0.0 else max(_RFAR_FIELD_MULT * r_grid - r_grid, _RFAR_DECAY * alpha_l)
+    r_far = min(r_grid + washout, r_far_cap)
     r_max = min(r_grid, r_far)
     nodes, weights = np.polynomial.legendre.leggauss(n_quad)
     r_nodes = 0.5 * (r_max - r_w) * (nodes + 1.0) + r_w
@@ -356,6 +360,7 @@ def _interval_transitions(
             msg = "block interval-transition integration failed"
             raise RuntimeError(msg)
         out[lo:hi] = np.ascontiguousarray(sol.y[:, -1]).view(complex).reshape(nc, n_s, nm, nm)
+        sol.y = None  # the cycled result object would otherwise pin the (state, steps) trajectory
     return out
 
 
@@ -442,6 +447,9 @@ def _block_solutions(
     else:
         astar = alpha_l * abs(a0) / d_m
         kappa = np.sqrt(retardation_factor * s / d_m)
+        # Decay-aware recessive start (mirrors the scalar kernels): the slowest node needs
+        # _RFAR_DECAY / min Re(kappa) of washout beyond the grid; r_far keeps the outer cap.
+        r_far = min(r_far, r_max + _RFAR_DECAY / float(kappa.real.min()))
         a_coef = (1.0 - sigma_a * abs(a0) / d_m) / 2.0 - kappa * astar / 2.0
         l0 = -kappa - a_coef / (r_far + astar)
     prev = np.concatenate(([r_w], r_nodes[:-1]))
@@ -486,7 +494,14 @@ def _block_solutions(
         def l_at(r: npt.NDArray[np.floating]) -> npt.NDArray[np.complexfloating]:
             return np.ascontiguousarray(sol.sol(r).T).view(complex).reshape(np.size(r), n_s, nm, nm)
 
-        return l_at(r_nodes), l_at(np.array([r_w]))[0], _interval_transitions(l_at, hop_from, hop_to, n_s, nm)
+        l_nodes = l_at(r_nodes)
+        l_w = l_at(np.array([r_w]))[0]
+        hops = _interval_transitions(l_at, hop_from, hop_to, n_s, nm)
+        # The result object sits in a reference cycle, so refcounting alone never frees the per-step
+        # interpolant arrays (the engine's peak-memory term); drop them now that all evaluations are done.
+        sol.sol.interpolants.clear()
+        sol.y = None
+        return l_nodes, l_w, hops
 
     lm0 = (l0[:, None, None] * eye[None]).astype(complex)
     # Psi_-(r_i, r_{i-1}): recessive outward hops

--- a/src/gwtransport/_radial_asr_kernels.py
+++ b/src/gwtransport/_radial_asr_kernels.py
@@ -438,6 +438,9 @@ def _integrate_logderiv(
         )
         y = sol.sol(radii)  # dense output at all radii at once -> shape (2n, n_radii)
         j_w = sol.sol(r_w)[n:, None]  # re-anchor J to int_{r_w}^{r} (the IC put J(r_far) = 0)
+        # The result object sits in a reference cycle, so refcounting alone never frees the per-step
+        # interpolant arrays (the dominant allocation); drop them now that all evaluations are done.
+        sol.sol.interpolants.clear()
         return y[:n], y[n:] - j_w
 
     # regular branch: outward from r_w to r_max -- the growing solution is the stable outward attractor and
@@ -446,6 +449,7 @@ def _integrate_logderiv(
     y0 = np.concatenate([np.full(n, ld0, dtype=complex), np.zeros(n, dtype=complex)])
     sol = solve_ivp(rhs, [r_w, r_max], y0, rtol=_RICCATI_RTOL, atol=_RICCATI_ATOL, dense_output=True, method="DOP853")
     y = sol.sol(radii)
+    sol.sol.interpolants.clear()
     return y[:n], y[n:]
 
 

--- a/tests/src/conftest.py
+++ b/tests/src/conftest.py
@@ -5,6 +5,8 @@ This module provides common fixtures used across multiple test files to reduce
 code duplication and improve test maintainability.
 """
 
+import gc
+import os
 import sys
 from pathlib import Path
 
@@ -13,6 +15,11 @@ import pandas as pd
 import pytest
 
 from gwtransport.utils import compute_time_edges
+
+# macOS libmalloc strands freed large solver buffers as dirty free-list pages, ratcheting each xdist
+# worker's footprint by ~the size of every distinct heavy test it ran. Space-efficient mode returns
+# them; workers inherit the env at spawn. No effect on other platforms or already-running processes.
+os.environ.setdefault("MallocSpaceEfficient", "1")
 
 # Make tests-only helper modules (e.g. the finite-volume oracle _radial_asr_fv_oracle) importable by bare
 # name under the importlib import mode.
@@ -433,6 +440,18 @@ def pytest_generate_tests(metafunc):
 # ============================================================================
 # Pytest Configuration
 # ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _collect_cycles():
+    """Collect reference cycles after every test.
+
+    Large solver buffers (e.g. the radial-ASR dense ODE interpolants) sit in reference cycles and
+    otherwise survive until an allocation-count-triggered generational collection, ratcheting each
+    xdist worker's resident memory to the sum of its recent tests' transients.
+    """
+    yield
+    gc.collect()
 
 
 def pytest_configure(config):

--- a/tests/src/test_radial_asr_drift.py
+++ b/tests/src/test_radial_asr_drift.py
@@ -12,14 +12,14 @@ rest, the v_d = 0 reduction to the scalar Bessel rest kernel (to the Neumann-ima
 FV drift-loss cross-check of an inject-rest-extract cycle, and the honest spectral-tail guard.
 
 Cost note: the block engine's peak memory is one branch's dense Riccati interpolant
-(``O(steps * n_s * (2 n_modes + 1)^2)`` with ``n_s = 2 n_terms + 1``), which reaches ~1-2 GB per call at
-``v_d ~ 0`` where the recessive-IC grid is uncapped (``r_far = 8 r_grid``); runtime grows steeply with
+(``O(steps * n_s * (2 n_modes + 1)^2)`` with ``n_s = 2 n_terms + 1``); runtime grows steeply with
 ``n_modes`` at the production ODE tolerances. Each test therefore keeps ``n_quad``/``n_terms``/``n_modes``
-as small as its physics anchor allows (assertion margins re-measured at the reduced settings), U=0
-reference recoveries use the scalar engine (the exact ``v_d -> 0`` limit, certified by the
-reduces-to-scalar tests), and tests with multi-GB transients carry
-``@pytest.mark.xdist_group("radial-asr-heavy-a"/"-b")`` so ``--dist=loadgroup`` serializes them onto two
-workers (~5 min wall on two workers, peak ~4.6 GB).
+as small as its physics anchor allows (assertion margins re-measured at the reduced settings; parity /
+identity / guard anchors are exact at any azimuthal truncation and run at ``n_modes=2``), U=0 reference
+recoveries use the scalar engine (the exact ``v_d -> 0`` limit, certified by the reduces-to-scalar
+tests), and the heaviest tests carry ``@pytest.mark.xdist_group("radial-asr-heavy-a"/"-b")`` so
+``--dist=loadgroup`` serializes them onto two workers (~5 min wall on two workers, true-footprint peak
+~1.3 GB).
 """
 
 import numpy as np
@@ -188,7 +188,7 @@ def test_drift_reversal_symmetry():
         "c_geo": _C_GEO,
         "r_w": _R_W,
         "alpha_l": _ALPHA_L,
-        "n_modes": 3,
+        "n_modes": 2,
         "n_quad": 48,
         "n_terms": 40,
         "tol": 1e-11,
@@ -255,7 +255,7 @@ def test_retardation_rescale_in_drift():
         v_d=v_d,
         molecular_diffusivity=0.4,
         retardation_factor=r,
-        n_modes=3,
+        n_modes=2,
         n_quad=60,
         n_terms=40,
         tol=1e-11,
@@ -271,7 +271,7 @@ def test_retardation_rescale_in_drift():
         v_d=v_d / r,
         molecular_diffusivity=0.4 / r,
         retardation_factor=1.0,
-        n_modes=3,
+        n_modes=2,
         n_quad=60,
         n_terms=40,
         tol=1e-11,
@@ -375,7 +375,7 @@ def test_rest_long_translation_raises():
             r_w=_R_W,
             alpha_l=_ALPHA_L,
             v_d=v_d,
-            n_modes=3,
+            n_modes=2,
             n_quad=60,
         )
 
@@ -385,7 +385,7 @@ def test_rest_long_translation_raises():
 def test_rest_tiny_duration_reduces_to_no_rest():
     """A vanishing rest phase is a no-op: the translate+spread kernel reduces to the identity (t -> 0),
     exercising the full real-space evaluate / Gauss-Hermite / FFT-reproject round trip at delta ~ 0."""
-    kw = {"c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_modes": 3, "n_quad": 48, "n_terms": 40, "tol": 1e-10}
+    kw = {"c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_modes": 2, "n_quad": 48, "n_terms": 40, "tol": 1e-10}
     r_b = np.sqrt(_R_W**2 + _Q * 6 / _C_GEO)
     v_d = _eps_to_vd(0.2, r_b)
     flow_r = np.array([_Q] * 6 + [0.0] + [-_Q] * 10)
@@ -417,7 +417,7 @@ def test_rest_drift_reversal_symmetry():
         "c_geo": _C_GEO,
         "r_w": _R_W,
         "alpha_l": _ALPHA_L,
-        "n_modes": 3,
+        "n_modes": 2,
         "n_quad": 48,
         "n_terms": 40,
         "tol": 1e-10,
@@ -435,7 +435,7 @@ def test_rest_drift_reversal_symmetry():
         r_w=_R_W,
         alpha_l=_ALPHA_L,
         v_d=v_d,
-        n_modes=3,
+        n_modes=2,
         n_quad=48,
         n_terms=40,
         tol=1e-10,
@@ -455,7 +455,7 @@ def test_rest_dm_reduces_to_scalar_bessel():
     ext = flow < 0
     kw = {"c_geo": _C_GEO, "r_w": _R_W, "alpha_l": _ALPHA_L, "n_quad": 90, "n_terms": 40, "tol": 1e-10}
     blk = block_cout_deviation(
-        cin_deviation=cin, flow=flow, dt_days=dt, v_d=0.0, molecular_diffusivity=0.5, n_modes=3, **kw
+        cin_deviation=cin, flow=flow, dt_days=dt, v_d=0.0, molecular_diffusivity=0.5, n_modes=2, **kw
     )
     sca = cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, molecular_diffusivity=0.5, **kw)
     np.testing.assert_allclose(blk[ext], sca[ext], atol=1e-3)
@@ -654,7 +654,7 @@ def test_public_drift_background_linearity():
         "well_radius": _R_W,
         "longitudinal_dispersivity": _ALPHA_L,
         "regional_flux": 0.04,
-        "n_modes": 3,
+        "n_modes": 2,
         "n_quad": 48,
     }
     bg = 5.0
@@ -682,7 +682,7 @@ def test_reverse_round_trip_under_drift():
         "well_radius": _R_W,
         "longitudinal_dispersivity": _ALPHA_L,
         "regional_flux": 0.05,
-        "n_modes": 3,
+        "n_modes": 2,
         "n_quad": 48,
     }
     cout = infiltration_to_extraction(cin=cin, **kw)
@@ -711,7 +711,7 @@ def test_public_single_streamtube_ensemble_equals_engine():
         well_radius=_R_W,
         longitudinal_dispersivity=_ALPHA_L,
         regional_flux=u,
-        n_modes=3,
+        n_modes=2,
         n_quad=40,
     )
     engine = block_cout_deviation(
@@ -722,7 +722,7 @@ def test_public_single_streamtube_ensemble_equals_engine():
         r_w=_R_W,
         alpha_l=_ALPHA_L,
         v_d=u / _POROSITY,
-        n_modes=3,
+        n_modes=2,
         n_quad=40,
     )
     np.testing.assert_allclose(public[ext], engine[ext], atol=1e-12)
@@ -748,7 +748,7 @@ def test_public_multi_streamtube_ensemble_averaging():
         well_radius=_R_W,
         longitudinal_dispersivity=_ALPHA_L,
         regional_flux=u,
-        n_modes=3,
+        n_modes=2,
         n_quad=40,
     )
     per_tube = [
@@ -760,7 +760,7 @@ def test_public_multi_streamtube_ensemble_averaging():
             r_w=_R_W,
             alpha_l=_ALPHA_L,
             v_d=u / _POROSITY,
-            n_modes=3,
+            n_modes=2,
             n_quad=40,
         )
         for h in heights
@@ -822,7 +822,7 @@ def test_nonuniform_phase_schedule():
     np.testing.assert_allclose(block0[ext], scalar[ext], atol=1e-6)
     r_b = np.sqrt(_R_W**2 + 80.0 * 4 / _C_GEO)
     v_d = 0.15 * (60.0 / (2.0 * _C_GEO)) / r_b  # eps relative to the WEAKEST phase (the binding envelope)
-    drift = block_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, v_d=v_d, n_modes=3, **kw)
+    drift = block_cout_deviation(cin_deviation=cin, flow=flow, dt_days=dt, v_d=v_d, n_modes=2, **kw)
     assert np.isfinite(drift[ext]).all()
     assert np.all(drift[ext] > -1e-9)
     assert np.nansum(drift[ext]) < np.nansum(block0[ext])  # drift strictly reduces recovery


### PR DESCRIPTION
## Summary

Follow-up to #355. That PR made the radial-ASR suite finish; this one takes the *true* memory footprint (`phys_footprint`, the metric the kernel actually charges) of the three radial files at `-n 2` down to a **1.25 GB concurrent peak** (drift file alone: 34 tests, 5:06, 1.29 GB), from the 5 GB-class runs that twice crashed a 16 GB machine. Four measured mechanisms, fixed at the source:

- **Decay-length-aware recessive grid** (`field_grid`, `_block_solutions`): at `v_d ≈ 0` the recessive IC sat at `r_far = 8·r_grid` (~2500 dense ODE steps, ~1.4 GB per branch). The `D_m=0` washout is now sized from the uniform branch-separation floor `1/α_L` (valid for every Laplace node, radius, and mode since `Re√w ≥ √(Re w)`); the `D_m>0` start is refined from the actual Laplace batch (`min Re κ`), mirroring the scalar kernels. Real-drift results **bit-identical** (stagnation cap governs); near-zero-drift shifts ≤ 1.8e-10 (washout-completeness floor) and runs ~2.7× faster.
- **Deterministic release of solver payloads**: scipy dense-output results sit in reference cycles, so refcounting never frees the per-step interpolant arrays — they survived to rare gen-2 collections, ratcheting each xdist worker by ~the size of every past solve. The radial kernels now clear `interpolants`/trajectories after their last evaluation (inert by construction: clears happen after all evaluations), plus an autouse per-test `gc.collect()` in `tests/src/conftest.py`.
- **`MallocSpaceEfficient=1` for the test session**: macOS libmalloc strands freed large solver blocks as dirty free-list pages (`malloc_zone_pressure_relief` frees 0 while a worker idles at ~630 MB with nothing live). Space-efficient mode returns them — the worst single call drops 1275 → 479 MB with a flat plateau. Set via `os.environ.setdefault` in the tests/src conftest; workers inherit it, other platforms no-op.
- **Azimuthal truncation matched to the anchor**: parity/identity/guard tests hold exactly at any truncation and both comparison sides share `n_modes`, so 14 sites now run `n_modes=2`; `n_modes ≥ 3` is kept where coupling *magnitude* is the anchor (FV-loss vs oracle, quadratic tail bound, coupling/face generator pins).

Also validated suite-wide (1961 tests, per-test high-water tracking): the radial-ASR tests are the largest in both time (24 of top-25 durations) and memory (all top worker peaks); the largest non-radial rise is 171 MB.

Rejected on measured margins: a blanket `n_terms` 40 → 24 cut (two comparison floors fail outright — 1.9e-6 vs 1e-7 and 6.7e-6 vs 1e-6 — and the rest erode to ~2× headroom). No tolerance was loosened anywhere.

## Test plan

- Three radial files at `-n 2`: 148 passed; `phys_footprint` concurrent peak 1.25 GB (sampled in-worker via `task_info`), system free+purgeable never below 3.6 GB.
- Drift file at `-n 2`: 34 passed in 5:06, footprint peak 1.29 GB.
- Full `tests/src` at `-n 4`: 1961 passed, 1 skipped.
- Old-vs-new `_block_solutions` outputs bit-identical at real drift; ≤ 1.8e-10 at `v_d ≈ 0` (washout floor); rest-schedule nansum identical through the gc/clear changes.
- Margin probes for the D_m>0 washout at test settings: reduce-to-scalar 6.9e-9 vs 1e-7; Bessel-rest reduction 3.59e-4 vs 1e-3 (unchanged from before the refinement).
- `ruff format`, `ruff check`, `ty check` (diagnostic count unchanged vs main).

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.