### PR TITLE
Raise the pytest-xdist floor so the -n0 job can start

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ test = [
   "nbformat>=5.0.2",
   "pytest>=6.2.5",
   "pytest-cov>=2.3.1",
-  "pytest-xdist>=3.0.0",
+  # 3.1 is the first release where -n0 also clears --dist; with --dist=loadgroup in addopts,
+  # 3.0 fails "MISSING test execution (tx) nodes" whenever CI runs a job with -n0.
+  "pytest-xdist>=3.1.0",
   "python-flint>=0.8.0",
   "ruff==0.15.6",
   "timflow>=0.3",


### PR DESCRIPTION
## Summary

`Python 3.12 - minimum dependencies` has been failing on `main` — it fails on `d55debc` too,
so this predates any of the current PRs. It is not a test failure: pytest exits **4**, a usage
error, before collecting anything.

```
ERROR: MISSING test execution (tx) nodes: please specify --tx
```

`addopts` carries `--dist=loadgroup`, and the workflow runs that job with `-n0`. On
pytest-xdist **3.0** — which is what `>=3.0.0` resolves to under `--resolution lowest-direct` —
`-n0` stops the workers being spawned but leaves `--dist` set, so xdist demands `--tx` nodes and
refuses to start. 3.1 is the first release where `-n0` also clears `--dist`.

## Test plan

Reproduced locally against a lowest-direct 3.12 environment (pytest 6.2.5, py 1.11.0,
pytest-cov 2.3.1, **xdist 3.0.2**):

```
$ uv sync --extra test --resolution lowest-direct --python 3.12
$ uv run pytest tests/src -n0
ERROR: MISSING test execution (tx) nodes: please specify --tx
```

Bisected across 3.1.0 / 3.2.0 / 3.3.0 — all three clear `--dist` on `-n0`, so 3.1.0 is the
minimum. With the floor raised, the same `uv sync … --resolution lowest-direct` resolves xdist
3.1.0 and the identical command collects and runs the suite instead of erroring out.

This is a prerequisite for #357: that branch cannot go green while a required check fails for a
reason it does not contain.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/gwtransport/gwtransport/blob/main/CLA.md) and I agree to its terms for this and all future contributions I make to gwtransport.